### PR TITLE
Fix missing SetBasePath extension

### DIFF
--- a/LYBT.Infrastructure/LYBT.Infrastructure.csproj
+++ b/LYBT.Infrastructure/LYBT.Infrastructure.csproj
@@ -17,7 +17,9 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+                <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
+                <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
+                <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- add required configuration packages to Infrastructure project so `SetBasePath` extension is available

## Testing
- `dotnet build LYBT.Infrastructure/LYBT.Infrastructure.csproj -nologo` *(fails: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_685057ec79c88333bda3e151d736708e