### PR TITLE
Implement login window startup

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -9,6 +9,16 @@ namespace LYBT.UI.WPF {
     /// Prism application bootstrap
     /// </summary>
     public partial class App : PrismApplication {
+        protected override void OnStartup(StartupEventArgs e) {
+            var login = new LoginWindow();
+            var result = login.ShowDialog();
+            if (result != true) {
+                Shutdown();
+                return;
+            }
+            base.OnStartup(e);
+        }
+
         protected override Window CreateShell() {
             return Container.Resolve<ShellView>();
         }

--- a/LYBT.UI.WPF/README.md
+++ b/LYBT.UI.WPF/README.md
@@ -3,5 +3,6 @@
 Desktop WPF client that consumes the backend modules via the Web API.
 It is built with Prism and Material Design in XAML. The application boots via
 `PrismApplication` and shows a `ShellView` containing a drawer based navigation.
-On startup a simple `LoginView` is registered for navigation.
+At startup the application now displays a modal `LoginWindow` to authenticate
+the user. After a successful login the main `ShellView` is launched.
 

--- a/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
@@ -1,5 +1,6 @@
 using Prism.Commands;
 using Prism.Mvvm;
+using System;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
@@ -24,6 +25,8 @@ namespace LYBT.UI.WPF.ViewModels {
             set => SetProperty(ref _password, value);
         }
 
+        public event Action? LoginSucceeded;
+
         public ICommand LoginCommand { get; }
 
         public LoginViewModel() {
@@ -36,7 +39,7 @@ namespace LYBT.UI.WPF.ViewModels {
             try {
                 var response = await http.PostAsJsonAsync("api/auth/login", dto);
                 if (response.IsSuccessStatusCode) {
-                    MessageBox.Show("登录成功");
+                    LoginSucceeded?.Invoke();
                 }
                 else {
                     MessageBox.Show("用户名或密码错误", "登录失败", MessageBoxButton.OK, MessageBoxImage.Warning);

--- a/LYBT.UI.WPF/Views/LoginView.xaml
+++ b/LYBT.UI.WPF/Views/LoginView.xaml
@@ -11,7 +11,7 @@
                      materialDesign:HintAssist.Hint="用户名"
                      Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}"/>
 
-            <PasswordBox Margin="0,0,0,20" Style="{StaticResource MaterialDesignFloatingHintTextBox}"
+            <PasswordBox Margin="0,0,0,20" Style="{StaticResource MaterialDesignFloatingHintPasswordBox}"
                          materialDesign:HintAssist.Hint="密码"
                          PasswordChanged="PasswordBox_PasswordChanged"/>
 

--- a/LYBT.UI.WPF/Views/LoginWindow.xaml
+++ b/LYBT.UI.WPF/Views/LoginWindow.xaml
@@ -1,0 +1,11 @@
+<Window x:Class="LYBT.UI.WPF.Views.LoginWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:LYBT.UI.WPF.Views"
+        xmlns:viewModels="clr-namespace:LYBT.UI.WPF.ViewModels"
+        Title="登录" Height="300" Width="400" WindowStartupLocation="CenterScreen">
+    <Window.DataContext>
+        <viewModels:LoginViewModel />
+    </Window.DataContext>
+    <local:LoginView />
+</Window>

--- a/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
@@ -1,0 +1,20 @@
+using System.Windows;
+using LYBT.UI.WPF.ViewModels;
+
+namespace LYBT.UI.WPF.Views {
+    /// <summary>
+    /// Interaction logic for LoginWindow
+    /// </summary>
+    public partial class LoginWindow : Window {
+        public LoginWindow() {
+            InitializeComponent();
+            if (DataContext is LoginViewModel vm) {
+                vm.LoginSucceeded += OnLoginSucceeded;
+            }
+        }
+
+        private void OnLoginSucceeded() {
+            DialogResult = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show `LoginWindow` before launching shell
- trigger shell launch after successful login
- document login window behavior
- fix style on PasswordBox

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bd40400833399e3751b0fb4e53f