### PR TITLE
Implement waiting prescription operations

### DIFF
--- a/LYBT.Common/Enums/PharmacyStatus.cs
+++ b/LYBT.Common/Enums/PharmacyStatus.cs
@@ -1,13 +1,25 @@
 ﻿namespace LYBT.Common.Enums {
 
     /// <summary>
-    /// 药房订单状态枚举
+    /// 药房处方状态枚举
     /// </summary>
     public enum PharmacyStatus {
-        待收费 = 0,
-        已收费 = 1,
-        抓药中 = 2,
-        已完成 = 3,
-        已作废 = 9
+        /// <summary>待抓药</summary>
+        Waiting = 0,
+
+        /// <summary>抓药中</summary>
+        Preparing = 1,
+
+        /// <summary>已抓药</summary>
+        Prepared = 2,
+
+        /// <summary>待代煎</summary>
+        DecoctionWaiting = 3,
+
+        /// <summary>代煎完成</summary>
+        DecoctionCompleted = 4,
+
+        /// <summary>抓药完毕</summary>
+        Completed = 5
     }
 }

--- a/LYBT.Module.Pharmacy/Interfaces/IPharmacyRepository.cs
+++ b/LYBT.Module.Pharmacy/Interfaces/IPharmacyRepository.cs
@@ -1,5 +1,6 @@
 ﻿using LYBT.Models; // PharmacyModel 统一存放在 LYBT.Models
 using LYBT.Models.Pharmacy;
+using LYBT.Common.Enums;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -33,5 +34,10 @@ namespace LYBT.Module.Pharmacy.Interfaces {
         /// 删除药房记录
         /// </summary>
         Task<bool> DeleteAsync(Guid id);
+
+        /// <summary>
+        /// 根据状态获取药房记录列表
+        /// </summary>
+        Task<List<PharmacyModel>> GetByStatusAsync(PharmacyStatus status);
     }
 }

--- a/LYBT.Module.Pharmacy/Interfaces/IPharmacyService.cs
+++ b/LYBT.Module.Pharmacy/Interfaces/IPharmacyService.cs
@@ -32,5 +32,15 @@ namespace LYBT.Module.Pharmacy.Interfaces {
         /// 删除药房单
         /// </summary>
         Task<bool> DeleteAsync(Guid id);
+
+        /// <summary>
+        /// 获取待抓药处方列表
+        /// </summary>
+        Task<List<PharmacyDto>> GetWaitingListAsync();
+
+        /// <summary>
+        /// 将指定处方标记为已抓药
+        /// </summary>
+        Task<bool> MarkAsPreparedAsync(Guid id);
     }
 }

--- a/LYBT.Module.Pharmacy/Repositories/PharmacyRepository.cs
+++ b/LYBT.Module.Pharmacy/Repositories/PharmacyRepository.cs
@@ -2,6 +2,7 @@
 using LYBT.Models;
 using LYBT.Models.Pharmacy;
 using LYBT.Module.Pharmacy.Interfaces;
+using LYBT.Common.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,6 +61,15 @@ namespace LYBT.Module.Pharmacy.Repositories {
                 return false;
             _appDbContext.Pharmacies.Remove(pharmacyModel);
             return await _appDbContext.SaveChangesAsync() > 0;
+        }
+
+        /// <summary>
+        /// 根据状态获取药房记录列表
+        /// </summary>
+        public async Task<List<PharmacyModel>> GetByStatusAsync(PharmacyStatus status) {
+            return await Task.FromResult(_appDbContext.Pharmacies
+                .Where(p => p.Status == status)
+                .ToList());
         }
     }
 }

--- a/LYBT.Module.Pharmacy/Services/PharmacyService.cs
+++ b/LYBT.Module.Pharmacy/Services/PharmacyService.cs
@@ -3,6 +3,7 @@ using LYBT.Models;
 using LYBT.Models.Pharmacy;
 using LYBT.Module.Pharmacy.Dtos;
 using LYBT.Module.Pharmacy.Interfaces;
+using LYBT.Common.Enums;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -68,6 +69,25 @@ namespace LYBT.Module.Pharmacy.Services {
         /// </summary>
         public async Task<bool> DeleteAsync(Guid id) {
             return await _pharmacyRepository.DeleteAsync(id);
+        }
+
+        /// <summary>
+        /// 获取待抓药处方列表
+        /// </summary>
+        public async Task<List<PharmacyDto>> GetWaitingListAsync() {
+            var list = await _pharmacyRepository.GetByStatusAsync(PharmacyStatus.Waiting);
+            return _mapper.Map<List<PharmacyDto>>(list);
+        }
+
+        /// <summary>
+        /// 将处方标记为已抓药
+        /// </summary>
+        public async Task<bool> MarkAsPreparedAsync(Guid id) {
+            var model = await _pharmacyRepository.GetByIdAsync(id);
+            if (model == null)
+                return false;
+            model.Status = PharmacyStatus.Prepared;
+            return await _pharmacyRepository.UpdateAsync(model);
         }
     }
 }

--- a/LYBT.WebAPI/Controllers/PharmacyController.cs
+++ b/LYBT.WebAPI/Controllers/PharmacyController.cs
@@ -19,6 +19,15 @@ namespace LYBT.Module.Pharmacy.Controllers {
         }
 
         /// <summary>
+        /// 获取待抓药的处方列表
+        /// </summary>
+        [HttpGet("waiting")]
+        public async Task<ActionResult<List<PharmacyDto>>> GetWaitingList() {
+            var list = await _pharmacyService.GetWaitingListAsync();
+            return Ok(list);
+        }
+
+        /// <summary>
         /// 获取药房单列表
         /// </summary>
         [HttpGet]
@@ -77,6 +86,17 @@ namespace LYBT.Module.Pharmacy.Controllers {
             if (!result)
                 return NotFound();
             return Ok("删除药房单成功");
+        }
+
+        /// <summary>
+        /// 标记处方为已抓药
+        /// </summary>
+        [HttpPost("{id}/prepared")]
+        public async Task<ActionResult> MarkAsPrepared(Guid id) {
+            var result = await _pharmacyService.MarkAsPreparedAsync(id);
+            if (!result)
+                return NotFound();
+            return Ok();
         }
     }
 }


### PR DESCRIPTION
## Summary
- refine `PharmacyStatus` enum with detailed pharmacy workflow states
- expose repository method for querying pharmacy records by status
- extend pharmacy service with waiting list and mark-as-prepared logic
- update controller to provide waiting-list endpoint and prepared action

## Testing
- `dotnet build` *(fails: NETSDK1100 EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_6850c2352bd48333bd5aafce2d5ffbce