### PR TITLE
Add full user management APIs

### DIFF
--- a/LYBT.Module.Users/Dtos/BatchIdsDto.cs
+++ b/LYBT.Module.Users/Dtos/BatchIdsDto.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Users.Dtos {
+    /// <summary>
+    /// 批量操作用户时提交的ID列表 DTO
+    /// </summary>
+    public class BatchIdsDto {
+        [Required]
+        public List<Guid> Ids { get; set; } = new();
+    }
+}

--- a/LYBT.Module.Users/Dtos/ChangePasswordDto.cs
+++ b/LYBT.Module.Users/Dtos/ChangePasswordDto.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Users.Dtos {
+    /// <summary>
+    /// 用户修改密码 DTO
+    /// </summary>
+    public class ChangePasswordDto {
+        /// <summary>
+        /// 用户ID
+        /// </summary>
+        [Required]
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// 原密码
+        /// </summary>
+        [Required]
+        [StringLength(32, MinimumLength = 6)]
+        public string OldPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新密码
+        /// </summary>
+        [Required]
+        [StringLength(32, MinimumLength = 6)]
+        public string NewPassword { get; set; } = string.Empty;
+    }
+}

--- a/LYBT.Module.Users/Dtos/ResetPasswordDto.cs
+++ b/LYBT.Module.Users/Dtos/ResetPasswordDto.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Users.Dtos {
+    /// <summary>
+    /// 管理员重置密码 DTO
+    /// </summary>
+    public class ResetPasswordDto {
+        /// <summary>
+        /// 新密码，留空则使用默认值
+        /// </summary>
+        [StringLength(32, MinimumLength = 6)]
+        public string? NewPassword { get; set; }
+    }
+}

--- a/LYBT.Module.Users/Interfaces/IUserRepository.cs
+++ b/LYBT.Module.Users/Interfaces/IUserRepository.cs
@@ -1,4 +1,6 @@
-﻿using LYBT.Module.Users.Dtos;
+﻿using System;
+using System.Collections.Generic;
+using LYBT.Module.Users.Dtos;
 using LYBT.Module.Users.Models;
 
 /// <summary>
@@ -44,4 +46,14 @@ public interface IUserRepository {
     /// 校验用户名是否存在
     /// </summary>
     Task<bool> ExistsByUsernameAsync(string userName);
+
+    /// <summary>
+    /// 更新用户密码
+    /// </summary>
+    Task<bool> UpdatePasswordAsync(Guid id, string passwordHash);
+
+    /// <summary>
+    /// 批量更新启用状态
+    /// </summary>
+    Task<int> UpdateActiveStatusAsync(List<Guid> ids, bool isActive);
 }

--- a/LYBT.Module.Users/Interfaces/IUserService.cs
+++ b/LYBT.Module.Users/Interfaces/IUserService.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LYBT.Module.Users.Dtos;
+using LYBT.Module.Logs.Dtos;
+using LYBT.Common.Enums;
 
 /// <summary>
 /// 用户服务接口，封装业务逻辑（含日志集成）
@@ -36,4 +38,34 @@ public interface IUserService {
     /// 启用用户
     /// </summary>
     Task<bool> EnableAsync(Guid id, Guid operatorId, string operatorName);
+
+    /// <summary>
+    /// 批量禁用用户
+    /// </summary>
+    Task<int> BatchDisableAsync(List<Guid> ids, Guid operatorId, string operatorName);
+
+    /// <summary>
+    /// 批量启用用户
+    /// </summary>
+    Task<int> BatchEnableAsync(List<Guid> ids, Guid operatorId, string operatorName);
+
+    /// <summary>
+    /// 管理员重置密码
+    /// </summary>
+    Task<bool> ResetPasswordAsync(Guid id, string newPassword, Guid operatorId, string operatorName);
+
+    /// <summary>
+    /// 用户修改密码
+    /// </summary>
+    Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword);
+
+    /// <summary>
+    /// 获取系统所有角色
+    /// </summary>
+    List<UserRole> GetRoles();
+
+    /// <summary>
+    /// 获取指定用户的操作日志
+    /// </summary>
+    Task<(IList<LogDto> logs, int total)> GetLogsAsync(Guid id, int page, int pageSize);
 }

--- a/LYBT.Module.Users/Repositories/UserRepository.cs
+++ b/LYBT.Module.Users/Repositories/UserRepository.cs
@@ -108,4 +108,28 @@ public class UserRepository : IUserRepository {
     public async Task<bool> ExistsByUsernameAsync(string userName) {
         return await _dbContext.Users.AnyAsync(u => u.UserName == userName);
     }
+
+    /// <summary>
+    /// 更新用户密码
+    /// </summary>
+    public async Task<bool> UpdatePasswordAsync(Guid id, string passwordHash) {
+        var user = await _dbContext.Users.FindAsync(id);
+        if (user == null)
+            return false;
+        user.PasswordHash = passwordHash;
+        _dbContext.Users.Update(user);
+        return await _dbContext.SaveChangesAsync() > 0;
+    }
+
+    /// <summary>
+    /// 批量更新启用状态
+    /// </summary>
+    public async Task<int> UpdateActiveStatusAsync(List<Guid> ids, bool isActive) {
+        var users = await _dbContext.Users.Where(u => ids.Contains(u.Id)).ToListAsync();
+        foreach (var u in users) {
+            u.IsActive = isActive;
+        }
+        _dbContext.Users.UpdateRange(users);
+        return await _dbContext.SaveChangesAsync();
+    }
 }

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -1,8 +1,13 @@
-﻿using LYBT.Common.Enums.Logs;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using LYBT.Common.Enums;
+using LYBT.Common.Enums.Logs;
 using LYBT.Module.Logs.Dtos;
 using LYBT.Module.Logs.Interfaces;
 using LYBT.Module.Users.Dtos;
 using LYBT.Module.Users.Models;
+using LYBT.Module.Users.Interfaces;
 
 /// <summary>
 /// 用户服务实现类（集成日志模块）
@@ -169,5 +174,86 @@ public class UserService : IUserService {
             });
         }
         return result;
+    }
+
+    /// <summary>
+    /// 批量禁用用户
+    /// </summary>
+    public async Task<int> BatchDisableAsync(List<Guid> ids, Guid operatorId, string operatorName) {
+        int count = 0;
+        foreach (var id in ids) {
+            if (await DisableAsync(id, operatorId, operatorName))
+                count++;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// 批量启用用户
+    /// </summary>
+    public async Task<int> BatchEnableAsync(List<Guid> ids, Guid operatorId, string operatorName) {
+        int count = 0;
+        foreach (var id in ids) {
+            if (await EnableAsync(id, operatorId, operatorName))
+                count++;
+        }
+        return count;
+    }
+
+    private static string HashPassword(string password) {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return Convert.ToBase64String(sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password)));
+    }
+
+    /// <summary>
+    /// 管理员重置密码
+    /// </summary>
+    public async Task<bool> ResetPasswordAsync(Guid id, string newPassword, Guid operatorId, string operatorName) {
+        var user = await _userRepository.GetByIdAsync(id);
+        if (user == null)
+            throw new Exception("用户不存在");
+
+        user.PasswordHash = HashPassword(newPassword);
+        var result = await _userRepository.UpdateAsync(user);
+        if (result) {
+            await _logService.AddLogAsync(new LogDto {
+                LogType = LogType.Operation,
+                ObjectType = ObjectType.User,
+                ObjectId = id,
+                ActionType = ActionType.ResetPassword,
+                OperatorId = operatorId,
+                OperatorName = operatorName,
+                LogTime = DateTime.Now,
+                Content = $"重置用户密码：{user.UserName}"
+            });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// 用户修改密码
+    /// </summary>
+    public async Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword) {
+        var user = await _userRepository.GetByIdAsync(id);
+        if (user == null)
+            return false;
+        if (user.PasswordHash != HashPassword(oldPassword))
+            return false;
+        user.PasswordHash = HashPassword(newPassword);
+        return await _userRepository.UpdateAsync(user);
+    }
+
+    public List<UserRole> GetRoles() {
+        return Enum.GetValues(typeof(UserRole)).Cast<UserRole>().ToList();
+    }
+
+    public async Task<(IList<LogDto> logs, int total)> GetLogsAsync(Guid id, int page, int pageSize) {
+        var query = new LogQueryDto {
+            ObjectType = ObjectType.User,
+            ObjectId = id,
+            Page = page,
+            PageSize = pageSize
+        };
+        return await _logService.GetLogsAsync(query);
     }
 }

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -2,16 +2,17 @@
 using System;
 using System.Threading.Tasks;
 using LYBT.Module.Users.Dtos;
+using LYBT.Module.Users.Interfaces;
 
 /// <summary>
 /// 用户管理控制器，提供RESTful API接口
 /// </summary>
 [ApiController]
 [Route("api/[controller]")]
-public class UserController : ControllerBase {
+public class UsersController : ControllerBase {
     private readonly IUserService _userService;
 
-    public UserController(IUserService userService) {
+    public UsersController(IUserService userService) {
         _userService = userService;
     }
 
@@ -27,7 +28,7 @@ public class UserController : ControllerBase {
     /// <summary>
     /// 新增用户
     /// </summary>
-    [HttpPost("AddUser")]
+    [HttpPost("add")]
     public async Task<IActionResult> Add([FromBody] UserCreateDto dto) {
         // 从Token/Session等获取操作人信息
         Guid operatorId = Guid.NewGuid(); // 实际开发应取登录管理员ID
@@ -39,11 +40,10 @@ public class UserController : ControllerBase {
     /// <summary>
     /// 编辑用户
     /// </summary>
-    [HttpPut("{id:guid}")]
-    public async Task<IActionResult> Update(Guid id, [FromBody] UserEditDto dto) {
+    [HttpPut("update")]
+    public async Task<IActionResult> Update([FromBody] UserEditDto dto) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
-        dto.Id = id;
         var result = await _userService.UpdateAsync(dto, operatorId, operatorName);
         return result ? Ok(new { success = true }) : BadRequest(new { success = false });
     }
@@ -51,7 +51,7 @@ public class UserController : ControllerBase {
     /// <summary>
     /// 禁用用户
     /// </summary>
-    [HttpPut("{id:guid}/disable")]
+    [HttpPost("disable/{id}")]
     public async Task<IActionResult> Disable(Guid id) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
@@ -62,11 +62,81 @@ public class UserController : ControllerBase {
     /// <summary>
     /// 启用用户
     /// </summary>
-    [HttpPut("{id:guid}/enable")]
+    [HttpPost("enable/{id}")]
     public async Task<IActionResult> Enable(Guid id) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
         var result = await _userService.EnableAsync(id, operatorId, operatorName);
         return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+    }
+
+    /// <summary>
+    /// 批量禁用
+    /// </summary>
+    [HttpPost("batchDisable")]
+    public async Task<IActionResult> BatchDisable([FromBody] BatchIdsDto dto) {
+        Guid operatorId = Guid.NewGuid();
+        string operatorName = "管理员A";
+        var count = await _userService.BatchDisableAsync(dto.Ids, operatorId, operatorName);
+        return Ok(new { success = true, count });
+    }
+
+    /// <summary>
+    /// 批量启用
+    /// </summary>
+    [HttpPost("batchEnable")]
+    public async Task<IActionResult> BatchEnable([FromBody] BatchIdsDto dto) {
+        Guid operatorId = Guid.NewGuid();
+        string operatorName = "管理员A";
+        var count = await _userService.BatchEnableAsync(dto.Ids, operatorId, operatorName);
+        return Ok(new { success = true, count });
+    }
+
+    /// <summary>
+    /// 管理员重置密码
+    /// </summary>
+    [HttpPost("resetPassword/{id}")]
+    public async Task<IActionResult> ResetPassword(Guid id, [FromBody] ResetPasswordDto dto) {
+        Guid operatorId = Guid.NewGuid();
+        string operatorName = "管理员A";
+        var password = string.IsNullOrWhiteSpace(dto.NewPassword) ? "123456" : dto.NewPassword;
+        var result = await _userService.ResetPasswordAsync(id, password, operatorId, operatorName);
+        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+    }
+
+    /// <summary>
+    /// 用户修改密码
+    /// </summary>
+    [HttpPost("changePassword")]
+    public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordDto dto) {
+        var result = await _userService.ChangePasswordAsync(dto.UserId, dto.OldPassword, dto.NewPassword);
+        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+    }
+
+    /// <summary>
+    /// 获取所有角色
+    /// </summary>
+    [HttpGet("getRoles")]
+    public IActionResult GetRoles() {
+        var roles = _userService.GetRoles();
+        return Ok(roles);
+    }
+
+    /// <summary>
+    /// 根据Id获取用户详情
+    /// </summary>
+    [HttpGet("getById/{id}")]
+    public async Task<IActionResult> GetById(Guid id) {
+        var user = await _userService.GetByIdAsync(id);
+        return user == null ? NotFound() : Ok(user);
+    }
+
+    /// <summary>
+    /// 获取用户操作日志
+    /// </summary>
+    [HttpGet("getLogs/{id}")]
+    public async Task<IActionResult> GetLogs(Guid id, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) {
+        var (logs, total) = await _userService.GetLogsAsync(id, page, pageSize);
+        return Ok(new { total, logs });
     }
 }


### PR DESCRIPTION
## Summary
- flesh out user API routes for add/search/update/enable/disable
- support batch enable/disable, password changes and logs
- expose roles lookup and user details
- implement service/repository methods for new features
- add DTOs for password and batch id operations

## Testing
- `dotnet build` *(fails: NETSDK1100 on non‑Windows targets)*

------
https://chatgpt.com/codex/tasks/task_e_685066d246d083338545c50909b12f81