### PR TITLE
Add AuthController

### DIFF
--- a/LYBT.WebAPI/Controllers/AuthController.cs
+++ b/LYBT.WebAPI/Controllers/AuthController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using LYBT.Module.Auth.Interfaces;
+using LYBT.Module.Auth.Dtos;
+using System.Threading.Tasks;
+
+namespace LYBT.WebAPI.Controllers {
+    /// <summary>
+    /// 认证相关接口
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase {
+        private readonly IAuthService _authService;
+
+        public AuthController(IAuthService authService) {
+            _authService = authService;
+        }
+
+        /// <summary>
+        /// 用户登录
+        /// </summary>
+        [HttpPost("login")]
+        public async Task<IActionResult> Login([FromBody] LoginRequestDto dto) {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+            var user = await _authService.LoginAsync(dto);
+            if (user == null)
+                return Unauthorized(new { success = false, message = "用户名或密码错误" });
+            return Ok(user);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthController to expose login endpoint

## Testing
- `dotnet build -v minimal` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68518359fd64833396adf2a93f0bcace