### PR TITLE
Add advanced doctors API

### DIFF
--- a/LYBT.Models/Doctors/DoctorModel.cs
+++ b/LYBT.Models/Doctors/DoctorModel.cs
@@ -64,5 +64,15 @@ namespace LYBT.Models.Doctors {
 
         /// <summary>执业证书号</summary>
         public string? LicenseNumber { get; set; }
+
+        /// <summary>
+        /// 医生姓名拼音码，用于快捷搜索
+        /// </summary>
+        public string PinyinCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 登录密码哈希值
+        /// </summary>
+        public string PasswordHash { get; set; } = string.Empty;
     }
 }

--- a/LYBT.Module.Doctors/Dtos/BatchIdsDto.cs
+++ b/LYBT.Module.Doctors/Dtos/BatchIdsDto.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Doctors.Dtos {
+    /// <summary>
+    /// 批量操作时提交的ID列表
+    /// </summary>
+    public class BatchIdsDto {
+        [Required]
+        public List<Guid> Ids { get; set; } = new();
+    }
+}

--- a/LYBT.Module.Doctors/Dtos/ChangePasswordDto.cs
+++ b/LYBT.Module.Doctors/Dtos/ChangePasswordDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Doctors.Dtos {
+    /// <summary>
+    /// 医生修改密码 DTO
+    /// </summary>
+    public class ChangePasswordDto {
+        [Required]
+        public Guid DoctorId { get; set; }
+
+        [Required]
+        [StringLength(32, MinimumLength = 6)]
+        public string OldPassword { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(32, MinimumLength = 6)]
+        public string NewPassword { get; set; } = string.Empty;
+    }
+}

--- a/LYBT.Module.Doctors/Dtos/DoctorCreateDto.cs
+++ b/LYBT.Module.Doctors/Dtos/DoctorCreateDto.cs
@@ -22,6 +22,9 @@ namespace LYBT.Module.Doctors.Dtos {
         [Required(ErrorMessage = "联系电话不能为空")]
         public string Phone { get; set; } = string.Empty;
 
+        /// <summary>姓名拼音码</summary>
+        public string PinyinCode { get; set; } = string.Empty;
+
         /// <summary>执业证书号</summary>
         public string? LicenseNumber { get; set; }
 

--- a/LYBT.Module.Doctors/Dtos/DoctorDetailDto.cs
+++ b/LYBT.Module.Doctors/Dtos/DoctorDetailDto.cs
@@ -20,6 +20,9 @@ namespace LYBT.Module.Doctors.Dtos {
         /// <summary>联系电话</summary>
         public string Phone { get; set; } = string.Empty;
 
+        /// <summary>姓名拼音码</summary>
+        public string PinyinCode { get; set; } = string.Empty;
+
         /// <summary>执业证书号</summary>
         public string? LicenseNumber { get; set; }
 

--- a/LYBT.Module.Doctors/Dtos/DoctorDto.cs
+++ b/LYBT.Module.Doctors/Dtos/DoctorDto.cs
@@ -17,6 +17,9 @@ namespace LYBT.Module.Doctors.Dtos {
         /// <summary>联系电话</summary>
         public string Phone { get; set; } = string.Empty;
 
+        /// <summary>姓名拼音码</summary>
+        public string PinyinCode { get; set; } = string.Empty;
+
         /// <summary>状态</summary>
         public string Status { get; set; } = string.Empty;
     }

--- a/LYBT.Module.Doctors/Dtos/DoctorEditDto.cs
+++ b/LYBT.Module.Doctors/Dtos/DoctorEditDto.cs
@@ -27,6 +27,9 @@ namespace LYBT.Module.Doctors.Dtos {
         [Required(ErrorMessage = "联系电话不能为空")]
         public string Phone { get; set; } = string.Empty;
 
+        /// <summary>姓名拼音码</summary>
+        public string PinyinCode { get; set; } = string.Empty;
+
         /// <summary>执业证书号</summary>
         public string? LicenseNumber { get; set; }
 

--- a/LYBT.Module.Doctors/Dtos/DoctorQueryDto.cs
+++ b/LYBT.Module.Doctors/Dtos/DoctorQueryDto.cs
@@ -1,0 +1,18 @@
+namespace LYBT.Module.Doctors.Dtos {
+    /// <summary>
+    /// 医生分页与条件查询 DTO
+    /// </summary>
+    public class DoctorQueryDto {
+        /// <summary>关键词（姓名/拼音码/手机号）</summary>
+        public string? Keyword { get; set; }
+
+        /// <summary>在职状态筛选</summary>
+        public bool? IsActive { get; set; }
+
+        /// <summary>页码，从1开始</summary>
+        public int Page { get; set; } = 1;
+
+        /// <summary>每页数量</summary>
+        public int PageSize { get; set; } = 20;
+    }
+}

--- a/LYBT.Module.Doctors/Dtos/ResetPasswordDto.cs
+++ b/LYBT.Module.Doctors/Dtos/ResetPasswordDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Doctors.Dtos {
+    /// <summary>
+    /// 重置密码 DTO
+    /// </summary>
+    public class ResetPasswordDto {
+        /// <summary>新密码，留空则使用默认值</summary>
+        [StringLength(32, MinimumLength = 6)]
+        public string? NewPassword { get; set; }
+    }
+}

--- a/LYBT.Module.Doctors/Interfaces/IDoctorRepository.cs
+++ b/LYBT.Module.Doctors/Interfaces/IDoctorRepository.cs
@@ -3,6 +3,7 @@ using LYBT.Models.Doctors;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using LYBT.Module.Doctors.Dtos;
 
 namespace LYBT.Module.Doctors.Interfaces {
     /// <summary>
@@ -15,9 +16,19 @@ namespace LYBT.Module.Doctors.Interfaces {
         Task<DoctorModel?> GetByIdAsync(Guid id);
 
         /// <summary>
-        /// 获取所有医生列表
+        /// 获取所有医生列表（不分页）
         /// </summary>
         Task<List<DoctorModel>> GetListAsync();
+
+        /// <summary>
+        /// 搜索医生
+        /// </summary>
+        Task<List<DoctorModel>> SearchAsync(string keyword);
+
+        /// <summary>
+        /// 分页获取医生
+        /// </summary>
+        Task<(List<DoctorModel> list, int total)> GetPagedAsync(DoctorQueryDto query);
 
         /// <summary>
         /// 新增医生
@@ -30,8 +41,28 @@ namespace LYBT.Module.Doctors.Interfaces {
         Task<bool> UpdateAsync(DoctorModel doctorModel);
 
         /// <summary>
-        /// 删除医生
+        /// 禁用医生
         /// </summary>
-        Task<bool> DeleteAsync(Guid id);
+        Task<bool> DisableAsync(Guid id);
+
+        /// <summary>
+        /// 启用医生
+        /// </summary>
+        Task<bool> EnableAsync(Guid id);
+
+        /// <summary>
+        /// 批量禁用
+        /// </summary>
+        Task<int> BatchDisableAsync(List<Guid> ids);
+
+        /// <summary>
+        /// 批量启用
+        /// </summary>
+        Task<int> BatchEnableAsync(List<Guid> ids);
+
+        /// <summary>
+        /// 更新密码
+        /// </summary>
+        Task<bool> UpdatePasswordAsync(Guid id, string passwordHash);
     }
 }

--- a/LYBT.Module.Doctors/Interfaces/IDoctorService.cs
+++ b/LYBT.Module.Doctors/Interfaces/IDoctorService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LYBT.Module.Doctors.Dtos;
+using LYBT.Common.Models;
 
 namespace LYBT.Module.Doctors.Interfaces {
     /// <summary>
@@ -14,9 +15,14 @@ namespace LYBT.Module.Doctors.Interfaces {
         Task<DoctorDetailDto?> GetByIdAsync(Guid id);
 
         /// <summary>
-        /// 获取医生列表
+        /// 关键词搜索
         /// </summary>
-        Task<List<DoctorDto>> GetListAsync();
+        Task<List<DoctorDto>> SearchAsync(string keyword);
+
+        /// <summary>
+        /// 分页获取医生列表
+        /// </summary>
+        Task<PagedResultDto<DoctorDto>> GetPagedAsync(DoctorQueryDto query);
 
         /// <summary>
         /// 新增医生
@@ -29,8 +35,33 @@ namespace LYBT.Module.Doctors.Interfaces {
         Task<bool> UpdateAsync(DoctorEditDto doctorEditDto);
 
         /// <summary>
-        /// 删除医生
+        /// 禁用医生
         /// </summary>
-        Task<bool> DeleteAsync(Guid id);
+        Task<bool> DisableAsync(Guid id);
+
+        /// <summary>
+        /// 启用医生
+        /// </summary>
+        Task<bool> EnableAsync(Guid id);
+
+        /// <summary>
+        /// 批量禁用
+        /// </summary>
+        Task<int> BatchDisableAsync(List<Guid> ids);
+
+        /// <summary>
+        /// 批量启用
+        /// </summary>
+        Task<int> BatchEnableAsync(List<Guid> ids);
+
+        /// <summary>
+        /// 重置密码
+        /// </summary>
+        Task<bool> ResetPasswordAsync(Guid id, string newPassword);
+
+        /// <summary>
+        /// 修改密码
+        /// </summary>
+        Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword);
     }
 }

--- a/LYBT.Module.Doctors/Repositories/DoctorRepository.cs
+++ b/LYBT.Module.Doctors/Repositories/DoctorRepository.cs
@@ -2,6 +2,9 @@
 using LYBT.Models;
 using LYBT.Models.Doctors;
 using LYBT.Module.Doctors.Interfaces;
+using LYBT.Module.Doctors.Dtos;
+using Microsoft.EntityFrameworkCore;
+using LYBT.Common.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,13 +55,74 @@ namespace LYBT.Module.Doctors.Repositories {
         }
 
         /// <summary>
-        /// 删除医生
+        /// 禁用医生
         /// </summary>
-        public async Task<bool> DeleteAsync(Guid id) {
+        public async Task<bool> DisableAsync(Guid id) {
             var model = await _appDbContext.Doctors.FindAsync(id);
             if (model == null)
                 return false;
-            _appDbContext.Doctors.Remove(model);
+            model.Status = DoctorStatus.Inactive;
+            _appDbContext.Doctors.Update(model);
+            return await _appDbContext.SaveChangesAsync() > 0;
+        }
+
+        /// <summary>
+        /// 启用医生
+        /// </summary>
+        public async Task<bool> EnableAsync(Guid id) {
+            var model = await _appDbContext.Doctors.FindAsync(id);
+            if (model == null)
+                return false;
+            model.Status = DoctorStatus.Active;
+            _appDbContext.Doctors.Update(model);
+            return await _appDbContext.SaveChangesAsync() > 0;
+        }
+
+        public async Task<int> BatchDisableAsync(List<Guid> ids) {
+            var list = await _appDbContext.Doctors.Where(d => ids.Contains(d.Id)).ToListAsync();
+            foreach (var d in list) d.Status = DoctorStatus.Inactive;
+            _appDbContext.Doctors.UpdateRange(list);
+            return await _appDbContext.SaveChangesAsync();
+        }
+
+        public async Task<int> BatchEnableAsync(List<Guid> ids) {
+            var list = await _appDbContext.Doctors.Where(d => ids.Contains(d.Id)).ToListAsync();
+            foreach (var d in list) d.Status = DoctorStatus.Active;
+            _appDbContext.Doctors.UpdateRange(list);
+            return await _appDbContext.SaveChangesAsync();
+        }
+
+        public async Task<List<DoctorModel>> SearchAsync(string keyword) {
+            var query = _appDbContext.Doctors.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(keyword)) {
+                query = query.Where(d => d.Name.Contains(keyword) || d.Phone.Contains(keyword) || d.PinyinCode.Contains(keyword));
+            }
+            return await query.OrderByDescending(d => d.CreatedTime).Take(20).ToListAsync();
+        }
+
+        public async Task<(List<DoctorModel> list, int total)> GetPagedAsync(DoctorQueryDto query) {
+            var dbSet = _appDbContext.Doctors.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(query.Keyword)) {
+                dbSet = dbSet.Where(d => d.Name.Contains(query.Keyword) || d.Phone.Contains(query.Keyword) || d.PinyinCode.Contains(query.Keyword));
+            }
+            if (query.IsActive.HasValue) {
+                var status = query.IsActive.Value ? DoctorStatus.Active : DoctorStatus.Inactive;
+                dbSet = dbSet.Where(d => d.Status == status);
+            }
+            int total = await dbSet.CountAsync();
+            var list = await dbSet.OrderByDescending(d => d.CreatedTime)
+                .Skip((query.Page - 1) * query.PageSize)
+                .Take(query.PageSize)
+                .ToListAsync();
+            return (list, total);
+        }
+
+        public async Task<bool> UpdatePasswordAsync(Guid id, string passwordHash) {
+            var model = await _appDbContext.Doctors.FindAsync(id);
+            if (model == null)
+                return false;
+            model.PasswordHash = passwordHash;
+            _appDbContext.Doctors.Update(model);
             return await _appDbContext.SaveChangesAsync() > 0;
         }
     }

--- a/LYBT.Module.Doctors/Services/DoctorService.cs
+++ b/LYBT.Module.Doctors/Services/DoctorService.cs
@@ -4,6 +4,7 @@ using LYBT.Models;
 using LYBT.Models.Doctors;
 using LYBT.Module.Doctors.Dtos;
 using LYBT.Module.Doctors.Interfaces;
+using LYBT.Common.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -33,11 +34,19 @@ namespace LYBT.Module.Doctors.Services {
         }
 
         /// <summary>
-        /// 获取医生列表
+        /// 关键词搜索
         /// </summary>
-        public async Task<List<DoctorDto>> GetListAsync() {
-            var list = await _doctorRepository.GetListAsync();
+        public async Task<List<DoctorDto>> SearchAsync(string keyword) {
+            var list = await _doctorRepository.SearchAsync(keyword);
             return _mapper.Map<List<DoctorDto>>(list);
+        }
+
+        public async Task<PagedResultDto<DoctorDto>> GetPagedAsync(DoctorQueryDto query) {
+            var (models, total) = await _doctorRepository.GetPagedAsync(query);
+            return new PagedResultDto<DoctorDto> {
+                TotalCount = total,
+                Items = _mapper.Map<List<DoctorDto>>(models)
+            };
         }
 
         /// <summary>
@@ -47,6 +56,7 @@ namespace LYBT.Module.Doctors.Services {
             var model = _mapper.Map<DoctorModel>(doctorCreateDto);
             model.Id = Guid.NewGuid();
             model.Status = DoctorStatus.Active;
+            model.PasswordHash = HashPassword("123456");
             return await _doctorRepository.AddAsync(model);
         }
 
@@ -61,6 +71,7 @@ namespace LYBT.Module.Doctors.Services {
             model.Gender = doctorEditDto.Gender;
             model.Birthday = doctorEditDto.Birthday;
             model.Phone = doctorEditDto.Phone;
+            model.PinyinCode = doctorEditDto.PinyinCode;
             model.LicenseNumber = doctorEditDto.LicenseNumber;
             model.Title = doctorEditDto.Title;
             model.Status = doctorEditDto.Status;
@@ -69,10 +80,39 @@ namespace LYBT.Module.Doctors.Services {
         }
 
         /// <summary>
-        /// 删除医生
+        /// 禁用医生
         /// </summary>
-        public async Task<bool> DeleteAsync(Guid id) {
-            return await _doctorRepository.DeleteAsync(id);
+        public async Task<bool> DisableAsync(Guid id) {
+            return await _doctorRepository.DisableAsync(id);
+        }
+
+        public async Task<bool> EnableAsync(Guid id) {
+            return await _doctorRepository.EnableAsync(id);
+        }
+
+        public async Task<int> BatchDisableAsync(List<Guid> ids) {
+            return await _doctorRepository.BatchDisableAsync(ids);
+        }
+
+        public async Task<int> BatchEnableAsync(List<Guid> ids) {
+            return await _doctorRepository.BatchEnableAsync(ids);
+        }
+
+        public async Task<bool> ResetPasswordAsync(Guid id, string newPassword) {
+            var hash = HashPassword(newPassword);
+            return await _doctorRepository.UpdatePasswordAsync(id, hash);
+        }
+
+        public async Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword) {
+            var model = await _doctorRepository.GetByIdAsync(id);
+            if (model == null) return false;
+            if (model.PasswordHash != HashPassword(oldPassword)) return false;
+            return await _doctorRepository.UpdatePasswordAsync(id, HashPassword(newPassword));
+        }
+
+        private static string HashPassword(string password) {
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            return Convert.ToBase64String(sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(password)));
         }
     }
 }

--- a/LYBT.WebAPI/Controllers/DoctorsController.cs
+++ b/LYBT.WebAPI/Controllers/DoctorsController.cs
@@ -1,85 +1,95 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
+using LYBT.Module.Doctors.Interfaces;
+using LYBT.Module.Doctors.Dtos;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using LYBT.Module.Doctors.Interfaces;
-using LYBT.Module.Doctors.Dtos;
 
-namespace LYBT.Module.Doctors.Controllers {
+namespace LYBT.WebAPI.Controllers {
     /// <summary>
-    /// 医生 API 控制器
+    /// 医生管理接口
     /// </summary>
     [ApiController]
     [Route("api/[controller]")]
     public class DoctorsController : ControllerBase {
         private readonly IDoctorService _doctorService;
-
-        /// <summary>
-        /// 构造方法，注入医生服务
-        /// </summary>
         public DoctorsController(IDoctorService doctorService) {
             _doctorService = doctorService;
         }
 
-        /// <summary>
-        /// 获取医生列表
-        /// </summary>
-        [HttpGet]
-        public async Task<ActionResult<List<DoctorDto>>> GetList() {
-            var list = await _doctorService.GetListAsync();
+        [HttpGet("search")]
+        public async Task<ActionResult<List<DoctorDto>>> Search([FromQuery] string keyword) {
+            var list = await _doctorService.SearchAsync(keyword);
             return Ok(list);
         }
 
-        /// <summary>
-        /// 获取医生详情
-        /// </summary>
         [HttpGet("{id}")]
         public async Task<ActionResult<DoctorDetailDto>> GetById(Guid id) {
-            var detail = await _doctorService.GetByIdAsync(id);
-            if (detail == null)
-                return NotFound();
-            return Ok(detail);
+            var item = await _doctorService.GetByIdAsync(id);
+            return item == null ? NotFound() : Ok(item);
         }
 
-        /// <summary>
-        /// 新增医生
-        /// </summary>
-        [HttpPost]
-        public async Task<ActionResult> Add([FromBody] DoctorCreateDto doctorCreateDto) {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var result = await _doctorService.AddAsync(doctorCreateDto);
-            if (!result)
-                return BadRequest("新增医生失败");
-
-            return Ok("新增医生成功");
+        [HttpPost("add")]
+        public async Task<IActionResult> Add([FromBody] DoctorCreateDto dto) {
+            if (!ModelState.IsValid) return BadRequest(ModelState);
+            var result = await _doctorService.AddAsync(dto);
+            return result ? Ok() : BadRequest();
         }
 
-        /// <summary>
-        /// 编辑医生
-        /// </summary>
-        [HttpPut]
-        public async Task<ActionResult> Update([FromBody] DoctorEditDto doctorEditDto) {
-            if (!ModelState.IsValid)
-                return BadRequest(ModelState);
-
-            var result = await _doctorService.UpdateAsync(doctorEditDto);
-            if (!result)
-                return BadRequest("编辑医生失败");
-
-            return Ok("编辑医生成功");
+        [HttpPut("update")]
+        public async Task<IActionResult> Update([FromBody] DoctorEditDto dto) {
+            if (!ModelState.IsValid) return BadRequest(ModelState);
+            var result = await _doctorService.UpdateAsync(dto);
+            return result ? Ok() : BadRequest();
         }
 
-        /// <summary>
-        /// 删除医生
-        /// </summary>
-        [HttpDelete("{id}")]
-        public async Task<ActionResult> Delete(Guid id) {
-            var result = await _doctorService.DeleteAsync(id);
-            if (!result)
-                return NotFound();
-            return Ok("删除医生成功");
+        [HttpPut("disable/{id}")]
+        public async Task<IActionResult> Disable(Guid id) {
+            var ok = await _doctorService.DisableAsync(id);
+            return ok ? Ok() : NotFound();
+        }
+
+        [HttpPut("enable/{id}")]
+        public async Task<IActionResult> Enable(Guid id) {
+            var ok = await _doctorService.EnableAsync(id);
+            return ok ? Ok() : NotFound();
+        }
+
+        [HttpPost("paged")]
+        public async Task<ActionResult<PagedResultDto<DoctorDto>>> GetPaged([FromBody] DoctorQueryDto query) {
+            var result = await _doctorService.GetPagedAsync(query);
+            return Ok(result);
+        }
+
+        [HttpPut("batch-disable")]
+        public async Task<IActionResult> BatchDisable([FromBody] BatchIdsDto dto) {
+            var count = await _doctorService.BatchDisableAsync(dto.Ids);
+            return Ok(new { count });
+        }
+
+        [HttpPut("batch-enable")]
+        public async Task<IActionResult> BatchEnable([FromBody] BatchIdsDto dto) {
+            var count = await _doctorService.BatchEnableAsync(dto.Ids);
+            return Ok(new { count });
+        }
+
+        [HttpPut("reset-password/{id}")]
+        public async Task<IActionResult> ResetPassword(Guid id, [FromBody] ResetPasswordDto dto) {
+            var pwd = string.IsNullOrWhiteSpace(dto.NewPassword) ? "123456" : dto.NewPassword;
+            var ok = await _doctorService.ResetPasswordAsync(id, pwd);
+            return ok ? Ok() : NotFound();
+        }
+
+        [HttpPut("change-password")]
+        public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordDto dto) {
+            var ok = await _doctorService.ChangePasswordAsync(dto.DoctorId, dto.OldPassword, dto.NewPassword);
+            return ok ? Ok() : BadRequest();
+        }
+
+        [HttpGet("roles")]
+        public IActionResult GetRoles() {
+            var roles = Enum.GetNames(typeof(LYBT.Common.Enums.UserRole));
+            return Ok(roles);
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend doctor model with password and pinyin code
- add query/batch/password DTOs for doctors
- expand repository/service with search, paging, enable/disable and password ops
- implement revamped DoctorsController with new endpoints

## Testing
- `dotnet build` *(fails: EnableWindowsTargeting required)*

------
https://chatgpt.com/codex/tasks/task_e_6850bba21e0c8333aeefaf13bfe66a77