### PR TITLE
Fix login window event hookup

### DIFF
--- a/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
@@ -7,8 +7,14 @@ namespace LYBT.UI.WPF.Views {
     /// </summary>
     public partial class LoginWindow : Window {
         public LoginWindow() {
-            InitializeComponent();
             DataContextChanged += LoginWindow_DataContextChanged;
+            InitializeComponent();
+
+            // AutoWireViewModel sets DataContext inside InitializeComponent,
+            // so subscribe to LoginSucceeded if it has already been set
+            if (DataContext is LoginViewModel vm) {
+                vm.LoginSucceeded += OnLoginSucceeded;
+            }
         }
 
         private void LoginWindow_DataContextChanged(object? sender, DependencyPropertyChangedEventArgs e) {


### PR DESCRIPTION
## Summary
- ensure LoginWindow subscribes to `LoginSucceeded` even when DataContext is set during `InitializeComponent`

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: unable to reach NuGet)*

------
https://chatgpt.com/codex/tasks/task_e_68525ee2fff48333ac751cbaa1b9c8dd