### PR TITLE
Extend records module with sharing

### DIFF
--- a/LYBT.Infrastructure/AppDbContext.cs
+++ b/LYBT.Infrastructure/AppDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System.Text.Json;
+using System.Collections.Generic;
 using LYBT.Models;
 using LYBT.Models.Billing;
 using LYBT.Models.DiagnosisTreatment;
@@ -94,6 +95,55 @@ namespace LYBT.Infrastructure {
                 .HasConversion(
                     v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
                     v => JsonSerializer.Deserialize<FormulaModel>(v, (JsonSerializerOptions)null));
+
+            // === RecordModel complex fields ===
+            modelBuilder.Entity<RecordModel>()
+                .Property(x => x.DiagnosisResults)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions)null))
+                .Metadata.SetValueComparer(
+                    new ValueComparer<List<string>>(
+                        (c1, c2) => JsonSerializer.Serialize(c1, (JsonSerializerOptions)null) == JsonSerializer.Serialize(c2, (JsonSerializerOptions)null),
+                        c => c == null ? 0 : JsonSerializer.Serialize(c, (JsonSerializerOptions)null).GetHashCode(),
+                        c => c == null ? null : JsonSerializer.Deserialize<List<string>>(JsonSerializer.Serialize(c, (JsonSerializerOptions)null), (JsonSerializerOptions)null)
+                    ));
+
+            modelBuilder.Entity<RecordModel>()
+                .Property(x => x.HerbalFormula)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<HerbItemModel>>(v, (JsonSerializerOptions)null))
+                .Metadata.SetValueComparer(
+                    new ValueComparer<List<HerbItemModel>>(
+                        (c1, c2) => JsonSerializer.Serialize(c1, (JsonSerializerOptions)null) == JsonSerializer.Serialize(c2, (JsonSerializerOptions)null),
+                        c => c == null ? 0 : JsonSerializer.Serialize(c, (JsonSerializerOptions)null).GetHashCode(),
+                        c => c == null ? null : JsonSerializer.Deserialize<List<HerbItemModel>>(JsonSerializer.Serialize(c, (JsonSerializerOptions)null), (JsonSerializerOptions)null)
+                    ));
+
+            modelBuilder.Entity<RecordModel>()
+                .Property(x => x.TreatmentPlans)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<TreatmentItemModel>>(v, (JsonSerializerOptions)null))
+                .Metadata.SetValueComparer(
+                    new ValueComparer<List<TreatmentItemModel>>(
+                        (c1, c2) => JsonSerializer.Serialize(c1, (JsonSerializerOptions)null) == JsonSerializer.Serialize(c2, (JsonSerializerOptions)null),
+                        c => c == null ? 0 : JsonSerializer.Serialize(c, (JsonSerializerOptions)null).GetHashCode(),
+                        c => c == null ? null : JsonSerializer.Deserialize<List<TreatmentItemModel>>(JsonSerializer.Serialize(c, (JsonSerializerOptions)null), (JsonSerializerOptions)null)
+                    ));
+
+            modelBuilder.Entity<RecordModel>()
+                .Property(x => x.SharedToDoctorIds)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions)null))
+                .Metadata.SetValueComparer(
+                    new ValueComparer<List<string>>(
+                        (c1, c2) => JsonSerializer.Serialize(c1, (JsonSerializerOptions)null) == JsonSerializer.Serialize(c2, (JsonSerializerOptions)null),
+                        c => c == null ? 0 : JsonSerializer.Serialize(c, (JsonSerializerOptions)null).GetHashCode(),
+                        c => c == null ? null : JsonSerializer.Deserialize<List<string>>(JsonSerializer.Serialize(c, (JsonSerializerOptions)null), (JsonSerializerOptions)null)
+                    ));
 
             // === 所有金额 decimal 字段加精度（18,2） ===
             modelBuilder.Entity<BillingModel>().Property(x => x.PaidAmount).HasPrecision(18, 2);

--- a/LYBT.Models/Records/RecordModel.cs
+++ b/LYBT.Models/Records/RecordModel.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using LYBT.Models.DiagnosisTreatment;
 
 namespace LYBT.Models.Records {
     /// <summary>
@@ -49,6 +51,24 @@ namespace LYBT.Models.Records {
 
         /// <summary>处方ID</summary>
         public Guid? PrescriptionId { get; set; }
+
+        /// <summary>辩证结果列表</summary>
+        public List<string> DiagnosisResults { get; set; } = new();
+
+        /// <summary>药材组成</summary>
+        public List<HerbItemModel>? HerbalFormula { get; set; }
+
+        /// <summary>辅助治疗方案</summary>
+        public List<TreatmentItemModel>? TreatmentPlans { get; set; }
+
+        /// <summary>共享给医生ID列表</summary>
+        public List<string> SharedToDoctorIds { get; set; } = new();
+
+        /// <summary>创建医生ID</summary>
+        public string? CreatedBy { get; set; }
+
+        /// <summary>创建时间</summary>
+        public DateTime CreatedTime { get; set; } = DateTime.Now;
     }
 }
 

--- a/LYBT.Module.Records/Dtos/RecordCreateDto.cs
+++ b/LYBT.Module.Records/Dtos/RecordCreateDto.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+using LYBT.Models.DiagnosisTreatment;
 
 namespace LYBT.Module.Records.Dtos {
     /// <summary>
@@ -26,6 +28,27 @@ namespace LYBT.Module.Records.Dtos {
 
         /// <summary>诊疗建议</summary>
         public string? TreatmentAdvice { get; set; }
+
+        /// <summary>辩证结果列表</summary>
+        public List<string> DiagnosisResults { get; set; } = new();
+
+        /// <summary>药材组成</summary>
+        public List<HerbItemModel>? HerbalFormula { get; set; }
+
+        /// <summary>辅助治疗方案</summary>
+        public List<TreatmentItemModel>? TreatmentPlans { get; set; }
+
+        /// <summary>是否共享</summary>
+        public bool IsShared { get; set; }
+
+        /// <summary>共享给医生ID列表</summary>
+        public List<string> SharedToDoctorIds { get; set; } = new();
+
+        /// <summary>创建医生ID</summary>
+        public string? CreatedBy { get; set; }
+
+        /// <summary>创建时间</summary>
+        public DateTime CreatedTime { get; set; } = DateTime.Now;
 
         /// <summary>开方信息（如药方ID）</summary>
         public Guid? PrescriptionId { get; set; }

--- a/LYBT.Module.Records/Dtos/RecordDetailDto.cs
+++ b/LYBT.Module.Records/Dtos/RecordDetailDto.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using LYBT.Models.DiagnosisTreatment;
 
 namespace LYBT.Module.Records.Dtos {
     /// <summary>
@@ -31,6 +33,27 @@ namespace LYBT.Module.Records.Dtos {
 
         /// <summary>开方信息（如药方ID）</summary>
         public Guid? PrescriptionId { get; set; }
+
+        /// <summary>辩证结果列表</summary>
+        public List<string> DiagnosisResults { get; set; } = new();
+
+        /// <summary>药材组成</summary>
+        public List<HerbItemModel>? HerbalFormula { get; set; }
+
+        /// <summary>辅助治疗方案</summary>
+        public List<TreatmentItemModel>? TreatmentPlans { get; set; }
+
+        /// <summary>是否共享</summary>
+        public bool IsShared { get; set; }
+
+        /// <summary>共享给医生ID列表</summary>
+        public List<string> SharedToDoctorIds { get; set; } = new();
+
+        /// <summary>创建医生ID</summary>
+        public string? CreatedBy { get; set; }
+
+        /// <summary>创建时间</summary>
+        public DateTime CreatedTime { get; set; }
 
         /// <summary>病历创建/修改时间</summary>
         public DateTime RecordTime { get; set; }

--- a/LYBT.Module.Records/Dtos/RecordDto.cs
+++ b/LYBT.Module.Records/Dtos/RecordDto.cs
@@ -16,5 +16,8 @@ namespace LYBT.Module.Records.Dtos {
 
         /// <summary>病历时间</summary>
         public DateTime RecordTime { get; set; }
+
+        /// <summary>是否共享</summary>
+        public bool IsShared { get; set; }
     }
 }

--- a/LYBT.Module.Records/Dtos/RecordEditDto.cs
+++ b/LYBT.Module.Records/Dtos/RecordEditDto.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
+using LYBT.Models.DiagnosisTreatment;
 
 namespace LYBT.Module.Records.Dtos {
     /// <summary>
@@ -25,6 +27,21 @@ namespace LYBT.Module.Records.Dtos {
 
         /// <summary>开方信息（如药方ID）</summary>
         public Guid? PrescriptionId { get; set; }
+
+        /// <summary>辩证结果列表</summary>
+        public List<string> DiagnosisResults { get; set; } = new();
+
+        /// <summary>药材组成</summary>
+        public List<HerbItemModel>? HerbalFormula { get; set; }
+
+        /// <summary>辅助治疗方案</summary>
+        public List<TreatmentItemModel>? TreatmentPlans { get; set; }
+
+        /// <summary>是否共享</summary>
+        public bool IsShared { get; set; }
+
+        /// <summary>共享给医生ID列表</summary>
+        public List<string> SharedToDoctorIds { get; set; } = new();
 
         /// <summary>病历修改时间</summary>
         public DateTime RecordTime { get; set; } = DateTime.Now;

--- a/LYBT.Module.Records/Interfaces/IRecordRepository.cs
+++ b/LYBT.Module.Records/Interfaces/IRecordRepository.cs
@@ -38,5 +38,10 @@ namespace LYBT.Module.Records.Interfaces {
         /// 根据患者ID获取病历列表
         /// </summary>
         Task<List<RecordModel>> GetListByPatientIdAsync(Guid patientId);
+
+        /// <summary>
+        /// 获取共享给某医生的病历
+        /// </summary>
+        Task<List<RecordModel>> GetSharedRecordsAsync(Guid doctorId);
     }
 }

--- a/LYBT.Module.Records/Interfaces/IRecordService.cs
+++ b/LYBT.Module.Records/Interfaces/IRecordService.cs
@@ -37,5 +37,20 @@ namespace LYBT.Module.Records.Interfaces {
         /// 根据患者ID获取病历列表
         /// </summary>
         Task<List<RecordDto>> GetByPatientIdAsync(Guid patientId);
+
+        /// <summary>
+        /// 标记共享病历
+        /// </summary>
+        Task<bool> MarkAsSharedAsync(Guid id, List<string> doctorIds);
+
+        /// <summary>
+        /// 撤销病历共享
+        /// </summary>
+        Task<bool> RevokeSharingAsync(Guid id);
+
+        /// <summary>
+        /// 获取共享给当前医生的病历
+        /// </summary>
+        Task<List<RecordDto>> GetSharedRecordsAsync(Guid doctorId);
     }
 }

--- a/LYBT.Module.Records/Repositories/RecordRepository.cs
+++ b/LYBT.Module.Records/Repositories/RecordRepository.cs
@@ -69,5 +69,12 @@ namespace LYBT.Module.Records.Repositories {
                 .OrderByDescending(r => r.RecordTime)
                 .ToListAsync();
         }
+
+        public async Task<List<RecordModel>> GetSharedRecordsAsync(Guid doctorId) {
+            var list = await _appDbContext.Records
+                .Where(r => r.IsShared)
+                .ToListAsync();
+            return list.Where(r => r.SharedToDoctorIds.Contains(doctorId.ToString())).ToList();
+        }
     }
 }

--- a/LYBT.Module.Records/Services/RecordService.cs
+++ b/LYBT.Module.Records/Services/RecordService.cs
@@ -52,6 +52,8 @@ namespace LYBT.Module.Records.Services {
             var model = _mapper.Map<RecordModel>(recordCreateDto);
             model.Id = Guid.NewGuid();
             model.RecordTime = DateTime.Now;
+            model.CreatedBy = operatorId.ToString();
+            model.CreatedTime = DateTime.Now;
             var result = await _recordRepository.AddAsync(model);
 
             if (result) {
@@ -86,6 +88,11 @@ namespace LYBT.Module.Records.Services {
             model.PresentIllness = recordEditDto.PresentIllness ?? model.PresentIllness;
             model.TreatmentAdvice = recordEditDto.TreatmentAdvice ?? model.TreatmentAdvice;
             model.PrescriptionId = recordEditDto.PrescriptionId;
+            model.DiagnosisResults = recordEditDto.DiagnosisResults;
+            model.HerbalFormula = recordEditDto.HerbalFormula;
+            model.TreatmentPlans = recordEditDto.TreatmentPlans;
+            model.IsShared = recordEditDto.IsShared;
+            model.SharedToDoctorIds = recordEditDto.SharedToDoctorIds;
             model.RecordTime = recordEditDto.RecordTime;
 
             var result = await _recordRepository.UpdateAsync(model);
@@ -134,6 +141,29 @@ namespace LYBT.Module.Records.Services {
 
         public async Task<List<RecordDto>> GetByPatientIdAsync(Guid patientId) {
             var list = await _recordRepository.GetListByPatientIdAsync(patientId);
+            return _mapper.Map<List<RecordDto>>(list);
+        }
+
+        public async Task<bool> MarkAsSharedAsync(Guid id, List<string> doctorIds) {
+            var model = await _recordRepository.GetByIdAsync(id);
+            if (model == null)
+                return false;
+            model.IsShared = true;
+            model.SharedToDoctorIds = doctorIds;
+            return await _recordRepository.UpdateAsync(model);
+        }
+
+        public async Task<bool> RevokeSharingAsync(Guid id) {
+            var model = await _recordRepository.GetByIdAsync(id);
+            if (model == null)
+                return false;
+            model.IsShared = false;
+            model.SharedToDoctorIds = new List<string>();
+            return await _recordRepository.UpdateAsync(model);
+        }
+
+        public async Task<List<RecordDto>> GetSharedRecordsAsync(Guid doctorId) {
+            var list = await _recordRepository.GetSharedRecordsAsync(doctorId);
             return _mapper.Map<List<RecordDto>>(list);
         }
     }

--- a/LYBT.WebAPI/Controllers/RecordsController.cs
+++ b/LYBT.WebAPI/Controllers/RecordsController.cs
@@ -30,6 +30,12 @@ namespace LYBT.Module.Records.Controllers {
             return Ok(list);
         }
 
+        [HttpGet("patient/{patientId}")]
+        public async Task<ActionResult<List<RecordDto>>> GetByPatient(Guid patientId) {
+            var list = await _recordService.GetByPatientIdAsync(patientId);
+            return Ok(list);
+        }
+
         /// <summary>
         /// 获取病历详情
         /// </summary>
@@ -86,6 +92,28 @@ namespace LYBT.Module.Records.Controllers {
             if (!result)
                 return NotFound();
             return Ok("删除病历成功");
+        }
+
+        [HttpPost("share/{id}")]
+        public async Task<ActionResult> MarkAsShared(Guid id, [FromBody] List<string> doctorIds) {
+            var result = await _recordService.MarkAsSharedAsync(id, doctorIds);
+            if (!result)
+                return NotFound();
+            return Ok();
+        }
+
+        [HttpPost("unshare/{id}")]
+        public async Task<ActionResult> RevokeSharing(Guid id) {
+            var result = await _recordService.RevokeSharingAsync(id);
+            if (!result)
+                return NotFound();
+            return Ok();
+        }
+
+        [HttpGet("shared/{doctorId}")]
+        public async Task<ActionResult<List<RecordDto>>> GetShared(Guid doctorId) {
+            var list = await _recordService.GetSharedRecordsAsync(doctorId);
+            return Ok(list);
         }
     }
 }


### PR DESCRIPTION
## Summary
- expand medical record DTOs with treatment, sharing and audit fields
- add corresponding properties to `RecordModel`
- store new lists as JSON in `AppDbContext`
- implement sharing APIs in service, repository and controller

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c49a4d0c8333aeaf7013f0178823