### PR TITLE
Fix Swagger schema conflicts

### DIFF
--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -114,6 +114,9 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => {
     options.SwaggerDoc("v1", new OpenApiInfo { Title = "LYBT.WebAPI", Version = "v1" });
+    // Use full type names as schema IDs to avoid conflicts between classes
+    // with the same name in different namespaces
+    options.CustomSchemaIds(type => type.FullName);
 });
 
 // =========== 4. 注册数据库上下文 ===========


### PR DESCRIPTION
## Summary
- avoid schema ID collisions in Swagger by using fully-qualified class names

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685165e0e16c8333a5e50b29ef1f1322