### PR TITLE
Fix Prism app base class

### DIFF
--- a/LYBT.UI.WPF/App.xaml
+++ b/LYBT.UI.WPF/App.xaml
@@ -1,6 +1,7 @@
-<Application x:Class="LYBT.UI.WPF.App"
+<prism:PrismApplication x:Class="LYBT.UI.WPF.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -11,4 +12,4 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>
-</Application>
+</prism:PrismApplication>


### PR DESCRIPTION
## Summary
- fix PrismApplication root element in `App.xaml`

## Testing
- `dotnet build LYBTZYZS.sln --no-restore` *(fails: EnableWindowsTargeting property not set and missing NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_685173ae26f48333b14ffd45fdf1a87d