### PR TITLE
Add WPF user management UI

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -13,6 +13,7 @@ namespace LYBT.UI.WPF {
         protected override void RegisterTypes(IContainerRegistry containerRegistry) {
             // 注册服务接口与实现，用于依赖注入
             containerRegistry.Register<IAuthService, AuthService>();
+            containerRegistry.Register<IUserManagementService, UserManagementService>();
             // 注册导航视图（将视图类型映射到导航名称）
             containerRegistry.RegisterForNavigation<LoginView, LoginViewModel>();
             containerRegistry.RegisterForNavigation<HomeView, HomeViewModel>();

--- a/LYBT.UI.WPF/Services/IUserApi.cs
+++ b/LYBT.UI.WPF/Services/IUserApi.cs
@@ -1,0 +1,35 @@
+using LYBT.Module.Users.Dtos;
+using LYBT.Common.Enums.Users;
+using Refit;
+
+namespace LYBT.UI.WPF.Services {
+    public class UserSearchResponseDto {
+        public int total { get; set; }
+        public List<UserDto> users { get; set; } = new();
+    }
+
+    public class SuccessResponseDto {
+        public bool success { get; set; }
+        public int count { get; set; }
+    }
+
+    public interface IUserApi {
+        [Get("/api/Users/search")]
+        Task<UserSearchResponseDto> SearchAsync([Query] UserQueryDto query);
+
+        [Post("/api/Users/add")]
+        Task<SuccessResponseDto> AddAsync([Body] UserCreateDto dto);
+
+        [Put("/api/Users/update")]
+        Task<SuccessResponseDto> UpdateAsync([Body] UserEditDto dto);
+
+        [Post("/api/Users/disable/{id}")]
+        Task<SuccessResponseDto> DisableAsync(Guid id);
+
+        [Post("/api/Users/enable/{id}")]
+        Task<SuccessResponseDto> EnableAsync(Guid id);
+
+        [Get("/api/Users/getRoles")]
+        Task<List<UserRole>> GetRolesAsync();
+    }
+}

--- a/LYBT.UI.WPF/Services/UserManagementService.cs
+++ b/LYBT.UI.WPF/Services/UserManagementService.cs
@@ -1,0 +1,50 @@
+using LYBT.Module.Users.Dtos;
+using LYBT.Common.Enums.Users;
+using Refit;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IUserManagementService {
+        Task<(IList<UserDto> users, int total)> SearchAsync(UserQueryDto query);
+        Task<List<UserRole>> GetRolesAsync();
+        Task<bool> AddAsync(UserCreateDto dto);
+        Task<bool> UpdateAsync(UserEditDto dto);
+        Task<bool> DisableAsync(Guid id);
+        Task<bool> EnableAsync(Guid id);
+    }
+
+    public class UserManagementService : IUserManagementService {
+        private readonly IUserApi _api;
+
+        public UserManagementService() {
+            var client = new HttpClient { BaseAddress = new Uri("http://localhost:5297") };
+            _api = RestService.For<IUserApi>(client);
+        }
+
+        public async Task<(IList<UserDto> users, int total)> SearchAsync(UserQueryDto query) {
+            var result = await _api.SearchAsync(query);
+            return (result.users, result.total);
+        }
+
+        public Task<List<UserRole>> GetRolesAsync() => _api.GetRolesAsync();
+
+        public async Task<bool> AddAsync(UserCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.success;
+        }
+
+        public async Task<bool> UpdateAsync(UserEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.success;
+        }
+
+        public async Task<bool> DisableAsync(Guid id) {
+            var resp = await _api.DisableAsync(id);
+            return resp.success;
+        }
+
+        public async Task<bool> EnableAsync(Guid id) {
+            var resp = await _api.EnableAsync(id);
+            return resp.success;
+        }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/AdminViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/AdminViewModel.cs
@@ -1,6 +1,71 @@
+using LYBT.Module.Users.Dtos;
+using LYBT.Common.Enums.Users;
+using LYBT.UI.WPF.Services;
+using Prism.Commands;
 using Prism.Mvvm;
+using Prism.Regions;
+using System.Collections.ObjectModel;
 
 namespace LYBT.UI.WPF.ViewModels {
-    public class AdminViewModel : BindableBase {
+    public class AdminViewModel : BindableBase, INavigationAware {
+        private readonly IUserManagementService _service;
+
+        public ObservableCollection<UserDto> Users { get; } = new();
+
+        public DelegateCommand AddUserCommand { get; }
+        public DelegateCommand<UserDto?> EditUserCommand { get; }
+        public DelegateCommand<UserDto?> ToggleUserStatusCommand { get; }
+
+        public AdminViewModel(IUserManagementService service) {
+            _service = service;
+            AddUserCommand = new DelegateCommand(AddUser);
+            EditUserCommand = new DelegateCommand<UserDto?>(EditUser);
+            ToggleUserStatusCommand = new DelegateCommand<UserDto?>(ToggleUserStatus);
+        }
+
+        private async void LoadUsers() {
+            var (list, _) = await _service.SearchAsync(new UserQueryDto { Page = 1, PageSize = 50 });
+            Users.Clear();
+            foreach (var u in list) {
+                Users.Add(u);
+            }
+        }
+
+        private async void AddUser() {
+            var roles = await _service.GetRolesAsync();
+            var dlg = new Views.UserEditWindow(roles);
+            if (dlg.ShowDialog() == true && dlg.CreatedUser != null) {
+                if (await _service.AddAsync(dlg.CreatedUser)) {
+                    LoadUsers();
+                }
+            }
+        }
+
+        private async void EditUser(UserDto? user) {
+            if (user == null) return;
+            var roles = await _service.GetRolesAsync();
+            var dlg = new Views.UserEditWindow(roles, user);
+            if (dlg.ShowDialog() == true && dlg.EditedUser != null) {
+                if (await _service.UpdateAsync(dlg.EditedUser)) {
+                    LoadUsers();
+                }
+            }
+        }
+
+        private async void ToggleUserStatus(UserDto? user) {
+            if (user == null) return;
+            bool ok = user.IsActive ? await _service.DisableAsync(user.Id) : await _service.EnableAsync(user.Id);
+            if (ok) {
+                LoadUsers();
+            }
+        }
+
+        public void OnNavigatedTo(NavigationContext navigationContext) {
+            LoadUsers();
+        }
+
+        public bool IsNavigationTarget(NavigationContext navigationContext) => true;
+
+        public void OnNavigatedFrom(NavigationContext navigationContext) { }
     }
 }

--- a/LYBT.UI.WPF/Views/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/AdminView.xaml
@@ -1,6 +1,12 @@
 <UserControl x:Class="LYBT.UI.WPF.Views.AdminView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:local="clr-namespace:LYBT.UI.WPF.Views"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <UserControl.Resources>
+        <local:StatusToButtonTextConverter x:Key="StatusToButtonTextConverter"/>
+    </UserControl.Resources>
 
     <Grid>
         <TabControl>
@@ -12,10 +18,11 @@
                     </Grid.RowDefinitions>
 
                     <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                        <Button Content="新增用户" Margin="0,0,10,0" Click="AddUser_Click"/>
+                        <Button Content="新增用户" Margin="0,0,10,0" Command="{Binding AddUserCommand}"/>
                     </StackPanel>
 
                     <DataGrid x:Name="UserDataGrid"
+                              ItemsSource="{Binding Users}"
                               Grid.Row="1"
                               AutoGenerateColumns="False"
                               IsReadOnly="True"
@@ -26,17 +33,17 @@
                             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="Auto"/>
                             <DataGridTextColumn Header="用户名" Binding="{Binding Username}" Width="*"/>
                             <DataGridTextColumn Header="邮箱" Binding="{Binding Email}" Width="*"/>
-                            <DataGridTextColumn Header="状态" Binding="{Binding Status}" Width="Auto"/>
+                            <DataGridTextColumn Header="状态" Binding="{Binding IsActive}" Width="Auto"/>
                             <DataGridTemplateColumn Header="操作" Width="Auto">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
                                         <StackPanel Orientation="Horizontal">
                                             <Button Content="编辑" Margin="0,0,5,0"
                                                     CommandParameter="{Binding}"
-                                                    Click="EditUser_Click"/>
-                                            <Button Content="{Binding Status, Converter={StaticResource StatusToButtonTextConverter}}"
+                                                    Command="{Binding DataContext.EditUserCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                                            <Button Content="{Binding IsActive, Converter={StaticResource StatusToButtonTextConverter}}"
                                                     CommandParameter="{Binding}"
-                                                    Click="ToggleUserStatus_Click"/>
+                                                    Command="{Binding DataContext.ToggleUserStatusCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
                                         </StackPanel>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>

--- a/LYBT.UI.WPF/Views/AdminView.xaml.cs
+++ b/LYBT.UI.WPF/Views/AdminView.xaml.cs
@@ -7,17 +7,6 @@ namespace LYBT.UI.WPF.Views {
             InitializeComponent();
         }
 
-        private void AddUser_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("新增用户功能待实现", "提示");
-        }
-
-        private void EditUser_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("编辑用户功能待实现", "提示");
-        }
-
-        private void ToggleUserStatus_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("启用/停用用户功能待实现", "提示");
-        }
 
         private void AddHerb_Click(object sender, System.Windows.RoutedEventArgs e) {
             MessageBox.Show("新增药材功能待实现", "提示");

--- a/LYBT.UI.WPF/Views/StatusToButtonTextConverter.cs
+++ b/LYBT.UI.WPF/Views/StatusToButtonTextConverter.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace LYBT.UI.WPF.Views {
+    public class StatusToButtonTextConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value is bool active) {
+                return active ? "禁用" : "启用";
+            }
+            return "切换";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml
@@ -1,0 +1,38 @@
+<Window x:Class="LYBT.UI.WPF.Views.UserEditWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="用户" Height="300" Width="300">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="70"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+
+        <TextBlock Text="用户名" VerticalAlignment="Center"/>
+        <TextBox x:Name="UserNameTextBox" Grid.Column="1" Margin="0,0,0,5"/>
+
+        <TextBlock Text="真实姓名" Grid.Row="1" VerticalAlignment="Center"/>
+        <TextBox x:Name="RealNameTextBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
+
+        <TextBlock Text="角色" Grid.Row="2" VerticalAlignment="Center"/>
+        <ComboBox x:Name="RoleComboBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
+
+        <TextBlock Text="密码" Grid.Row="3" VerticalAlignment="Center"/>
+        <PasswordBox x:Name="PasswordBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
+
+        <CheckBox x:Name="IsActiveCheckBox" Content="启用" Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="确定" Width="60" Margin="0,0,10,0" Click="Ok_Click"/>
+            <Button Content="取消" Width="60" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
@@ -1,0 +1,55 @@
+using LYBT.Common.Enums.Users;
+using LYBT.Module.Users.Dtos;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace LYBT.UI.WPF.Views {
+    public partial class UserEditWindow : Window {
+        private readonly UserDto? _origin;
+        public UserCreateDto? CreatedUser { get; private set; }
+        public UserEditDto? EditedUser { get; private set; }
+
+        public UserEditWindow(IEnumerable<UserRole> roles, UserDto? user = null) {
+            InitializeComponent();
+            RoleComboBox.ItemsSource = roles;
+            _origin = user;
+            if (user != null) {
+                Title = "编辑用户";
+                UserNameTextBox.Text = user.UserName;
+                UserNameTextBox.IsEnabled = false;
+                RealNameTextBox.Text = user.RealName;
+                RoleComboBox.SelectedItem = user.Role;
+                IsActiveCheckBox.IsChecked = user.IsActive;
+            } else {
+                Title = "新增用户";
+                RoleComboBox.SelectedIndex = 0;
+                IsActiveCheckBox.IsChecked = true;
+            }
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e) {
+            if (_origin == null) {
+                CreatedUser = new UserCreateDto {
+                    UserName = UserNameTextBox.Text,
+                    RealName = RealNameTextBox.Text,
+                    Role = (UserRole)RoleComboBox.SelectedItem!,
+                    IsActive = IsActiveCheckBox.IsChecked == true,
+                    Password = PasswordBox.Password
+                };
+            } else {
+                EditedUser = new UserEditDto {
+                    Id = _origin.Id,
+                    RealName = RealNameTextBox.Text,
+                    Role = (UserRole)RoleComboBox.SelectedItem!,
+                    IsActive = IsActiveCheckBox.IsChecked == true,
+                    Password = string.IsNullOrWhiteSpace(PasswordBox.Password) ? null : PasswordBox.Password
+                };
+            }
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e) {
+            DialogResult = false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- build user-management service for WPF
- wire user management service in App startup
- implement AdminViewModel with CRUD logic
- create UserEditWindow for adding/editing users
- connect AdminView to new view model and commands
- provide converter for enable/disable button text

## Testing
- `dotnet build --no-restore` *(fails: Assets file not found)*
- `dotnet restore` *(fails: unable to load NuGet packages due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68629f762a7083338b39639b0fdda4ba