### PR TITLE
Add Billing service integration to WPF client

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -27,16 +27,20 @@ namespace LYBT.UI.WPF {
             // 2. 用Refit创建IAuthApi实例  
             var authApi = RestService.For<IAuthApi>(httpClient);
             var userApi = RestService.For<IUserApi>(httpClient);
+            var billingApi = RestService.For<IBillingApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
             var userService = new UserManagementService(userApi);
+            var billingService = new BillingService(billingApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
             containerRegistry.RegisterInstance(userApi);
+            containerRegistry.RegisterInstance(billingApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
+            containerRegistry.RegisterInstance<IBillingService>(billingService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");
@@ -44,6 +48,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<HomeView>("HomeView");
             containerRegistry.RegisterForNavigation<AdminView>("AdminView");
             containerRegistry.RegisterForNavigation<UserManagementView>("UserManagementView");
+            containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
 
         }
 

--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <ProjectReference Include="..\LYBT.Module.Auth\LYBT.Module.Auth.csproj" />
     <ProjectReference Include="..\LYBT.Module.Users\LYBT.Module.Users.csproj" />
+    <ProjectReference Include="..\LYBT.Module.Billing\LYBT.Module.Billing.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LYBT.UI.WPF/Services/Api/IBillingApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IBillingApi.cs
@@ -1,0 +1,51 @@
+using LYBT.Module.Billing.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IBillingApi {
+        [Get("/api/Billing")] 
+        Task<List<BillingDto>> GetListAsync();
+
+        [Get("/api/Billing/{id}")]
+        Task<BillingDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/Billing")]
+        Task<ApiSuccessResponse> AddAsync([Body] BillingCreateDto dto);
+
+        [Put("/api/Billing")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] BillingEditDto dto);
+
+        [Delete("/api/Billing/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+
+        [Post("/api/Billing/mark-paid/{id}")]
+        Task<ApiSuccessResponse> MarkAsPaidAsync(Guid id);
+
+        [Post("/api/Billing/complete/{id}")]
+        Task<ApiSuccessResponse> MarkAsCompletedAsync(Guid id);
+
+        [Post("/api/Billing/request-refund/{id}")]
+        Task<ApiSuccessResponse> RequestRefundAsync(Guid id, [Body] string reason);
+
+        [Post("/api/Billing/approve-refund/{id}")]
+        Task<ApiSuccessResponse> ApproveRefundAsync(Guid id);
+
+        [Post("/api/Billing/reject-refund/{id}")]
+        Task<ApiSuccessResponse> RejectRefundAsync(Guid id);
+
+        [Post("/api/Billing/cancel/{id}")]
+        Task<ApiSuccessResponse> CancelAsync(Guid id);
+
+        [Get("/api/Billing/patient/{patientId}")]
+        Task<List<BillingDto>> GetByPatientIdAsync(Guid patientId);
+
+        [Get("/api/Billing/search")]
+        Task<List<BillingDto>> SearchAsync([Query] string keyword);
+
+        [Get("/api/Billing/refundable")]
+        Task<List<BillingDto>> GetRefundableBillsAsync();
+    }
+}

--- a/LYBT.UI.WPF/Services/BillingService.cs
+++ b/LYBT.UI.WPF/Services/BillingService.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LYBT.Module.Billing.Dtos;
+using LYBT.UI.WPF.Services.Api;
+
+namespace LYBT.UI.WPF.Services {
+    public class BillingService : IBillingService {
+        private readonly IBillingApi _billingApi;
+        public BillingService(IBillingApi billingApi) {
+            _billingApi = billingApi;
+        }
+        public async Task<IList<BillingDto>> GetAllAsync() {
+            return await _billingApi.GetListAsync();
+        }
+        public async Task<BillingDetailDto?> GetByIdAsync(Guid id) {
+            return await _billingApi.GetByIdAsync(id);
+        }
+        public async Task<bool> AddAsync(BillingCreateDto dto) {
+            var resp = await _billingApi.AddAsync(dto);
+            return resp.Success;
+        }
+        public async Task<bool> UpdateAsync(BillingEditDto dto) {
+            var resp = await _billingApi.UpdateAsync(dto);
+            return resp.Success;
+        }
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _billingApi.DeleteAsync(id);
+            return resp.Success;
+        }
+        public async Task<bool> MarkAsPaidAsync(Guid id) {
+            var resp = await _billingApi.MarkAsPaidAsync(id);
+            return resp.Success;
+        }
+        public async Task<bool> MarkAsCompletedAsync(Guid id) {
+            var resp = await _billingApi.MarkAsCompletedAsync(id);
+            return resp.Success;
+        }
+        public async Task<bool> RequestRefundAsync(Guid id, string reason) {
+            var resp = await _billingApi.RequestRefundAsync(id, reason);
+            return resp.Success;
+        }
+        public async Task<bool> ApproveRefundAsync(Guid id) {
+            var resp = await _billingApi.ApproveRefundAsync(id);
+            return resp.Success;
+        }
+        public async Task<bool> RejectRefundAsync(Guid id) {
+            var resp = await _billingApi.RejectRefundAsync(id);
+            return resp.Success;
+        }
+        public async Task<bool> CancelAsync(Guid id) {
+            var resp = await _billingApi.CancelAsync(id);
+            return resp.Success;
+        }
+        public async Task<IList<BillingDto>> GetByPatientIdAsync(Guid patientId) {
+            return await _billingApi.GetByPatientIdAsync(patientId);
+        }
+        public async Task<IList<BillingDto>> SearchAsync(string keyword) {
+            return await _billingApi.SearchAsync(keyword);
+        }
+        public async Task<IList<BillingDto>> GetRefundableBillsAsync() {
+            return await _billingApi.GetRefundableBillsAsync();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Services/IBillingService.cs
+++ b/LYBT.UI.WPF/Services/IBillingService.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LYBT.Module.Billing.Dtos;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IBillingService {
+        Task<IList<BillingDto>> GetAllAsync();
+        Task<BillingDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(BillingCreateDto dto);
+        Task<bool> UpdateAsync(BillingEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+        Task<bool> MarkAsPaidAsync(Guid id);
+        Task<bool> MarkAsCompletedAsync(Guid id);
+        Task<bool> RequestRefundAsync(Guid id, string reason);
+        Task<bool> ApproveRefundAsync(Guid id);
+        Task<bool> RejectRefundAsync(Guid id);
+        Task<bool> CancelAsync(Guid id);
+        Task<IList<BillingDto>> GetByPatientIdAsync(Guid patientId);
+        Task<IList<BillingDto>> SearchAsync(string keyword);
+        Task<IList<BillingDto>> GetRefundableBillsAsync();
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/BillingStaffViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/BillingStaffViewModel.cs
@@ -1,6 +1,50 @@
+using LYBT.Module.Billing.Dtos;
+using LYBT.UI.WPF.Services;
+using Prism.Commands;
 using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels {
     public class BillingStaffViewModel : BindableBase {
+        public ObservableCollection<BillingDto> Bills { get; } = new();
+
+        private BillingDto? _selectedBill;
+        public BillingDto? SelectedBill {
+            get => _selectedBill;
+            set => SetProperty(ref _selectedBill, value);
+        }
+
+        public DelegateCommand RefreshCommand { get; }
+        public DelegateCommand MarkPaidCommand { get; }
+
+        private readonly IBillingService _billingService;
+
+        public BillingStaffViewModel(IBillingService billingService) {
+            _billingService = billingService;
+            RefreshCommand = new DelegateCommand(async () => await LoadBills());
+            MarkPaidCommand = new DelegateCommand(async () => await MarkPaid(), () => SelectedBill != null)
+                .ObservesProperty(() => SelectedBill);
+            _ = LoadBills();
+        }
+
+        private async Task LoadBills() {
+            var list = await _billingService.GetAllAsync();
+            Bills.Clear();
+            foreach (var b in list)
+                Bills.Add(b);
+        }
+
+        private async Task MarkPaid() {
+            if (SelectedBill == null)
+                return;
+            bool ok = await _billingService.MarkAsPaidAsync(SelectedBill.Id);
+            if (ok)
+                await LoadBills();
+            else
+                MessageBox.Show("操作失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
     }
 }

--- a/LYBT.UI.WPF/Views/BillingStaffView.xaml
+++ b/LYBT.UI.WPF/Views/BillingStaffView.xaml
@@ -1,7 +1,28 @@
 <UserControl x:Class="LYBT.UI.WPF.Views.BillingStaffView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Control.Resources>
+        <converters:NullToBoolConverter x:Key="NullToBoolConverter" />
+    </Control.Resources>
     <Grid>
-        <TextBlock Text="BillingStaff 页面" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0" />
+            <Button Content="标记已支付" Command="{Binding MarkPaidCommand}" IsEnabled="{Binding SelectedBill, Converter={StaticResource NullToBoolConverter}}" />
+        </StackPanel>
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Bills}" SelectedItem="{Binding SelectedBill, Mode=TwoWay}" AutoGenerateColumns="False">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="病人" Binding="{Binding PatientName}" Width="*" />
+                <DataGridTextColumn Header="金额" Binding="{Binding TotalAmount}" Width="80" />
+                <DataGridTextColumn Header="状态" Binding="{Binding Status}" Width="80" />
+                <DataGridTextColumn Header="时间" Binding="{Binding BillingTime}" Width="130" />
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- integrate Billing API in WPF client
- implement `IBillingApi` interface using Refit
- add `BillingService` and `IBillingService`
- update `BillingStaffViewModel` to load bills and mark as paid
- design basic `BillingStaffView` UI
- register billing services and view in `App.xaml.cs`
- reference Billing module in WPF project

## Testing
- `dotnet build LYBTZYZS.sln -v:m` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_6865631261148333b3edb215424dbd93