### PR TITLE
Fix missing using directives in controllers

### DIFF
--- a/LYBT.WebAPI/Controllers/DiagnosisTreatmentController.cs
+++ b/LYBT.WebAPI/Controllers/DiagnosisTreatmentController.cs
@@ -1,6 +1,9 @@
 ﻿using LYBT.Module.DiagnosisTreatment.Interfaces;
 using LYBT.Module.DiagnosisTreatment.Models.Dtos;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LYBT.Module.DiagnosisTreatment.Controllers {
     /// <summary>

--- a/LYBT.WebAPI/Controllers/PatientsController.cs
+++ b/LYBT.WebAPI/Controllers/PatientsController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using LYBT.Module.Patients.Interfaces;

--- a/LYBT.WebAPI/Controllers/PharmacyController.cs
+++ b/LYBT.WebAPI/Controllers/PharmacyController.cs
@@ -1,6 +1,9 @@
 ﻿using LYBT.Module.Pharmacy.Dtos;
 using LYBT.Module.Pharmacy.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LYBT.Module.Pharmacy.Controllers {
     /// <summary>

--- a/LYBT.WebAPI/Controllers/QueueingController.cs
+++ b/LYBT.WebAPI/Controllers/QueueingController.cs
@@ -1,6 +1,9 @@
 ﻿using LYBT.Module.Queueing.Dtos;
 using LYBT.Module.Queueing.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LYBT.Module.Queueing.Controllers {
     /// <summary>

--- a/LYBT.WebAPI/Controllers/TreatmentRoomController.cs
+++ b/LYBT.WebAPI/Controllers/TreatmentRoomController.cs
@@ -1,6 +1,9 @@
 ﻿using LYBT.Module.TreatmentRoom.Dtos;
 using LYBT.Module.TreatmentRoom.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace LYBT.Module.TreatmentRoom.Controllers {
     /// <summary>

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using LYBT.Module.Users.Dtos;
-
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 /// <summary>
 /// 用户管理控制器，提供RESTful API接口


### PR DESCRIPTION
## Summary
- add System namespaces to WebAPI controllers

## Testing
- `dotnet build LYBTZYZS.sln --no-restore -c Release` *(fails: Unable to load service index due to proxy)*
- `dotnet test --no-build` *(fails: Unable to load service index due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851a8ea570883338cf8b468bf311c3b