### PR TITLE
Update JWT secret handling

### DIFF
--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -7,7 +7,7 @@
     "DefaultConnection": "Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True"
   },
   "Jwt": {
-    "Secret": "SuperSecretKey12345",
+    "Secret": "4/HC5fsPxo8xwjDyWCRZ96ZjD/9+pta7QyMmskmCeNLtInboBQBhaBxmriyOm93i",
     "Issuer": "LYBT.WebAPI",
     "Audience": "LYBT.Client",
     "ExpireMinutes": 60

--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ The solution is composed of many projects under the `LYBT.Module.*` namespace. E
 
 ## Build and Run
 
-Use the standard .NET CLI commands to build and start the Web API:
+Use the standard .NET CLI commands to build and start the Web API. The JWT 
+secret used for authentication should be supplied via an environment variable 
+instead of being hard coded in configuration files. Set `JWT__SECRET` before
+running the project. The value in `appsettings.json` is only a placeholder and
+should never be committed with real secrets:
 
 ```bash
+export JWT__SECRET="<your_jwt_secret>"
 dotnet build
 dotnet run --project LYBT.WebAPI
 ```


### PR DESCRIPTION
## Summary
- rotate JWT secret in `appsettings.json`
- document using `JWT__SECRET` environment variable

## Testing
- `dotnet build` *(fails: unable to load NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_6851a18f88588333948332125ad04274