### PR TITLE
Load connection string from config

### DIFF
--- a/LYBT.Infrastructure/AppDbContextFactory.cs
+++ b/LYBT.Infrastructure/AppDbContextFactory.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System.IO;
 
 namespace LYBT.Infrastructure {
     /// <summary>
@@ -10,9 +12,14 @@ namespace LYBT.Infrastructure {
         /// 创建数据库上下文实例
         /// </summary>
         public AppDbContext CreateDbContext(string[] args) {
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
             var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
-            // 下面请填写你的连接字符串（与 appsettings.json 里一致）
-            optionsBuilder.UseSqlServer("Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True");
+            optionsBuilder.UseSqlServer(configuration.GetConnectionString("DefaultConnection"));
             return new AppDbContext(optionsBuilder.Options);
         }
     }

--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -111,8 +111,9 @@ builder.Services.AddSwaggerGen(options => {
 
 // =========== 4. 注册数据库上下文 ===========
 
+var connection = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlServer(connection));
 
 // =========== 5. 启动Web应用 ===========
 

--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -4,7 +4,7 @@
     "DatacenterId": 1
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "<set via environment>"
   },
   "Logging": {
     "LogLevel": {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # LYBTZYZS
 
 This repository contains various modules for the LYBT healthcare management system. It is organized as a multi-project .NET solution.
+
+## Configuration
+
+The application reads the database connection string from the standard
+`DefaultConnection` setting. When running locally or in production, set the
+connection string using the environment variable
+`ConnectionStrings__DefaultConnection` or by providing it in configuration.
+
+Example:
+
+```bash
+export ConnectionStrings__DefaultConnection="Server=<host>;Database=<db>;User Id=<user>;Password=<pwd>;Encrypt=True;TrustServerCertificate=True"
+```


### PR DESCRIPTION
## Summary
- load database connection string through configuration in `AppDbContextFactory`
- pull the connection string once in WebAPI startup
- remove credentials from `appsettings.json`
- document `ConnectionStrings__DefaultConnection` environment variable

## Testing
- `dotnet build LYBTZYZS.sln -nologo` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504fbf67808333ad0e0b866a765516