### PR TITLE
Sanitize connection string

### DIFF
--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -4,7 +4,7 @@
     "DatacenterId": 1
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=60.190.215.86;Database=LYBTDB;User Id=sa;Password=Shou@850528;Encrypt=True;TrustServerCertificate=True"
+    "DefaultConnection": "Server=...;Database=...;User Id=...;Password=..."
   },
   "Jwt": {
     "Secret": "SuperSecretKey12345",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ dotnet build
 dotnet run --project LYBT.WebAPI
 ```
 
+### Configuration
+
+Use the `ConnectionStrings__DefaultConnection` environment variable to supply the production connection string:
+
+```bash
+export ConnectionStrings__DefaultConnection="Server=prod;Database=prod;User Id=user;Password=secret"
+```
+
+
 
 ### Building the WPF Client
 


### PR DESCRIPTION
## Summary
- scrub DefaultConnection string from `appsettings.json`
- document using `ConnectionStrings__DefaultConnection` env var in README

## Testing
- `dotnet build` *(fails: Unable to load NuGet packages due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851a4548a1c833394bc0b4c2db5cbd6