### PR TITLE
Centralize user log lookup into logs module

### DIFF
--- a/LYBT.Module.Logs/Interfaces/ILogService.cs
+++ b/LYBT.Module.Logs/Interfaces/ILogService.cs
@@ -23,6 +23,16 @@ namespace LYBT.Module.Logs.Interfaces {
         Task<(IList<LogDto> logs, int total)> GetLogsAsync(LogQueryDto query);
 
         /// <summary>
+        /// 获取指定用户的操作日志
+        /// </summary>
+        Task<(IList<LogDto> logs, int total)> GetUserLogsAsync(Guid userId, int page, int pageSize);
+
+        /// <summary>
+        /// 获取指定患者的操作日志
+        /// </summary>
+        Task<(IList<LogDto> logs, int total)> GetPatientLogsAsync(Guid patientId, int page, int pageSize);
+
+        /// <summary>
         /// 根据日志ID获取详情
         /// </summary>
         /// <param name="id">日志ID</param>

--- a/LYBT.Module.Logs/Services/LogService.cs
+++ b/LYBT.Module.Logs/Services/LogService.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using LYBT.Module.Logs.Dtos;
 using LYBT.Module.Logs.Interfaces;
+using LYBT.Common.Enums.Logs;
 
 namespace LYBT.Module.Logs.Services {
     /// <summary>
@@ -63,6 +64,28 @@ namespace LYBT.Module.Logs.Services {
                 });
             }
             return (list, total);
+        }
+
+        /// <inheritdoc />
+        public async Task<(IList<LogDto> logs, int total)> GetUserLogsAsync(Guid userId, int page, int pageSize) {
+            var query = new LogQueryDto {
+                ObjectType = ObjectType.User,
+                ObjectId = userId,
+                Page = page,
+                PageSize = pageSize
+            };
+            return await GetLogsAsync(query);
+        }
+
+        /// <inheritdoc />
+        public async Task<(IList<LogDto> logs, int total)> GetPatientLogsAsync(Guid patientId, int page, int pageSize) {
+            var query = new LogQueryDto {
+                ObjectType = ObjectType.Patient,
+                ObjectId = patientId,
+                Page = page,
+                PageSize = pageSize
+            };
+            return await GetLogsAsync(query);
         }
 
         /// <inheritdoc />

--- a/LYBT.Module.Users/Interfaces/IUserService.cs
+++ b/LYBT.Module.Users/Interfaces/IUserService.cs
@@ -64,8 +64,4 @@ public interface IUserService {
     /// </summary>
     List<UserRole> GetRoles();
 
-    /// <summary>
-    /// 获取指定用户的操作日志
-    /// </summary>
-    Task<(IList<LogDto> logs, int total)> GetLogsAsync(Guid id, int page, int pageSize);
 }

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -243,13 +243,4 @@ public class UserService : IUserService {
         return Enum.GetValues(typeof(UserRole)).Cast<UserRole>().ToList();
     }
 
-    public async Task<(IList<LogDto> logs, int total)> GetLogsAsync(Guid id, int page, int pageSize) {
-        var query = new LogQueryDto {
-            ObjectType = ObjectType.User,
-            ObjectId = id,
-            Page = page,
-            PageSize = pageSize
-        };
-        return await _logService.GetLogsAsync(query);
-    }
 }

--- a/LYBT.WebAPI/Controllers/LogsController.cs
+++ b/LYBT.WebAPI/Controllers/LogsController.cs
@@ -44,6 +44,24 @@ public class LogController : ControllerBase {
     }
 
     /// <summary>
+    /// 获取指定用户的操作日志
+    /// </summary>
+    [HttpGet("user/{userId}")]
+    public async Task<IActionResult> GetUserLogs(Guid userId, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) {
+        var (logs, total) = await _logService.GetUserLogsAsync(userId, page, pageSize);
+        return Ok(new { total, logs });
+    }
+
+    /// <summary>
+    /// 获取指定患者的操作日志
+    /// </summary>
+    [HttpGet("patient/{patientId}")]
+    public async Task<IActionResult> GetPatientLogs(Guid patientId, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) {
+        var (logs, total) = await _logService.GetPatientLogsAsync(patientId, page, pageSize);
+        return Ok(new { total, logs });
+    }
+
+    /// <summary>
     /// 获取日志详情
     /// </summary>
     /// <param name="id">日志ID</param>

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using LYBT.Module.Users.Dtos;
+using LYBT.Module.Logs.Interfaces;
 
 /// <summary>
 /// 用户管理控制器，提供RESTful API接口
@@ -8,9 +9,11 @@ using LYBT.Module.Users.Dtos;
 [Route("api/[controller]")]
 public class UsersController : ControllerBase {
     private readonly IUserService _userService;
+    private readonly ILogService _logService;
 
-    public UsersController(IUserService userService) {
+    public UsersController(IUserService userService, ILogService logService) {
         _userService = userService;
+        _logService = logService;
     }
 
     /// <summary>
@@ -133,7 +136,7 @@ public class UsersController : ControllerBase {
     /// </summary>
     [HttpGet("getLogs/{id}")]
     public async Task<IActionResult> GetLogs(Guid id, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) {
-        var (logs, total) = await _userService.GetLogsAsync(id, page, pageSize);
+        var (logs, total) = await _logService.GetUserLogsAsync(id, page, pageSize);
         return Ok(new { total, logs });
     }
 }


### PR DESCRIPTION
## Summary
- drop GetLogsAsync from user service
- expose GetUserLogsAsync and GetPatientLogsAsync in log service
- implement new queries inside `LogService`
- adjust controllers to use new log service methods

## Testing
- `dotnet build LYBTZYZS.sln -v q` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850b92e0db8833388772d6dd0a0252d