### PR TITLE
Add README files for modules

### DIFF
--- a/LYBT.Models/README.md
+++ b/LYBT.Models/README.md
@@ -1,0 +1,4 @@
+# LYBT.Models
+
+This project contains the domain models shared across the LYBT solution. Other modules reference these models to work with a consistent set of entities.
+

--- a/LYBT.UI.WPF/README.md
+++ b/LYBT.UI.WPF/README.md
@@ -1,0 +1,4 @@
+# LYBT.UI.WPF
+
+Desktop WPF client that consumes the backend modules via the Web API.
+

--- a/LYBT.WebAPI/README.md
+++ b/LYBT.WebAPI/README.md
@@ -1,0 +1,4 @@
+# LYBT.WebAPI
+
+The ASP.NET Core API project that wires up all modules, registers their services and dependencies, and exposes REST endpoints for clients.
+


### PR DESCRIPTION
## Summary
- document LYBT.Models as the shared domain models project
- describe how LYBT.WebAPI wires modules together and exposes APIs
- state that LYBT.UI.WPF is the WPF desktop client

## Testing
- `dotnet build LYBTZYZS.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685052ed7e308333a434f016d4811d1f