### PR TITLE
Add treatment task models and update roles

### DIFF
--- a/LYBT.Common/Enums/TreatmentRoomStatus.cs
+++ b/LYBT.Common/Enums/TreatmentRoomStatus.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+
+namespace LYBT.Common.Enums {
+    /// <summary>
+    /// 诊疗室状态
+    /// </summary>
+    public enum TreatmentRoomStatus {
+        /// <summary>空闲</summary>
+        [Description("空闲")]
+        Idle = 0,
+
+        /// <summary>使用中</summary>
+        [Description("使用中")]
+        InUse = 1,
+
+        /// <summary>暂停</summary>
+        [Description("暂停")]
+        Paused = 2,
+
+        /// <summary>已停用</summary>
+        [Description("停用")]
+        Disabled = 3
+    }
+}

--- a/LYBT.Common/Enums/TreatmentTaskStatus.cs
+++ b/LYBT.Common/Enums/TreatmentTaskStatus.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+
+namespace LYBT.Common.Enums {
+    /// <summary>
+    /// 治疗任务状态
+    /// </summary>
+    public enum TreatmentTaskStatus {
+        /// <summary>待执行</summary>
+        [Description("待执行")]
+        Pending = 0,
+
+        /// <summary>进行中</summary>
+        [Description("进行中")]
+        InProgress = 1,
+
+        /// <summary>已完成</summary>
+        [Description("已完成")]
+        Completed = 2
+    }
+}

--- a/LYBT.Common/Enums/UserRole.cs
+++ b/LYBT.Common/Enums/UserRole.cs
@@ -4,9 +4,19 @@ namespace LYBT.Common.Enums {
     /// 系统用户角色枚举
     /// </summary>
     public enum UserRole {
+        /// <summary>系统管理员</summary>
         Admin = 0,
-        Doctor = 1,
-        FrontDesk = 2,
-        Pharmacy = 3
+
+        /// <summary>看诊医生</summary>
+        DiagnosingDoctor = 1,
+
+        /// <summary>诊疗室医生（执行治疗任务）</summary>
+        TreatmentDoctor = 2,
+
+        /// <summary>药房工作人员</summary>
+        PharmacyStaff = 3,
+
+        /// <summary>挂号/前台工作人员</summary>
+        RegistrationStaff = 4
     }
 }

--- a/LYBT.Models/TreatmentRoom/TreatmentRoomModel.cs
+++ b/LYBT.Models/TreatmentRoom/TreatmentRoomModel.cs
@@ -1,56 +1,15 @@
-﻿using System;
+using LYBT.Common.Enums;
 
 namespace LYBT.Models.TreatmentRoom {
     /// <summary>
-    /// 治疗执行记录模型
+    /// 诊疗室基础信息
     /// </summary>
     public class TreatmentRoomModel {
-        /// <summary>执行记录ID</summary>
-        public Guid ExecutionId { get; set; }
-
-        /// <summary>治疗计划ID</summary>
-        public Guid PlanId { get; set; }
-
-        /// <summary>病人ID</summary>
-        public Guid PatientId { get; set; }
-
-        /// <summary>治疗类型（针灸/推拿）</summary>
-        public string TreatmentType { get; set; } = string.Empty;
-
-        /// <summary>已执行次数</summary>
-        public int ExecutedCount { get; set; }
-
-        /// <summary>总疗程次数</summary>
-        public int TotalCount { get; set; }
-
-        /// <summary>当前状态</summary>
-        public string Status { get; set; } = string.Empty;
-
-        /// <summary>治疗人</summary>
-        public string Executor { get; set; } = string.Empty;
-
-        /// <summary>最后执行时间</summary>
-        public DateTime LastExecuteTime { get; set; }
-
-        /// <summary>医生ID</summary>
-        public Guid DoctorId { get; set; }
-
-        /// <summary>主键ID</summary>
-        public Guid Id { get; set; }
-
-        /// <summary>开始时间</summary>
-        public DateTime StartTime { get; set; }
-
-        /// <summary>治疗项目</summary>
-        public string TreatmentItem { get; set; } = string.Empty;
-
-        /// <summary>结束时间</summary>
-        public DateTime EndTime { get; set; }
-
-        /// <summary>备注</summary>
-        public string? Remark { get; set; }
-
-        /// <summary>次数</summary>
-        public int Count { get; set; }
+        public string Id { get; set; } = string.Empty;
+        public string RoomName { get; set; } = string.Empty;
+        public string RoomCode { get; set; } = string.Empty;
+        public string? BoundDoctorId { get; set; }
+        public TreatmentRoomStatus Status { get; set; } = TreatmentRoomStatus.Idle;
+        public string? Description { get; set; }
     }
 }

--- a/LYBT.Models/TreatmentTask/TreatmentTaskModel.cs
+++ b/LYBT.Models/TreatmentTask/TreatmentTaskModel.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using LYBT.Common.Enums;
+using LYBT.Module.DiagnosisTreatment.Models.Dtos;
+
+namespace LYBT.Models.TreatmentTask {
+    /// <summary>
+    /// 治疗任务模型
+    /// </summary>
+    public class TreatmentTaskModel {
+        public string Id { get; set; } = string.Empty;
+        public string PatientId { get; set; } = string.Empty;
+        public string DoctorId { get; set; } = string.Empty;
+        public string TreatmentRoomId { get; set; } = string.Empty;
+
+        public List<TreatmentItemDto> TreatmentItems { get; set; } = new();
+        public TreatmentTaskStatus Status { get; set; } = TreatmentTaskStatus.Pending;
+
+        public DateTime CreatedTime { get; set; }
+        public DateTime? StartTime { get; set; }
+        public DateTime? CompletedTime { get; set; }
+        public string? Remarks { get; set; }
+    }
+}

--- a/LYBT.Models/Users/UserModel.cs
+++ b/LYBT.Models/Users/UserModel.cs
@@ -24,7 +24,7 @@ namespace LYBT.Module.Users.Models {
         /// <summary>
         /// 用户角色（管理员、医生等，枚举）
         /// </summary>
-        public UserRole Role { get; set; } = UserRole.Doctor;
+        public UserRole Role { get; set; } = UserRole.DiagnosingDoctor;
 
         /// <summary>
         /// 启用状态（true=启用，false=禁用）

--- a/LYBT.Module.TreatmentRoom/README.md
+++ b/LYBT.Module.TreatmentRoom/README.md
@@ -1,13 +1,14 @@
 # LYBT.Module.TreatmentRoom
 
-治疗室执行记录模块，跟踪各类治疗计划的执行情况。
+诊疗室模块负责辅助治疗任务的执行与资源调度，不再仅是简单的空间记录。除了管理诊疗室基础信息，还负责治疗任务队列的流转与状态控制。
 
 ## 主要服务及接口
 - `ITreatmentRoomService` / `TreatmentRoomService`
 - `ITreatmentRoomRepository` / `TreatmentRoomRepository`
 
 ## 重要模型和DTO
-- `TreatmentRoomModel`
+- `TreatmentRoomModel` – 诊疗室基础信息
+- `TreatmentTaskModel` – 具体治疗任务记录
 - `TreatmentRoomDto`、`TreatmentRoomCreateDto`、`TreatmentRoomEditDto`、`TreatmentRoomDetailDto`
 
 ## 用法

--- a/LYBT.Module.Users/Dtos/UserCreateDto.cs
+++ b/LYBT.Module.Users/Dtos/UserCreateDto.cs
@@ -26,7 +26,7 @@ namespace LYBT.Module.Users.Dtos {
         /// </summary>
         [Required(ErrorMessage = "用户角色不能为空")]
         [EnumDataType(typeof(UserRole), ErrorMessage = "用户角色无效")]
-        public UserRole Role { get; set; } = UserRole.Doctor;
+        public UserRole Role { get; set; } = UserRole.DiagnosingDoctor;
 
         /// <summary>
         /// 账号启用状态（true=启用，false=禁用）

--- a/LYBT.Module.Users/Dtos/UserEditDto.cs
+++ b/LYBT.Module.Users/Dtos/UserEditDto.cs
@@ -25,7 +25,7 @@ namespace LYBT.Module.Users.Dtos {
         /// </summary>
         [Required(ErrorMessage = "用户角色不能为空")]
         [EnumDataType(typeof(UserRole), ErrorMessage = "用户角色无效")]
-        public UserRole Role { get; set; } = UserRole.Doctor;
+        public UserRole Role { get; set; } = UserRole.DiagnosingDoctor;
 
         /// <summary>
         /// 账号启用状态（true=启用，false=禁用，必填）

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The solution is composed of many projects under the `LYBT.Module.*` namespace. E
 - **LYBT.Module.Pharmacy** – processes dispensing at the pharmacy.
 - **LYBT.Module.FormulaTemplates** – saves reusable prescription templates.
 - **LYBT.Module.Prescriptions** – creates and edits patient prescriptions.
-- **LYBT.Module.TreatmentRoom** – schedules and tracks treatment rooms.
+- **LYBT.Module.TreatmentRoom** – manages treatment rooms and executes assisted treatment tasks.
 - **LYBT.Module.Users** – manages user accounts, roles, and authentication.
 - **LYBT.Module.Settings** – stores system configuration values.
 - **LYBT.Module.Sync** – synchronizes data with external systems.


### PR DESCRIPTION
## Summary
- update `UserRole` enum with finer roles
- add enums for treatment room and task status
- redefine TreatmentRoom model
- introduce TreatmentTask model
- document new responsibilities of treatment room module

## Testing
- `dotnet build` *(fails: NETSDK1100 Windows targeting not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_6850c69bd9688333b9b87ee93d77f6b6