### PR TITLE
Align UI fields with UserModel

### DIFF
--- a/LYBT.Module.Users/Dtos/UserCreateDto.cs
+++ b/LYBT.Module.Users/Dtos/UserCreateDto.cs
@@ -35,6 +35,18 @@ namespace LYBT.Module.Users.Dtos {
         public bool IsActive { get; set; } = true;
 
         /// <summary>
+        /// 邮箱地址
+        /// </summary>
+        [EmailAddress(ErrorMessage = "邮箱格式不正确")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// 联系电话
+        /// </summary>
+        [Phone(ErrorMessage = "联系电话格式不正确")]
+        public string? PhoneNumber { get; set; }
+
+        /// <summary>
         /// 初始密码（必填）
         /// </summary>
         [Required(ErrorMessage = "密码不能为空")]

--- a/LYBT.Module.Users/Dtos/UserDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDto.cs
@@ -46,5 +46,15 @@ namespace LYBT.Module.Users.Dtos {
         /// 最近登录时间
         /// </summary>
         public DateTime? LastLoginTime { get; set; }
+
+        /// <summary>
+        /// 邮箱地址
+        /// </summary>
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// 联系电话
+        /// </summary>
+        public string? PhoneNumber { get; set; }
     }
 }

--- a/LYBT.Module.Users/Dtos/UserEditDto.cs
+++ b/LYBT.Module.Users/Dtos/UserEditDto.cs
@@ -35,6 +35,18 @@ namespace LYBT.Module.Users.Dtos {
         public bool IsActive { get; set; }
 
         /// <summary>
+        /// 邮箱地址
+        /// </summary>
+        [EmailAddress(ErrorMessage = "邮箱格式不正确")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// 联系电话
+        /// </summary>
+        [Phone(ErrorMessage = "联系电话格式不正确")]
+        public string? PhoneNumber { get; set; }
+
+        /// <summary>
         /// 新密码（可选，留空表示不修改。修改密码时必须符合长度要求）
         /// </summary>
         [StringLength(32, MinimumLength = 6, ErrorMessage = "密码长度必须在6-32个字符之间")]

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -32,7 +32,9 @@ public class UserService : IUserService {
                 Role = m.Role,
                 IsActive = m.IsActive,
                 CreatedTime = m.CreatedTime,
-                LastLoginTime = m.LastLoginTime
+                LastLoginTime = m.LastLoginTime,
+                Email = m.Email,
+                PhoneNumber = m.PhoneNumber
             });
         }
         return (users, total);
@@ -52,7 +54,9 @@ public class UserService : IUserService {
             Role = m.Role,
             IsActive = m.IsActive,
             CreatedTime = m.CreatedTime,
-            LastLoginTime = m.LastLoginTime
+            LastLoginTime = m.LastLoginTime,
+            Email = m.Email,
+            PhoneNumber = m.PhoneNumber
         };
     }
 
@@ -69,6 +73,8 @@ public class UserService : IUserService {
             RealName = dto.RealName,
             Role = dto.Role,
             IsActive = dto.IsActive,
+            Email = dto.Email,
+            PhoneNumber = dto.PhoneNumber,
             CreatedTime = DateTime.Now,
 
             PasswordHash = PasswordHelper.Hash(dto.Password)
@@ -105,6 +111,8 @@ public class UserService : IUserService {
         oldUser.RealName = dto.RealName;
         oldUser.Role = dto.Role;
         oldUser.IsActive = dto.IsActive;
+        oldUser.Email = dto.Email;
+        oldUser.PhoneNumber = dto.PhoneNumber;
 
         if (!string.IsNullOrWhiteSpace(dto.Password)) {
             oldUser.PasswordHash = PasswordHelper.Hash(dto.Password);

--- a/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/LoginViewModel.cs
@@ -8,11 +8,11 @@ namespace LYBT.UI.WPF.ViewModels {
     /// LoginView 对应的视图模型，处理登录逻辑
     /// </summary>
     public class LoginViewModel : BindableBase {
-        private string _username;
+        private string _userName;
 
-        public string Username {
-            get => _username;
-            set => SetProperty(ref _username, value);
+        public string UserName {
+            get => _userName;
+            set => SetProperty(ref _userName, value);
         }
 
         private string _password;
@@ -36,7 +36,7 @@ namespace LYBT.UI.WPF.ViewModels {
             _regionManager = regionManager;
             // 初始化命令，指定执行方法和可执行判定（可执行判定此处简单为非空校验）
             LoginCommand = new DelegateCommand(ExecuteLogin, CanExecuteLogin)
-                               .ObservesProperty(() => Username)
+                               .ObservesProperty(() => UserName)
                                .ObservesProperty(() => Password);
         }
 
@@ -45,7 +45,7 @@ namespace LYBT.UI.WPF.ViewModels {
         /// </summary>
         private void ExecuteLogin() {
             // 调用认证服务进行验证（此处为模拟逻辑）
-            var roles = _authService.Login(Username, Password);
+            var roles = _authService.Login(UserName, Password);
             if (roles != null && roles.Count > 0) {
                 // 登录成功，携带角色信息导航到主内容视图HomeView
                 var parameters = new NavigationParameters();
@@ -64,7 +64,7 @@ namespace LYBT.UI.WPF.ViewModels {
         /// </summary>
         private bool CanExecuteLogin() {
             // 当用户名和密码都不为空时，命令才可执行
-            return !string.IsNullOrEmpty(Username) && !string.IsNullOrEmpty(Password);
+            return !string.IsNullOrEmpty(UserName) && !string.IsNullOrEmpty(Password);
         }
     }
 }

--- a/LYBT.UI.WPF/Views/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/AdminView.xaml
@@ -31,8 +31,10 @@
                               HeadersVisibility="Column">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="Auto"/>
-                            <DataGridTextColumn Header="用户名" Binding="{Binding Username}" Width="*"/>
+                            <DataGridTextColumn Header="用户名" Binding="{Binding UserName}" Width="*"/>
+                            <DataGridTextColumn Header="真实姓名" Binding="{Binding RealName}" Width="*"/>
                             <DataGridTextColumn Header="邮箱" Binding="{Binding Email}" Width="*"/>
+                            <DataGridTextColumn Header="电话" Binding="{Binding PhoneNumber}" Width="*"/>
                             <DataGridTextColumn Header="状态" Binding="{Binding IsActive}" Width="Auto"/>
                             <DataGridTemplateColumn Header="操作" Width="Auto">
                                 <DataGridTemplateColumn.CellTemplate>

--- a/LYBT.UI.WPF/Views/LoginView.xaml
+++ b/LYBT.UI.WPF/Views/LoginView.xaml
@@ -6,7 +6,7 @@
     <StackPanel Margin="30" HorizontalAlignment="Center" VerticalAlignment="Center" Width="200">
         <!-- 用户名输入框 -->
         <TextBlock Text="用户名:" />
-        <TextBox Text="{Binding Username, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10" />
+        <TextBox Text="{Binding UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,10" />
         <!-- 密码输入框 -->
         <TextBlock Text="密码:" />
         <TextBox Text="{Binding Password, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,20" />

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml
@@ -10,6 +10,8 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="70"/>
@@ -25,12 +27,18 @@
         <TextBlock Text="角色" Grid.Row="2" VerticalAlignment="Center"/>
         <ComboBox x:Name="RoleComboBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
 
-        <TextBlock Text="密码" Grid.Row="3" VerticalAlignment="Center"/>
-        <PasswordBox x:Name="PasswordBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
+        <TextBlock Text="邮箱" Grid.Row="3" VerticalAlignment="Center"/>
+        <TextBox x:Name="EmailTextBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
 
-        <CheckBox x:Name="IsActiveCheckBox" Content="启用" Grid.Row="4" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+        <TextBlock Text="电话" Grid.Row="4" VerticalAlignment="Center"/>
+        <TextBox x:Name="PhoneNumberTextBox" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"/>
 
-        <StackPanel Orientation="Horizontal" Grid.Row="5" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <TextBlock Text="密码" Grid.Row="5" VerticalAlignment="Center"/>
+        <PasswordBox x:Name="PasswordBox" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5"/>
+
+        <CheckBox x:Name="IsActiveCheckBox" Content="启用" Grid.Row="6" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="确定" Width="60" Margin="0,0,10,0" Click="Ok_Click"/>
             <Button Content="取消" Width="60" Click="Cancel_Click"/>
         </StackPanel>

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
@@ -19,6 +19,8 @@ namespace LYBT.UI.WPF.Views {
                 UserNameTextBox.IsEnabled = false;
                 RealNameTextBox.Text = user.RealName;
                 RoleComboBox.SelectedItem = user.Role;
+                EmailTextBox.Text = user.Email ?? string.Empty;
+                PhoneNumberTextBox.Text = user.PhoneNumber ?? string.Empty;
                 IsActiveCheckBox.IsChecked = user.IsActive;
             } else {
                 Title = "新增用户";
@@ -34,6 +36,8 @@ namespace LYBT.UI.WPF.Views {
                     RealName = RealNameTextBox.Text,
                     Role = (UserRole)RoleComboBox.SelectedItem!,
                     IsActive = IsActiveCheckBox.IsChecked == true,
+                    Email = EmailTextBox.Text,
+                    PhoneNumber = PhoneNumberTextBox.Text,
                     Password = PasswordBox.Password
                 };
             } else {
@@ -42,6 +46,8 @@ namespace LYBT.UI.WPF.Views {
                     RealName = RealNameTextBox.Text,
                     Role = (UserRole)RoleComboBox.SelectedItem!,
                     IsActive = IsActiveCheckBox.IsChecked == true,
+                    Email = EmailTextBox.Text,
+                    PhoneNumber = PhoneNumberTextBox.Text,
                     Password = string.IsNullOrWhiteSpace(PasswordBox.Password) ? null : PasswordBox.Password
                 };
             }


### PR DESCRIPTION
## Summary
- match UI bindings with `UserModel` property names
- allow editing user email and phone
- expose email and phone in user DTOs and service mappings
- rename LoginViewModel property to `UserName`

## Testing
- `dotnet build LYBTZYZS.sln -warnaserror` *(fails: Unable to load nuget packages)*

------
https://chatgpt.com/codex/tasks/task_e_6862b1877db48333b4402b159246154a