### PR TITLE
Fix TreatmentTaskModel compile error

### DIFF
--- a/LYBT.Models/TreatmentTask/TreatmentTaskModel.cs
+++ b/LYBT.Models/TreatmentTask/TreatmentTaskModel.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LYBT.Common.Enums;
-using LYBT.Module.DiagnosisTreatment.Models.Dtos;
+using LYBT.Models.DiagnosisTreatment;
 
 namespace LYBT.Models.TreatmentTask {
     /// <summary>
@@ -13,7 +13,7 @@ namespace LYBT.Models.TreatmentTask {
         public string DoctorId { get; set; } = string.Empty;
         public string TreatmentRoomId { get; set; } = string.Empty;
 
-        public List<TreatmentItemDto> TreatmentItems { get; set; } = new();
+        public List<TreatmentItemModel> TreatmentItems { get; set; } = new();
         public TreatmentTaskStatus Status { get; set; } = TreatmentTaskStatus.Pending;
 
         public DateTime CreatedTime { get; set; }


### PR DESCRIPTION
## Summary
- correct namespace usage in TreatmentTaskModel
- use `TreatmentItemModel` instead of DTO

## Testing
- `dotnet build LYBT.Models/LYBT.Models.csproj -c Release /p:EnableWindowsTargeting=true` *(fails: unable to load service index from nuget.org)*

------
https://chatgpt.com/codex/tasks/task_e_685153bb92908333abb230a0cfbf18d6