### PR TITLE
Centralize enums to Common project

### DIFF
--- a/LYBT.Common/Enums/Prescriptions/PrescriptionStatus.cs
+++ b/LYBT.Common/Enums/Prescriptions/PrescriptionStatus.cs
@@ -1,4 +1,4 @@
-﻿namespace LYBT.Module.Prescriptions.Enums {
+﻿namespace LYBT.Common.Enums.Prescriptions {
 
     /// <summary>
     /// 处方状态枚举

--- a/LYBT.Common/Enums/Users/UserRole.cs
+++ b/LYBT.Common/Enums/Users/UserRole.cs
@@ -1,4 +1,4 @@
-namespace LYBT.Common.Enums {
+namespace LYBT.Common.Enums.Users {
 
     /// <summary>
     /// 系统用户角色枚举

--- a/LYBT.Common/Enums/Users/UserStatus.cs
+++ b/LYBT.Common/Enums/Users/UserStatus.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace LYBT.Common.Enums {
+namespace LYBT.Common.Enums.Users {
     /// <summary>
     /// 用户账号状态
     /// </summary>
@@ -18,3 +18,4 @@ namespace LYBT.Common.Enums {
         Disabled = 1
     }
 }
+

--- a/LYBT.Infrastructure/Helpers/LogHelper.cs
+++ b/LYBT.Infrastructure/Helpers/LogHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using LYBT.Common.Enums.Logs;
 
 namespace LYBT.Infrastructure.Helpers {
     /// <summary>
@@ -11,9 +12,4 @@ namespace LYBT.Infrastructure.Helpers {
         }
     }
 
-    public enum LogType {
-        操作,
-        异常,
-        登录
-    }
 }

--- a/LYBT.Models/Users/UserModel.cs
+++ b/LYBT.Models/Users/UserModel.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using LYBT.Common.Enums;
+using LYBT.Common.Enums.Users;
 
 namespace LYBT.Module.Users.Models {
     /// <summary>

--- a/LYBT.Module.Prescriptions/Models/PrescriptionModel.cs
+++ b/LYBT.Module.Prescriptions/Models/PrescriptionModel.cs
@@ -1,4 +1,4 @@
-﻿using LYBT.Module.Prescriptions.Enums;
+﻿using LYBT.Common.Enums.Prescriptions;
 
 namespace LYBT.Module.Prescriptions.Models {
 

--- a/LYBT.Module.Users/Dtos/UserCreateDto.cs
+++ b/LYBT.Module.Users/Dtos/UserCreateDto.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using LYBT.Common.Enums;
+using LYBT.Common.Enums.Users;
 
 namespace LYBT.Module.Users.Dtos {
     /// <summary>

--- a/LYBT.Module.Users/Dtos/UserDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDto.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using LYBT.Common.Enums;
+using LYBT.Common.Enums.Users;
 
 namespace LYBT.Module.Users.Dtos {
     /// <summary>

--- a/LYBT.Module.Users/Dtos/UserEditDto.cs
+++ b/LYBT.Module.Users/Dtos/UserEditDto.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using LYBT.Common.Enums;
+using LYBT.Common.Enums.Users;
 
 namespace LYBT.Module.Users.Dtos {
     /// <summary>

--- a/LYBT.Module.Users/Dtos/UserQueryDto.cs
+++ b/LYBT.Module.Users/Dtos/UserQueryDto.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using LYBT.Common.Enums;
+using LYBT.Common.Enums.Users;
 
 namespace LYBT.Module.Users.Dtos {
     /// <summary>

--- a/LYBT.Module.Users/Interfaces/IUserService.cs
+++ b/LYBT.Module.Users/Interfaces/IUserService.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using LYBT.Module.Users.Dtos;
 using LYBT.Module.Logs.Dtos;
-using LYBT.Common.Enums;
+using LYBT.Common.Enums.Users;
 
 /// <summary>
 /// 用户服务接口，封装业务逻辑（含日志集成）

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -1,4 +1,4 @@
-﻿using LYBT.Common.Enums;
+﻿using LYBT.Common.Enums.Users;
 using LYBT.Common.Enums.Logs;
 using LYBT.Module.Logs.Dtos;
 using LYBT.Module.Logs.Interfaces;

--- a/LYBT.WebAPI/Controllers/DoctorsController.cs
+++ b/LYBT.WebAPI/Controllers/DoctorsController.cs
@@ -88,7 +88,7 @@ namespace LYBT.WebAPI.Controllers {
 
         [HttpGet("roles")]
         public IActionResult GetRoles() {
-            var roles = Enum.GetNames(typeof(LYBT.Common.Enums.UserRole));
+            var roles = Enum.GetNames(typeof(LYBT.Common.Enums.Users.UserRole));
             return Ok(roles);
         }
     }


### PR DESCRIPTION
## Summary
- move `PrescriptionStatus` enum into `LYBT.Common`
- create `Users` enum folder and move `UserRole` and `UserStatus`
- update models, DTOs and services to use new enum namespaces
- reference shared `LogType` enum from `LogHelper`
- adjust API controller to use updated enum

## Testing
- `dotnet build -property:EnableWindowsTargeting=true --no-restore` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_685134096b808333ae5e532aebe4e606