### PR TITLE
Add multi-role login support

### DIFF
--- a/LYBT.UI.WPF/Services/AuthService.cs
+++ b/LYBT.UI.WPF/Services/AuthService.cs
@@ -1,4 +1,5 @@
 using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 
 namespace LYBT.UI.WPF.Services {
 
@@ -7,18 +8,22 @@ namespace LYBT.UI.WPF.Services {
     /// </summary>
     public class AuthService : IAuthService {
 
-        public UserRole? Login(string userName, string password) {
-            // 根据用户名简单判定用户角色并验证密码
-            if (userName == "admin" && password == "123")
-                return UserRole.Admin;
-            if (userName == "doctor" && password == "123")
-                return UserRole.DiagnosingDoctor;
-            if (userName == "treatment" && password == "123")
-                return UserRole.TreatmentDoctor;
-            if (userName == "pharmacy" && password == "123")
-                return UserRole.PharmacyStaff;
-            if (userName == "register" && password == "123")
-                return UserRole.RegistrationStaff;
+        private readonly Dictionary<string, (string Password, List<UserRole> Roles)> _accounts = new()
+        {
+            ["admin"] = ("123", new List<UserRole> { UserRole.Admin }),
+            ["doctor"] = ("123", new List<UserRole> { UserRole.DiagnosingDoctor }),
+            ["treatment"] = ("123", new List<UserRole> { UserRole.TreatmentDoctor }),
+            ["pharmacy"] = ("123", new List<UserRole> { UserRole.PharmacyStaff }),
+            ["register"] = ("123", new List<UserRole> { UserRole.RegistrationStaff }),
+            // 多权限测试账号
+            ["admin_pharmacy"] = ("123", new List<UserRole> { UserRole.Admin, UserRole.PharmacyStaff }),
+            ["doctor_admin"] = ("123", new List<UserRole> { UserRole.DiagnosingDoctor, UserRole.Admin }),
+            ["doctor_pharmacy_register"] = ("123", new List<UserRole> { UserRole.DiagnosingDoctor, UserRole.PharmacyStaff, UserRole.RegistrationStaff })
+        };
+
+        public IList<UserRole>? Login(string userName, string password) {
+            if (_accounts.TryGetValue(userName, out var info) && info.Password == password)
+                return info.Roles;
             return null;
         }
     }

--- a/LYBT.UI.WPF/Services/IAuthService.cs
+++ b/LYBT.UI.WPF/Services/IAuthService.cs
@@ -1,4 +1,5 @@
 using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 
 namespace LYBT.UI.WPF.Services {
 
@@ -8,8 +9,8 @@ namespace LYBT.UI.WPF.Services {
     public interface IAuthService {
 
         /// <summary>
-        /// 验证用户名和密码，返回对应的用户角色。登录失败返回 null
+    /// 验证用户名和密码，返回对应的用户角色列表。登录失败返回 null
         /// </summary>
-        UserRole? Login(string userName, string password);
+        IList<UserRole>? Login(string userName, string password);
     }
 }

--- a/LYBT.UI.WPF/ViewModels/HomeViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/HomeViewModel.cs
@@ -1,5 +1,10 @@
 using LYBT.Common.Enums.Users;
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Regions;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
 using LYBT.UI.WPF.Models;
 
 namespace LYBT.UI.WPF.ViewModels {
@@ -25,30 +30,32 @@ namespace LYBT.UI.WPF.ViewModels {
             }
         }
 
-        private void LoadNavigation(UserRole role) {
+        private void LoadNavigation(IEnumerable<UserRole> roles) {
             NavigationItems.Clear();
-            switch (role) {
-                case UserRole.Admin:
-                    NavigationItems.Add(new NavigationItem("管理员面板", "AdminView"));
-                    break;
-                case UserRole.DiagnosingDoctor:
-                    NavigationItems.Add(new NavigationItem("医生面板", "DiagnosingDoctorView"));
-                    break;
-                case UserRole.TreatmentDoctor:
-                    NavigationItems.Add(new NavigationItem("治疗面板", "TreatmentDoctorView"));
-                    break;
-                case UserRole.PharmacyStaff:
-                    NavigationItems.Add(new NavigationItem("药房面板", "PharmacyStaffView"));
-                    break;
-                case UserRole.RegistrationStaff:
-                    NavigationItems.Add(new NavigationItem("挂号面板", "RegistrationStaffView"));
-                    break;
+            foreach (var role in roles.Distinct()) {
+                switch (role) {
+                    case UserRole.Admin:
+                        NavigationItems.Add(new NavigationItem("管理员面板", "AdminView"));
+                        break;
+                    case UserRole.DiagnosingDoctor:
+                        NavigationItems.Add(new NavigationItem("医生面板", "DiagnosingDoctorView"));
+                        break;
+                    case UserRole.TreatmentDoctor:
+                        NavigationItems.Add(new NavigationItem("治疗面板", "TreatmentDoctorView"));
+                        break;
+                    case UserRole.PharmacyStaff:
+                        NavigationItems.Add(new NavigationItem("药房面板", "PharmacyStaffView"));
+                        break;
+                    case UserRole.RegistrationStaff:
+                        NavigationItems.Add(new NavigationItem("挂号面板", "RegistrationStaffView"));
+                        break;
+                }
             }
         }
 
         public void OnNavigatedTo(NavigationContext navigationContext) {
-            if (navigationContext.Parameters.TryGetValue("UserRole", out UserRole role)) {
-                LoadNavigation(role);
+            if (navigationContext.Parameters.TryGetValue("UserRoles", out IList<UserRole> roles)) {
+                LoadNavigation(roles);
             }
         }
 

--- a/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
@@ -45,11 +45,11 @@ namespace LYBT.UI.WPF.ViewModels {
         /// </summary>
         private void ExecuteLogin() {
             // 调用认证服务进行验证（此处为模拟逻辑）
-            UserRole? role = _authService.Login(Username, Password);
-            if (role.HasValue) {
+            var roles = _authService.Login(Username, Password);
+            if (roles != null && roles.Count > 0) {
                 // 登录成功，携带角色信息导航到主内容视图HomeView
                 var parameters = new NavigationParameters();
-                parameters.Add("UserRole", role.Value);
+                parameters.Add("UserRoles", roles);
                 _regionManager.RequestNavigate("ContentRegion", "HomeView", parameters);
                 // 将主窗口切换为最大化显示
                 Application.Current.MainWindow.WindowState = WindowState.Maximized;


### PR DESCRIPTION
## Summary
- extend the AuthService to keep a dictionary of test accounts
- allow IAuthService to return multiple roles
- update LoginViewModel to pass role list
- update HomeViewModel to render navigation for all roles

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d4a116ad483339e0a05fedd1a12ee