### PR TITLE
Add READMEs for core modules

### DIFF
--- a/LYBT.Module.Billing/README.md
+++ b/LYBT.Module.Billing/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.Billing
+
+费用结算模块，处理患者账单的创建、查询及支付状态维护。
+
+## 主要服务及接口
+- `IBillingService` / `BillingService`
+- `IBillingRepository` / `BillingRepository`
+
+## 重要模型和DTO
+- `BillingModel`、`BillingItem`
+- `BillingDto`、`BillingCreateDto`、`BillingEditDto`、`BillingDetailDto`
+
+## 用法
+在启动时调用 `BillingModule.Register(services)` 注册依赖，随后通过 `IBillingService` 完成账单的增删改查。

--- a/LYBT.Module.DiagnosisTreatment/README.md
+++ b/LYBT.Module.DiagnosisTreatment/README.md
@@ -1,0 +1,15 @@
+# LYBT.Module.DiagnosisTreatment
+
+诊疗记录模块，负责保存诊断内容、治疗方案及药方信息。
+
+## 主要服务及接口
+- `IDiagnosisTreatmentService` / `DiagnosisTreatmentService`
+- `IDiagnosisTreatmentRepository` / `DiagnosisTreatmentRepository`
+
+## 重要模型和DTO
+- `DiagnosisTreatmentModel`、`TreatmentItemModel`、`FormulaModel`
+- `DiagnosisTreatmentDto`、`DiagnosisTreatmentCreateDto`、`DiagnosisTreatmentEditDto`、`DiagnosisTreatmentDetailDto`
+- `TreatmentItemDto`、`FormulaDto`
+
+## 用法
+调用 `DiagnosisTreatmentModule.Register(services)` 注册后，通过 `IDiagnosisTreatmentService` 进行诊疗记录的增删改查。

--- a/LYBT.Module.FormulaTemplates/README.md
+++ b/LYBT.Module.FormulaTemplates/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.FormulaTemplates
+
+经验方模板模块，保存常用药方模板并提供增删改查。
+
+## 主要服务及接口
+- `IFormulaTemplateService` / `FormulaTemplateService`
+- `IFormulaTemplateRepository` / `FormulaTemplateRepository`
+
+## 重要模型和DTO
+- `FormulaTemplateModel`
+- `FormulaTemplateDto`、`FormulaTemplateCreateDto`、`FormulaTemplateEditDto`、`FormulaTemplateDetailDto`
+
+## 用法
+应用启动时执行 `FormulaTemplatesModule.Register(services)`，之后通过 `IFormulaTemplateService` 管理模板数据。

--- a/LYBT.Module.Herbs/README.md
+++ b/LYBT.Module.Herbs/README.md
@@ -1,0 +1,14 @@
+# LYBT.Module.Herbs
+
+药材管理模块，提供药材信息的维护和查询功能。
+
+## 主要服务及接口
+- `IHerbService` / `HerbService`
+- `IHerbRepository` / `HerbRepository`
+
+## 重要模型和DTO
+- `HerbModel`
+- `HerbDto`、`HerbCreateDto`、`HerbEditDto`、`HerbDetailDto`
+
+## 用法
+调用 `HerbsModule.Register(services)` 后即可通过 `IHerbService` 增删改查药材数据。

--- a/LYBT.Module.Logs/README.md
+++ b/LYBT.Module.Logs/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.Logs
+
+操作日志模块，用于记录系统内各类操作行为。
+
+## 主要服务及接口
+- `ILogService` / `LogService`
+- `ILogRepository` / `LogRepository`
+
+## 重要模型和DTO
+- `LogModel`
+- `LogDto`、`LogQueryDto`、`LogCreateDto`
+
+## 用法
+启动时执行 `LogsModule.Register(services)`，应用层通过 `ILogService` 新增或查询日志记录。

--- a/LYBT.Module.Pharmacy/README.md
+++ b/LYBT.Module.Pharmacy/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.Pharmacy
+
+药房任务模块，管理处方抓药及代煎流程。
+
+## 主要服务及接口
+- `IPharmacyService` / `PharmacyService`
+- `IPharmacyRepository` / `PharmacyRepository`
+
+## 重要模型和DTO
+- `PharmacyModel`
+- `PharmacyDto`、`PharmacyCreateDto`、`PharmacyEditDto`、`PharmacyDetailDto`
+
+## 用法
+启动时通过 `PharmacyModule.Register(services)` 注册依赖，之后使用 `IPharmacyService` 处理药房任务。

--- a/LYBT.Module.Prescriptions/README.md
+++ b/LYBT.Module.Prescriptions/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.Prescriptions
+
+处方模块，保存和编辑患者处方信息。
+
+## 主要服务及接口
+- `IPrescriptionService` / `PrescriptionService`
+- `IPrescriptionApi` 外部接口调用
+
+## 重要模型和DTO
+- `PrescriptionModel`、`PrescriptionHerbModel`
+- 枚举 `PrescriptionStatus`
+
+## 用法
+在 Prism 应用中加载 `PrescriptionsModule`，通过 `IPrescriptionService` 操作处方数据。

--- a/LYBT.Module.Records/README.md
+++ b/LYBT.Module.Records/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.Records
+
+病历模块，管理患者诊疗记录与病历文档。
+
+## 主要服务及接口
+- `IRecordService` / `RecordService`
+- `IRecordRepository` / `RecordRepository`
+
+## 重要模型和DTO
+- `RecordModel`
+- `RecordDto`、`RecordCreateDto`、`RecordEditDto`、`RecordDetailDto`
+
+## 用法
+调用 `RecordsModule.Register(services)` 注册后，使用 `IRecordService` 对病历数据进行增删改查。

--- a/LYBT.Module.Settings/README.md
+++ b/LYBT.Module.Settings/README.md
@@ -1,1 +1,14 @@
-﻿
+# LYBT.Module.Settings
+
+系统设置模块，维护应用级配置项。
+
+## 主要服务及接口
+- `ISettingsService` / `SettingsService`
+- `ISettingsRepository` / `SettingsRepository`
+
+## 重要模型和DTO
+- `SettingsModel`
+- `SettingsDto`、`SettingsCreateDto`、`SettingsEditDto`、`SettingsDetailDto`
+
+## 用法
+执行 `SettingsModule.Register(services)` 后，可通过 `ISettingsService` 读取和保存系统设置。

--- a/LYBT.Module.Sync/README.md
+++ b/LYBT.Module.Sync/README.md
@@ -1,1 +1,15 @@
-﻿
+# LYBT.Module.Sync
+
+数据同步模块，记录同步任务及日志。
+
+## 主要服务及接口
+- `ISyncService` / `SyncService`
+- `ISyncRepository` / `SyncRepository`
+
+## 重要模型和DTO
+- `SyncTaskModel`、`SyncLogModel`
+- `SyncTaskDto`、`SyncTaskCreateDto`、`SyncTaskEditDto`、`SyncTaskDetailDto`
+- `SyncLogDto`、`SyncLogCreateDto`
+
+## 用法
+在启动时调用 `SyncModule.Register(services)`，随后使用 `ISyncService` 创建或查询同步任务和日志。

--- a/LYBT.Module.TreatmentRoom/README.md
+++ b/LYBT.Module.TreatmentRoom/README.md
@@ -1,0 +1,14 @@
+# LYBT.Module.TreatmentRoom
+
+治疗室执行记录模块，跟踪各类治疗计划的执行情况。
+
+## 主要服务及接口
+- `ITreatmentRoomService` / `TreatmentRoomService`
+- `ITreatmentRoomRepository` / `TreatmentRoomRepository`
+
+## 重要模型和DTO
+- `TreatmentRoomModel`
+- `TreatmentRoomDto`、`TreatmentRoomCreateDto`、`TreatmentRoomEditDto`、`TreatmentRoomDetailDto`
+
+## 用法
+通过 `TreatmentRoomModule.Register(services)` 注入依赖，使用 `ITreatmentRoomService` 管理治疗室记录。


### PR DESCRIPTION
## Summary
- add missing README docs for DiagnosisTreatment, Herbs and TreatmentRoom modules
- replace placeholder READMEs in other modules with concise Chinese summaries

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1100, needs Windows targeting)*

------
https://chatgpt.com/codex/tasks/task_e_685052e8af348333aa3df577d9684f7f