### PR TITLE
Refactor patient deletion signatures to Guid

### DIFF
--- a/LYBT.Module.Patients/Interfaces/IPatientRepository.cs
+++ b/LYBT.Module.Patients/Interfaces/IPatientRepository.cs
@@ -29,7 +29,7 @@ namespace LYBT.Module.Patients.Interfaces {
         /// <summary>
         /// 删除病人记录
         /// </summary>
-        Task<bool> DeleteAsync(string id);
+        Task<bool> DeleteAsync(Guid id);
 
         /// <summary>
         /// 通过身份证号查找病人

--- a/LYBT.Module.Patients/Interfaces/IPatientService.cs
+++ b/LYBT.Module.Patients/Interfaces/IPatientService.cs
@@ -21,7 +21,7 @@ namespace LYBT.Module.Patients.Interfaces {
         /// <summary>
         /// 删除单个病人
         /// </summary>
-        Task<bool> DeleteAsync(string id, Guid operatorId, string operatorName);
+        Task<bool> DeleteAsync(Guid id, Guid operatorId, string operatorName);
 
         /// <summary>
         /// 根据Id获取病人信息

--- a/LYBT.Module.Patients/Repositories/PatientRepository.cs
+++ b/LYBT.Module.Patients/Repositories/PatientRepository.cs
@@ -43,7 +43,7 @@ namespace LYBT.Module.Patients.Repositories {
             return await _dbContext.SaveChangesAsync() > 0;
         }
 
-        public async Task<bool> DeleteAsync(string id) {
+        public async Task<bool> DeleteAsync(Guid id) {
             var entity = await _dbContext.Patients.FindAsync(id);
             if (entity == null)
                 return false;

--- a/LYBT.Module.Patients/Services/PatientService.cs
+++ b/LYBT.Module.Patients/Services/PatientService.cs
@@ -77,8 +77,8 @@ namespace LYBT.Module.Patients.Services {
             return result;
         }
 
-        public async Task<bool> DeleteAsync(string id, Guid operatorId, string operatorName) {
-            var patient = await _patientRepository.GetByIdAsync(Guid.Parse(id));
+        public async Task<bool> DeleteAsync(Guid id, Guid operatorId, string operatorName) {
+            var patient = await _patientRepository.GetByIdAsync(id);
             var result = await _patientRepository.DeleteAsync(id);
 
             if (result && patient != null) {
@@ -121,7 +121,7 @@ namespace LYBT.Module.Patients.Services {
         public async Task<int> BatchDeleteAsync(List<string> ids, Guid operatorId, string operatorName) {
             int count = 0;
             foreach (var id in ids) {
-                if (await DeleteAsync(id, operatorId, operatorName))
+                if (Guid.TryParse(id, out var guid) && await DeleteAsync(guid, operatorId, operatorName))
                     count++;
             }
             return count;

--- a/LYBT.WebAPI/Controllers/PatientsController.cs
+++ b/LYBT.WebAPI/Controllers/PatientsController.cs
@@ -44,7 +44,7 @@ namespace LYBT.WebAPI.Controllers {
         /// 删除单个病人
         /// </summary>
         [HttpDelete("{id}")]
-        public async Task<IActionResult> Delete(string id) {
+        public async Task<IActionResult> Delete(Guid id) {
             Guid operatorId = Guid.NewGuid();
             string operatorName = "管理员A";
             var result = await _patientService.DeleteAsync(id, operatorId, operatorName);


### PR DESCRIPTION
## Summary
- update patient repository/service interfaces to accept `Guid`
- adjust repository implementation and service logic
- parse `Guid` values for batch deletes
- update API controller for `Guid` id parameter

## Testing
- `dotnet test LYBTZYZS.sln` *(fails: NETSDK1100 Windows targeting)*

------
https://chatgpt.com/codex/tasks/task_e_6850501d06bc8333b582e84a065a6fa5