### PR TITLE
Add admin view and navigate on login

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -26,6 +26,7 @@ namespace LYBT.UI.WPF {
 
         protected override void RegisterTypes(IContainerRegistry containerRegistry) {
             containerRegistry.RegisterForNavigation<LoginView>(nameof(LoginView));
+            containerRegistry.RegisterForNavigation<AdminView>(nameof(AdminView));
 
             // share a single TokenService instance between Prism and the HTTP client
             var tokenService = new TokenService();

--- a/LYBT.UI.WPF/ViewModels/ShellViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/ShellViewModel.cs
@@ -12,7 +12,7 @@ namespace LYBT.UI.WPF.ViewModels {
         public ShellViewModel(IRegionManager regionManager) {
             _regionManager = regionManager;
             NavigateCommand = new DelegateCommand<string?>(Navigate);
-            _regionManager.RequestNavigate("MainRegion", nameof(LoginView));
+            _regionManager.RequestNavigate("MainRegion", nameof(AdminView));
         }
 
         private void Navigate(string? view) {

--- a/LYBT.UI.WPF/Views/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/AdminView.xaml
@@ -1,0 +1,9 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.AdminView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="False">
+    <Grid>
+        <TextBlock Text="管理员界面" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/AdminView.xaml.cs
+++ b/LYBT.UI.WPF/Views/AdminView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views {
+    /// <summary>
+    /// Simple admin dashboard view
+    /// </summary>
+    public partial class AdminView : UserControl {
+        public AdminView() {
+            InitializeComponent();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/LoginWindow.xaml.cs
@@ -7,8 +7,14 @@ namespace LYBT.UI.WPF.Views {
     /// </summary>
     public partial class LoginWindow : Window {
         public LoginWindow() {
-            InitializeComponent();
             DataContextChanged += LoginWindow_DataContextChanged;
+            InitializeComponent();
+
+            // AutoWireViewModel sets DataContext inside InitializeComponent,
+            // so subscribe to LoginSucceeded if it has already been set
+            if (DataContext is LoginViewModel vm) {
+                vm.LoginSucceeded += OnLoginSucceeded;
+            }
         }
 
         private void LoginWindow_DataContextChanged(object? sender, DependencyPropertyChangedEventArgs e) {

--- a/LYBT.UI.WPF/Views/ShellView.xaml
+++ b/LYBT.UI.WPF/Views/ShellView.xaml
@@ -10,9 +10,7 @@
         <materialDesign:DrawerHost>
             <materialDesign:DrawerHost.LeftDrawerContent>
                 <StackPanel>
-                    <Button Content="患者管理" Command="{Binding NavigateCommand}" CommandParameter="Patients"/>
-                    <Button Content="挂号管理" Command="{Binding NavigateCommand}" CommandParameter="Registration"/>
-                    <Button Content="系统设置" Command="{Binding NavigateCommand}" CommandParameter="Settings"/>
+                    <Button Content="管理员主页" Command="{Binding NavigateCommand}" CommandParameter="AdminView"/>
                 </StackPanel>
             </materialDesign:DrawerHost.LeftDrawerContent>
             <Grid>


### PR DESCRIPTION
## Summary
- add simple AdminView as landing page
- register AdminView for Prism navigation
- navigate to AdminView after login and expose drawer button

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: unable to reach NuGet)*

------
https://chatgpt.com/codex/tasks/task_e_68525ee2fff48333ac751cbaa1b9c8dd