### PR TITLE
Integrate WPF login with API

### DIFF
--- a/LYBT.UI.WPF/Services/AuthService.cs
+++ b/LYBT.UI.WPF/Services/AuthService.cs
@@ -1,30 +1,38 @@
 using LYBT.Common.Enums.Users;
+using LYBT.Module.Auth.Dtos;
+using Refit;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace LYBT.UI.WPF.Services {
 
     /// <summary>
-    /// 认证服务实现：提供模拟的登录验证逻辑
+    /// 认证服务实现：通过 WebAPI 调用进行真实登录验证
     /// </summary>
     public class AuthService : IAuthService {
 
-        private readonly Dictionary<string, (string Password, List<UserRole> Roles)> _accounts = new()
-        {
-            ["admin"] = ("123", new List<UserRole> { UserRole.Admin }),
-            ["doctor"] = ("123", new List<UserRole> { UserRole.DiagnosingDoctor }),
-            ["treatment"] = ("123", new List<UserRole> { UserRole.TreatmentDoctor }),
-            ["pharmacy"] = ("123", new List<UserRole> { UserRole.PharmacyStaff }),
-            ["register"] = ("123", new List<UserRole> { UserRole.RegistrationStaff }),
-            // 多权限测试账号
-            ["admin_pharmacy"] = ("123", new List<UserRole> { UserRole.Admin, UserRole.PharmacyStaff }),
-            ["doctor_admin"] = ("123", new List<UserRole> { UserRole.DiagnosingDoctor, UserRole.Admin }),
-            ["doctor_pharmacy_register"] = ("123", new List<UserRole> { UserRole.DiagnosingDoctor, UserRole.PharmacyStaff, UserRole.RegistrationStaff })
-        };
+        private readonly IAuthApi _authApi;
+
+        public AuthService() {
+            // TODO: 可从配置读取 API 地址
+            var client = new HttpClient { BaseAddress = new Uri("http://localhost:5297") };
+            _authApi = RestService.For<IAuthApi>(client);
+        }
 
         public IList<UserRole>? Login(string userName, string password) {
-            if (_accounts.TryGetValue(userName, out var info) && info.Password == password)
-                return info.Roles;
-            return null;
+            try {
+                var result = _authApi.LoginAsync(new LoginRequestDto {
+                    Username = userName,
+                    Password = password
+                }).GetAwaiter().GetResult();
+
+                var roles = result.User.Roles;
+                if (roles == null || roles.Count == 0)
+                    roles = new List<UserRole> { result.User.Role };
+                return roles;
+            } catch (ApiException) {
+                return null;
+            }
         }
     }
 }

--- a/LYBT.UI.WPF/Services/IAuthApi.cs
+++ b/LYBT.UI.WPF/Services/IAuthApi.cs
@@ -1,0 +1,9 @@
+using LYBT.Module.Auth.Dtos;
+using Refit;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IAuthApi {
+        [Post("/api/Auth/login")]
+        Task<LoginResponseDto> LoginAsync([Body] LoginRequestDto dto);
+    }
+}


### PR DESCRIPTION
## Summary
- switch WPF AuthService to call real WebAPI login endpoint
- add Refit interface for authentication API

## Testing
- `dotnet build LYBTZYZS.sln -v q` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_686296a185008333bc141218a32c5c18