### PR TITLE
Update connection string

### DIFF
--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -4,7 +4,7 @@
     "DatacenterId": 1
   },
   "ConnectionStrings": {
-    "DefaultConnection": "<set via environment>"
+    "DefaultConnection": "Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
## Summary
- set the `DefaultConnection` value in `appsettings.json`

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1100 requires EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_68505b6b41548333abbb7859b16e9703