### PR TITLE
Implement JWT login with Refit client

### DIFF
--- a/LYBT.Module.Auth/Dtos/LoginResponseDto.cs
+++ b/LYBT.Module.Auth/Dtos/LoginResponseDto.cs
@@ -1,0 +1,12 @@
+namespace LYBT.Module.Auth.Dtos {
+    /// <summary>
+    /// 登录成功返回 DTO
+    /// </summary>
+    public class LoginResponseDto {
+        /// <summary>JWT Token</summary>
+        public string Token { get; set; } = string.Empty;
+
+        /// <summary>用户信息</summary>
+        public LYBT.Module.Users.Dtos.UserDto User { get; set; } = new();
+    }
+}

--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -3,6 +3,10 @@ using Prism.Modularity;
 using Prism.Unity;
 using System.Windows;
 using LYBT.UI.WPF.Views;
+using LYBT.UI.WPF.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Refit;
 
 namespace LYBT.UI.WPF {
     /// <summary>
@@ -10,7 +14,7 @@ namespace LYBT.UI.WPF {
     /// </summary>
     public partial class App : PrismApplication {
         protected override void OnStartup(StartupEventArgs e) {
-            var login = new LoginWindow();
+            var login = Container.Resolve<LoginWindow>();
             var result = login.ShowDialog();
             if (result != true) {
                 Shutdown();
@@ -25,6 +29,21 @@ namespace LYBT.UI.WPF {
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry) {
             containerRegistry.RegisterForNavigation<LoginView>(nameof(LoginView));
+            containerRegistry.RegisterSingleton<TokenService>();
+            containerRegistry.Register<LoginWindow>();
+
+            var services = new ServiceCollection();
+            services.AddTransient<AuthHttpMessageHandler>();
+            services.AddRefitClient<IAuthApi>(new RefitSettings {
+                    ContentSerializer = new SystemTextJsonContentSerializer()
+                })
+                .ConfigureHttpClient(c => c.BaseAddress = new System.Uri("http://localhost:5297/"))
+                .AddHttpMessageHandler<AuthHttpMessageHandler>()
+                .AddPolicyHandler(Policy<HttpResponseMessage>.Handle<HttpRequestException>()
+                    .WaitAndRetryAsync(3, _ => System.TimeSpan.FromSeconds(1)));
+
+            var provider = services.BuildServiceProvider();
+            containerRegistry.RegisterInstance(provider.GetRequiredService<IAuthApi>());
         }
 
         protected override void ConfigureModuleCatalog(IModuleCatalog moduleCatalog) {

--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -32,6 +32,8 @@
     <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
     <PackageReference Include="Prism.Unity" Version="9.0.537" />
     <PackageReference Include="Prism.Wpf" Version="9.0.537" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/LYBT.UI.WPF/Services/AuthHttpMessageHandler.cs
+++ b/LYBT.UI.WPF/Services/AuthHttpMessageHandler.cs
@@ -1,0 +1,23 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    /// <summary>
+    /// 自动在请求中附加 JWT Token
+    /// </summary>
+    public class AuthHttpMessageHandler : DelegatingHandler {
+        private readonly TokenService _tokenService;
+        public AuthHttpMessageHandler(TokenService tokenService) {
+            _tokenService = tokenService;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            if (!string.IsNullOrEmpty(_tokenService.Token)) {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _tokenService.Token);
+            }
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/LYBT.UI.WPF/Services/IAuthApi.cs
+++ b/LYBT.UI.WPF/Services/IAuthApi.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using Refit;
+using LYBT.Module.Auth.Dtos;
+
+namespace LYBT.UI.WPF.Services {
+    /// <summary>
+    /// Refit 登录接口
+    /// </summary>
+    public interface IAuthApi {
+        [Post("api/auth/login")]
+        Task<LoginResponseDto> LoginAsync([Body] LoginRequestDto dto);
+    }
+}

--- a/LYBT.UI.WPF/Services/TokenService.cs
+++ b/LYBT.UI.WPF/Services/TokenService.cs
@@ -1,0 +1,10 @@
+namespace LYBT.UI.WPF.Services {
+    /// <summary>
+    /// 存储并提供 JWT Token
+    /// </summary>
+    public class TokenService {
+        private string? _token;
+        public string? Token => _token;
+        public void SetToken(string token) => _token = token;
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
@@ -1,8 +1,7 @@
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
-using System.Net.Http;
-using System.Net.Http.Json;
+using Refit;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -27,25 +26,28 @@ namespace LYBT.UI.WPF.ViewModels {
 
         public event Action? LoginSucceeded;
 
+        private readonly IAuthApi _authApi;
+        private readonly Services.TokenService _tokenService;
+
         public ICommand LoginCommand { get; }
 
-        public LoginViewModel() {
+        public LoginViewModel(IAuthApi authApi, Services.TokenService tokenService) {
+            _authApi = authApi;
+            _tokenService = tokenService;
             LoginCommand = new DelegateCommand(async () => await OnLoginAsync());
         }
 
         private async Task OnLoginAsync() {
-            using var http = new HttpClient { BaseAddress = new System.Uri("http://localhost:5297/") };
             var dto = new LoginRequestDto { Username = Username, Password = Password };
             try {
-                var response = await http.PostAsJsonAsync("api/auth/login", dto);
-                if (response.IsSuccessStatusCode) {
-                    LoginSucceeded?.Invoke();
-                }
-                else {
-                    MessageBox.Show("用户名或密码错误", "登录失败", MessageBoxButton.OK, MessageBoxImage.Warning);
-                }
+                var response = await _authApi.LoginAsync(dto);
+                _tokenService.SetToken(response.Token);
+                LoginSucceeded?.Invoke();
             }
-            catch (HttpRequestException ex) {
+            catch (ApiException ex) {
+                MessageBox.Show(ex.Content ?? "用户名或密码错误", "登录失败", MessageBoxButton.OK, MessageBoxImage.Warning);
+            }
+            catch (System.Exception ex) {
                 MessageBox.Show($"无法连接到服务器: {ex.Message}", "登录失败", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }

--- a/LYBT.UI.WPF/Views/LoginWindow.xaml
+++ b/LYBT.UI.WPF/Views/LoginWindow.xaml
@@ -2,10 +2,8 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:LYBT.UI.WPF.Views"
-        xmlns:viewModels="clr-namespace:LYBT.UI.WPF.ViewModels"
-        Title="登录" Height="300" Width="400" WindowStartupLocation="CenterScreen">
-    <Window.DataContext>
-        <viewModels:LoginViewModel />
-    </Window.DataContext>
+        xmlns:prism="http://prismlibrary.com/"
+        Title="登录" Height="300" Width="400" WindowStartupLocation="CenterScreen"
+        prism:ViewModelLocator.AutoWireViewModel="True">
     <local:LoginView />
 </Window>

--- a/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
@@ -8,7 +8,11 @@ namespace LYBT.UI.WPF.Views {
     public partial class LoginWindow : Window {
         public LoginWindow() {
             InitializeComponent();
-            if (DataContext is LoginViewModel vm) {
+            DataContextChanged += LoginWindow_DataContextChanged;
+        }
+
+        private void LoginWindow_DataContextChanged(object? sender, DependencyPropertyChangedEventArgs e) {
+            if (e.NewValue is LoginViewModel vm) {
                 vm.LoginSucceeded += OnLoginSucceeded;
             }
         }

--- a/LYBT.WebAPI/Controllers/AuthController.cs
+++ b/LYBT.WebAPI/Controllers/AuthController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using LYBT.Module.Auth.Interfaces;
 using LYBT.Module.Auth.Dtos;
 using System.Threading.Tasks;
+using LYBT.WebAPI.Services;
 
 namespace LYBT.WebAPI.Controllers {
     /// <summary>
@@ -11,9 +12,11 @@ namespace LYBT.WebAPI.Controllers {
     [Route("api/[controller]")]
     public class AuthController : ControllerBase {
         private readonly IAuthService _authService;
+        private readonly JwtTokenService _jwtTokenService;
 
-        public AuthController(IAuthService authService) {
+        public AuthController(IAuthService authService, JwtTokenService jwtTokenService) {
             _authService = authService;
+            _jwtTokenService = jwtTokenService;
         }
 
         /// <summary>
@@ -26,7 +29,9 @@ namespace LYBT.WebAPI.Controllers {
             var user = await _authService.LoginAsync(dto);
             if (user == null)
                 return Unauthorized(new { success = false, message = "用户名或密码错误" });
-            return Ok(user);
+
+            var token = _jwtTokenService.GenerateToken(user);
+            return Ok(new LoginResponseDto { Token = token, User = user });
         }
 
 

--- a/LYBT.WebAPI/LYBT.WebAPI.csproj
+++ b/LYBT.WebAPI/LYBT.WebAPI.csproj
@@ -7,15 +7,16 @@
 		<BaseOutputPath>..\BIN</BaseOutputPath>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\LYBT.Common\LYBT.Common.csproj" />

--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -39,6 +39,7 @@ using LYBT.Module.Sync.Services;
 using LYBT.Module.Records.Interfaces;
 using LYBT.Module.Records.Repositories;
 using LYBT.Module.Records.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using LYBT.Module.Logs.Interfaces;
@@ -48,6 +49,9 @@ using LYBT.Module.Auth.Interfaces;
 using LYBT.Module.Auth.Repositories;
 using LYBT.Module.Auth.Services;
 using LYBT.Infrastructure.Helpers;
+using LYBT.WebAPI.Services;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -131,7 +135,24 @@ var connection = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(connection));
 
-// =========== 5. 启动Web应用 ===========
+// =========== 5. JWT 认证配置 ===========
+builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection("Jwt"));
+builder.Services.AddSingleton<JwtTokenService>();
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options => {
+        var jwt = builder.Configuration.GetSection("Jwt").Get<JwtOptions>();
+        options.TokenValidationParameters = new TokenValidationParameters {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwt.Issuer,
+            ValidAudience = jwt.Audience,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Secret))
+        };
+    });
+builder.Services.AddAuthorization();
+
+// =========== 6. 启动Web应用 ===========
 
 var app = builder.Build();
 
@@ -145,6 +166,9 @@ if (app.Environment.IsDevelopment()) {
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapControllers();
 

--- a/LYBT.WebAPI/Services/JwtOptions.cs
+++ b/LYBT.WebAPI/Services/JwtOptions.cs
@@ -1,0 +1,11 @@
+namespace LYBT.WebAPI.Services {
+    /// <summary>
+    /// JWT 配置项
+    /// </summary>
+    public class JwtOptions {
+        public string Secret { get; set; } = string.Empty;
+        public string Issuer { get; set; } = string.Empty;
+        public string Audience { get; set; } = string.Empty;
+        public int ExpireMinutes { get; set; } = 60;
+    }
+}

--- a/LYBT.WebAPI/Services/JwtTokenService.cs
+++ b/LYBT.WebAPI/Services/JwtTokenService.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using LYBT.Module.Users.Dtos;
+
+namespace LYBT.WebAPI.Services {
+    /// <summary>
+    /// 生成 JWT Token 的服务
+    /// </summary>
+    public class JwtTokenService {
+        private readonly JwtOptions _options;
+
+        public JwtTokenService(IOptions<JwtOptions> options) {
+            _options = options.Value;
+        }
+
+        public string GenerateToken(UserDto user) {
+            var claims = new[] {
+                new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+                new Claim(JwtRegisteredClaimNames.UniqueName, user.UserName),
+                new Claim(ClaimTypes.Role, user.Role.ToString())
+            };
+
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.Secret));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var token = new JwtSecurityToken(
+                issuer: _options.Issuer,
+                audience: _options.Audience,
+                claims: claims,
+                expires: DateTime.Now.AddMinutes(_options.ExpireMinutes),
+                signingCredentials: creds);
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+    }
+}

--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -6,6 +6,12 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True"
   },
+  "Jwt": {
+    "Secret": "SuperSecretKey12345",
+    "Issuer": "LYBT.WebAPI",
+    "Audience": "LYBT.Client",
+    "ExpireMinutes": 60
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- add LoginResponseDto for issuing tokens
- configure JWT authentication in WebAPI and provide JwtTokenService
- update AuthController to return token
- register Jwt settings in appsettings.json
- integrate Refit and HttpClient factory with Polly in the WPF app
- inject API client and token service into LoginViewModel
- resolve LoginWindow via DI and auto-wire view model

## Testing
- `dotnet build --no-restore` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851926e7b3c83339022d0a0f511103f