### PR TITLE
Fix JWT config section

### DIFF
--- a/LYBT.Infrastructure.Auth/Extensions/JwtAuthenticationExtensions.cs
+++ b/LYBT.Infrastructure.Auth/Extensions/JwtAuthenticationExtensions.cs
@@ -10,7 +10,7 @@ namespace LYBT.Infrastructure.Auth.Extensions {
     /// </summary>
     public static class JwtAuthenticationExtensions {
         public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration) {
-            var jwtSection = configuration.GetSection("JwtOptions");
+            var jwtSection = configuration.GetSection("Jwt");
             services.Configure<JwtOptions>(jwtSection);
 
             var options = jwtSection.Get<JwtOptions>();

--- a/LYBT.Infrastructure/Auth/Extensions/JwtAuthenticationExtensions.cs
+++ b/LYBT.Infrastructure/Auth/Extensions/JwtAuthenticationExtensions.cs
@@ -10,7 +10,7 @@ namespace LYBT.Infrastructure.Auth.Extensions {
     /// </summary>
     public static class JwtAuthenticationExtensions {
         public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration) {
-            var jwtSection = configuration.GetSection("JwtOptions");
+            var jwtSection = configuration.GetSection("Jwt");
             services.Configure<JwtOptions>(jwtSection);
 
             var options = jwtSection.Get<JwtOptions>();


### PR DESCRIPTION
## Summary
- ensure JwtAuthenticationExtensions reads from the `Jwt` config section

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_685258725680833385248cd1c97c370e