### PR TITLE
Support multiple roles per user

### DIFF
--- a/LYBT.Infrastructure/AppDbContext.cs
+++ b/LYBT.Infrastructure/AppDbContext.cs
@@ -13,9 +13,11 @@ using LYBT.Models.Settings;
 using LYBT.Models.TreatmentRoom;
 using LYBT.Module.Patients.Models;
 using LYBT.Module.Users.Models;
+using LYBT.Common.Enums.Users;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using System.Text.Json;
+using System.Collections.Generic;
 
 namespace LYBT.Infrastructure {
 
@@ -56,6 +58,19 @@ namespace LYBT.Infrastructure {
         /// </summary>
         protected override void OnModelCreating(ModelBuilder modelBuilder) {
             base.OnModelCreating(modelBuilder);
+
+            // === List<UserRole> for UserModel ===
+            modelBuilder.Entity<UserModel>()
+                .Property(x => x.Roles)
+                .HasConversion(
+                    v => JsonSerializer.Serialize(v, (JsonSerializerOptions)null),
+                    v => JsonSerializer.Deserialize<List<UserRole>>(v, (JsonSerializerOptions)null))
+                .Metadata.SetValueComparer(
+                    new ValueComparer<List<UserRole>>(
+                        (c1, c2) => JsonSerializer.Serialize(c1, (JsonSerializerOptions)null) == JsonSerializer.Serialize(c2, (JsonSerializerOptions)null),
+                        c => c == null ? 0 : JsonSerializer.Serialize(c, (JsonSerializerOptions)null).GetHashCode(),
+                        c => c == null ? null : JsonSerializer.Deserialize<List<UserRole>>(JsonSerializer.Serialize(c, (JsonSerializerOptions)null), (JsonSerializerOptions)null)
+                    ));
 
             // === List<HerbItemModel> for FormulaTemplateModel ===
             modelBuilder.Entity<FormulaTemplateModel>()

--- a/LYBT.Models/Users/UserModel.cs
+++ b/LYBT.Models/Users/UserModel.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 
 namespace LYBT.Module.Users.Models {
 
@@ -26,6 +27,11 @@ namespace LYBT.Module.Users.Models {
         /// 用户角色（管理员、医生等，枚举）
         /// </summary>
         public UserRole Role { get; set; } = UserRole.DiagnosingDoctor;
+
+        /// <summary>
+        /// 用户拥有的所有角色
+        /// </summary>
+        public List<UserRole> Roles { get; set; } = new();
 
         /// <summary>
         /// 启用状态（true=启用，false=禁用）

--- a/LYBT.Module.Auth/Services/AuthService.cs
+++ b/LYBT.Module.Auth/Services/AuthService.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using System.Collections.Generic;
 using LYBT.Common.Enums.Logs;
 using LYBT.Common.Helpers;
 using LYBT.Module.Auth.Dtos;
@@ -36,6 +37,7 @@ namespace LYBT.Module.Auth.Services {
                     UserName = "sysadmin",
                     RealName = "系统管理员",
                     Role = UserRole.Admin,
+                    Roles = new List<UserRole> { UserRole.Admin },
                     IsActive = true,
                     CreatedTime = DateTime.Now,
                     PasswordHash = string.Empty

--- a/LYBT.Module.Users/Dtos/UserCreateDto.cs
+++ b/LYBT.Module.Users/Dtos/UserCreateDto.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace LYBT.Module.Users.Dtos {
@@ -28,6 +29,11 @@ namespace LYBT.Module.Users.Dtos {
         [Required(ErrorMessage = "用户角色不能为空")]
         [EnumDataType(typeof(UserRole), ErrorMessage = "用户角色无效")]
         public UserRole Role { get; set; } = UserRole.DiagnosingDoctor;
+
+        /// <summary>
+        /// 多个用户角色
+        /// </summary>
+        public List<UserRole> Roles { get; set; } = new();
 
         /// <summary>
         /// 账号启用状态（true=启用，false=禁用）

--- a/LYBT.Module.Users/Dtos/UserDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDto.cs
@@ -1,4 +1,5 @@
 using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 
 namespace LYBT.Module.Users.Dtos {
 

--- a/LYBT.Module.Users/Dtos/UserEditDto.cs
+++ b/LYBT.Module.Users/Dtos/UserEditDto.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace LYBT.Module.Users.Dtos {
@@ -27,6 +28,11 @@ namespace LYBT.Module.Users.Dtos {
         [Required(ErrorMessage = "用户角色不能为空")]
         [EnumDataType(typeof(UserRole), ErrorMessage = "用户角色无效")]
         public UserRole Role { get; set; } = UserRole.DiagnosingDoctor;
+
+        /// <summary>
+        /// 多个用户角色
+        /// </summary>
+        public List<UserRole> Roles { get; set; } = new();
 
         /// <summary>
         /// 账号启用状态（true=启用，false=禁用，必填）

--- a/LYBT.Module.Users/Mapping/UserMappingProfile.cs
+++ b/LYBT.Module.Users/Mapping/UserMappingProfile.cs
@@ -1,5 +1,6 @@
 using AutoMapper;
 using LYBT.Common.Enums.Users;
+using System.Collections.Generic;
 using LYBT.Module.Users.Dtos;
 using LYBT.Module.Users.Models;
 
@@ -13,7 +14,8 @@ namespace LYBT.Module.Users.Mapping {
         public UserMappingProfile() {
             // 用户实体转DTO
             CreateMap<UserModel, UserDto>()
-                .ForMember(dest => dest.Roles, opt => opt.MapFrom(src => new List<UserRole> { src.Role }));
+                .ForMember(dest => dest.Roles,
+                    opt => opt.MapFrom(src => src.Roles != null && src.Roles.Count > 0 ? src.Roles : new List<UserRole> { src.Role }));
             // 新增DTO转实体
             CreateMap<UserCreateDto, UserModel>();
             // 编辑DTO转实体（密码字段需单独处理）

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Common.Enums.Logs;
+using System.Collections.Generic;
+using System.Linq;
 using LYBT.Common.Enums.Users;
 using LYBT.Common.Helpers;
 using LYBT.Module.Logs.Dtos;
@@ -30,6 +32,7 @@ public class UserService : IUserService {
                 UserName = m.UserName,
                 RealName = m.RealName,
                 Role = m.Role,
+                Roles = m.Roles != null && m.Roles.Count > 0 ? m.Roles : new List<UserRole> { m.Role },
                 IsActive = m.IsActive,
                 CreatedTime = m.CreatedTime,
                 LastLoginTime = m.LastLoginTime,
@@ -52,6 +55,7 @@ public class UserService : IUserService {
             UserName = m.UserName,
             RealName = m.RealName,
             Role = m.Role,
+            Roles = m.Roles != null && m.Roles.Count > 0 ? m.Roles : new List<UserRole> { m.Role },
             IsActive = m.IsActive,
             CreatedTime = m.CreatedTime,
             LastLoginTime = m.LastLoginTime,
@@ -67,11 +71,13 @@ public class UserService : IUserService {
         if (await _userRepository.ExistsByUsernameAsync(dto.UserName))
             throw new Exception("用户名已存在");
 
+        var roles = dto.Roles != null && dto.Roles.Count > 0 ? dto.Roles : new List<UserRole> { dto.Role };
         var user = new UserModel {
             Id = Guid.NewGuid(),
             UserName = dto.UserName,
             RealName = dto.RealName,
-            Role = dto.Role,
+            Role = roles.First(),
+            Roles = roles,
             IsActive = dto.IsActive,
             Email = dto.Email,
             PhoneNumber = dto.PhoneNumber,
@@ -109,7 +115,9 @@ public class UserService : IUserService {
         var oldSnapshot = System.Text.Json.JsonSerializer.Serialize(oldUser);
 
         oldUser.RealName = dto.RealName;
-        oldUser.Role = dto.Role;
+        var roles = dto.Roles != null && dto.Roles.Count > 0 ? dto.Roles : new List<UserRole> { dto.Role };
+        oldUser.Role = roles.First();
+        oldUser.Roles = roles;
         oldUser.IsActive = dto.IsActive;
         oldUser.Email = dto.Email;
         oldUser.PhoneNumber = dto.PhoneNumber;


### PR DESCRIPTION
## Summary
- allow storing a list of roles in `UserModel`
- serialize `UserModel.Roles` in EF Core
- expose roles in user DTOs and map them properly
- handle multi-role users in user service
- update auth service to populate roles for sysadmin

## Testing
- `dotnet test --no-restore --no-build --verbosity minimal` *(fails: api.nuget.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6863b7cf58f88333ada09ac05bc8f81b