### PR TITLE
Improve AddUser error handling

### DIFF
--- a/LYBT.UI.WPF/ViewModels/AdminViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/AdminViewModel.cs
@@ -40,7 +40,9 @@ namespace LYBT.UI.WPF.ViewModels {
                         MessageBox.Show("新增用户失败", "错误", MessageBoxButton.OK, MessageBoxImage.Warning);
                     }
                 } catch (ApiException ex) {
-                    MessageBox.Show($"新增用户失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+                    // Display server-provided error details when available
+                    var error = string.IsNullOrWhiteSpace(ex.Content) ? ex.Message : ex.Content;
+                    MessageBox.Show($"新增用户失败：{error}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                 } catch (Exception ex) {
                     MessageBox.Show($"新增用户失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                 }


### PR DESCRIPTION
## Summary
- show the server response content when creating a user fails

## Testing
- `dotnet build --no-restore` *(fails: assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b707b63c8333b3da77c0f89a4863