### PR TITLE
Fix AddEnvironmentVariables extension

### DIFF
--- a/LYBT.Infrastructure/LYBT.Infrastructure.csproj
+++ b/LYBT.Infrastructure/LYBT.Infrastructure.csproj
@@ -20,7 +20,8 @@
                 <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
                 <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.6" />
                 <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.6" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\LYBT.Common\LYBT.Common.csproj" />


### PR DESCRIPTION
## Summary
- add missing EnvironmentVariables package so `AddEnvironmentVariables` extension resolves

## Testing
- `dotnet restore /p:EnableWindowsTargeting=true`
- `dotnet build /p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_685059a535ec8333a0837507a06c42e9