### PR TITLE
Add log query APIs for more modules

### DIFF
--- a/LYBT.Common/Enums/Logs/ObjectType.cs
+++ b/LYBT.Common/Enums/Logs/ObjectType.cs
@@ -35,6 +35,72 @@ namespace LYBT.Common.Enums.Logs {
         Prescription = 4,
 
         /// <summary>
+        /// 费用结算
+        /// </summary>
+        [Description("费用结算")]
+        Billing = 5,
+
+        /// <summary>
+        /// 药房
+        /// </summary>
+        [Description("药房")]
+        Pharmacy = 6,
+
+        /// <summary>
+        /// 医生
+        /// </summary>
+        [Description("医生")]
+        Doctor = 7,
+
+        /// <summary>
+        /// 排队
+        /// </summary>
+        [Description("排队")]
+        Queueing = 8,
+
+        /// <summary>
+        /// 诊疗
+        /// </summary>
+        [Description("诊疗")]
+        DiagnosisTreatment = 9,
+
+        /// <summary>
+        /// 经验方模板
+        /// </summary>
+        [Description("经验方模板")]
+        FormulaTemplate = 10,
+
+        /// <summary>
+        /// 药材
+        /// </summary>
+        [Description("药材")]
+        Herb = 11,
+
+        /// <summary>
+        /// 挂号
+        /// </summary>
+        [Description("挂号")]
+        Registration = 12,
+
+        /// <summary>
+        /// 系统设置
+        /// </summary>
+        [Description("系统设置")]
+        Settings = 13,
+
+        /// <summary>
+        /// 治疗室
+        /// </summary>
+        [Description("治疗室")]
+        TreatmentRoom = 14,
+
+        /// <summary>
+        /// 同步
+        /// </summary>
+        [Description("同步")]
+        Sync = 15,
+
+        /// <summary>
         /// 未知
         /// </summary>
         [Description("未知")]

--- a/LYBT.Module.Logs/Interfaces/ILogService.cs
+++ b/LYBT.Module.Logs/Interfaces/ILogService.cs
@@ -33,6 +33,16 @@ namespace LYBT.Module.Logs.Interfaces {
         Task<(IList<LogDto> logs, int total)> GetPatientLogsAsync(Guid patientId, int page, int pageSize);
 
         /// <summary>
+        /// 获取指定病历的操作日志
+        /// </summary>
+        Task<(IList<LogDto> logs, int total)> GetRecordLogsAsync(Guid recordId, int page, int pageSize);
+
+        /// <summary>
+        /// 获取指定处方的操作日志
+        /// </summary>
+        Task<(IList<LogDto> logs, int total)> GetPrescriptionLogsAsync(Guid prescriptionId, int page, int pageSize);
+
+        /// <summary>
         /// 根据日志ID获取详情
         /// </summary>
         /// <param name="id">日志ID</param>

--- a/LYBT.Module.Logs/Services/LogService.cs
+++ b/LYBT.Module.Logs/Services/LogService.cs
@@ -89,6 +89,28 @@ namespace LYBT.Module.Logs.Services {
         }
 
         /// <inheritdoc />
+        public async Task<(IList<LogDto> logs, int total)> GetRecordLogsAsync(Guid recordId, int page, int pageSize) {
+            var query = new LogQueryDto {
+                ObjectType = ObjectType.Record,
+                ObjectId = recordId,
+                Page = page,
+                PageSize = pageSize
+            };
+            return await GetLogsAsync(query);
+        }
+
+        /// <inheritdoc />
+        public async Task<(IList<LogDto> logs, int total)> GetPrescriptionLogsAsync(Guid prescriptionId, int page, int pageSize) {
+            var query = new LogQueryDto {
+                ObjectType = ObjectType.Prescription,
+                ObjectId = prescriptionId,
+                Page = page,
+                PageSize = pageSize
+            };
+            return await GetLogsAsync(query);
+        }
+
+        /// <inheritdoc />
         public async Task<LogDto?> GetLogByIdAsync(Guid id) {
             var log = await _logRepository.GetByIdAsync(id);
             if (log == null)

--- a/LYBT.WebAPI/Controllers/LogController.cs
+++ b/LYBT.WebAPI/Controllers/LogController.cs
@@ -62,6 +62,24 @@ public class LogController : ControllerBase {
     }
 
     /// <summary>
+    /// 获取指定病历的操作日志
+    /// </summary>
+    [HttpGet("record/{recordId}")]
+    public async Task<IActionResult> GetRecordLogs(Guid recordId, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) {
+        var (logs, total) = await _logService.GetRecordLogsAsync(recordId, page, pageSize);
+        return Ok(new { total, logs });
+    }
+
+    /// <summary>
+    /// 获取指定处方的操作日志
+    /// </summary>
+    [HttpGet("prescription/{prescriptionId}")]
+    public async Task<IActionResult> GetPrescriptionLogs(Guid prescriptionId, [FromQuery] int page = 1, [FromQuery] int pageSize = 20) {
+        var (logs, total) = await _logService.GetPrescriptionLogsAsync(prescriptionId, page, pageSize);
+        return Ok(new { total, logs });
+    }
+
+    /// <summary>
     /// 获取日志详情
     /// </summary>
     /// <param name="id">日志ID</param>


### PR DESCRIPTION
## Summary
- extend `ObjectType` enum with additional module types
- add log query methods for records and prescriptions
- expose new endpoints in `LogController`

## Testing
- `dotnet build --no-restore` *(fails: EnableWindowsTargeting; no restore)*

------
https://chatgpt.com/codex/tasks/task_e_685131a976f483338da06951e8e819dd