### PR TITLE
Ignore WebAPI configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@
 .vs/
 bin/
 obj/
+
+# Local configuration
+LYBT.WebAPI/appsettings*.json
+!LYBT.WebAPI/appsettings.example.json

--- a/LYBT.WebAPI/README.md
+++ b/LYBT.WebAPI/README.md
@@ -2,3 +2,12 @@
 
 The ASP.NET Core API project that wires up all modules, registers their services and dependencies, and exposes REST endpoints for clients.
 
+## Configuration
+
+Sensitive settings such as connection strings and JWT secrets should **not** be committed to the repository. A template file `appsettings.example.json` is provided. Copy it to `appsettings.json` (and `appsettings.Development.json` if needed) and fill in your local values.
+
+```bash
+cp appsettings.example.json appsettings.json
+```
+
+Keep the updated files out of version control by relying on the rules in `.gitignore`.

--- a/LYBT.WebAPI/appsettings.Development.json
+++ b/LYBT.WebAPI/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/LYBT.WebAPI/appsettings.example.json
+++ b/LYBT.WebAPI/appsettings.example.json
@@ -4,10 +4,10 @@
     "DatacenterId": 1
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=YOUR_SERVER;Database=YOUR_DB;User Id=YOUR_USER;Password=YOUR_PASSWORD;Encrypt=True;TrustServerCertificate=True"
   },
   "Jwt": {
-    "Secret": "SuperSecretKey12345",
+    "Secret": "CHANGE_ME",
     "Issuer": "LYBT.WebAPI",
     "Audience": "LYBT.Client",
     "ExpireMinutes": 60


### PR DESCRIPTION
## Summary
- ignore `appsettings*.json` in WebAPI
- provide template `appsettings.example.json`
- document using the example config

## Testing
- `dotnet build LYBTZYZS.sln` *(fails: Unable to load service index for https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851a191a55c8333affd0828b9cb5ced