### PR TITLE
实现用户管理更新功能

### DIFF
--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -99,9 +99,16 @@ public class UserService : IUserService {
         if (oldUser == null)
             throw new Exception("用户不存在");
 
+        // 记录修改前的数据以便日志审计
+        var oldSnapshot = System.Text.Json.JsonSerializer.Serialize(oldUser);
+
         oldUser.RealName = dto.RealName;
         oldUser.Role = dto.Role;
-        // 其它属性赋值...
+        oldUser.IsActive = dto.IsActive;
+
+        if (!string.IsNullOrWhiteSpace(dto.Password)) {
+            oldUser.PasswordHash = PasswordHelper.Hash(dto.Password);
+        }
 
         var result = await _userRepository.UpdateAsync(oldUser);
 
@@ -115,8 +122,8 @@ public class UserService : IUserService {
                 OperatorName = operatorName,
                 LogTime = DateTime.Now,
                 Content = $"修改用户信息：{oldUser.UserName}",
-                OldValue = System.Text.Json.JsonSerializer.Serialize(oldUser),
-                NewValue = System.Text.Json.JsonSerializer.Serialize(dto)
+                OldValue = oldSnapshot,
+                NewValue = System.Text.Json.JsonSerializer.Serialize(oldUser)
             });
         }
         return result;


### PR DESCRIPTION
## Summary
- 完善用户更新逻辑，支持更新启用状态与密码
- 记录更新前的用户信息便于日志审计

## Testing
- `dotnet restore` *(fails: Unable to access api.nuget.org)*
- `dotnet build --no-restore` *(fails: project.assets.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629dac69f083339313b17d3e27c3da