### PR TITLE
Implement diagnosis treatment service for WPF

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -28,19 +28,23 @@ namespace LYBT.UI.WPF {
             var authApi = RestService.For<IAuthApi>(httpClient);
             var userApi = RestService.For<IUserApi>(httpClient);
             var billingApi = RestService.For<IBillingApi>(httpClient);
+            var diagnosisTreatmentApi = RestService.For<IDiagnosisTreatmentApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
             var userService = new UserManagementService(userApi);
             var billingService = new BillingService(billingApi);
+            var diagnosisTreatmentService = new DiagnosisTreatmentService(diagnosisTreatmentApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
             containerRegistry.RegisterInstance(userApi);
             containerRegistry.RegisterInstance(billingApi);
+            containerRegistry.RegisterInstance(diagnosisTreatmentApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
+            containerRegistry.RegisterInstance<IDiagnosisTreatmentService>(diagnosisTreatmentService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");

--- a/LYBT.UI.WPF/Services/Api/IDiagnosisTreatmentApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IDiagnosisTreatmentApi.cs
@@ -1,0 +1,24 @@
+using LYBT.Module.DiagnosisTreatment.Models.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IDiagnosisTreatmentApi {
+        [Get("/api/DiagnosisTreatment")]
+        Task<List<DiagnosisTreatmentDto>> GetListAsync();
+
+        [Get("/api/DiagnosisTreatment/{id}")]
+        Task<DiagnosisTreatmentDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/DiagnosisTreatment")]
+        Task<ApiSuccessResponse> AddAsync([Body] DiagnosisTreatmentCreateDto dto);
+
+        [Put("/api/DiagnosisTreatment")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] DiagnosisTreatmentEditDto dto);
+
+        [Delete("/api/DiagnosisTreatment/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/DiagnosisTreatmentService.cs
+++ b/LYBT.UI.WPF/Services/DiagnosisTreatmentService.cs
@@ -1,0 +1,39 @@
+using LYBT.Module.DiagnosisTreatment.Models.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class DiagnosisTreatmentService : IDiagnosisTreatmentService {
+        private readonly IDiagnosisTreatmentApi _api;
+
+        public DiagnosisTreatmentService(IDiagnosisTreatmentApi api) {
+            _api = api;
+        }
+
+        public async Task<IList<DiagnosisTreatmentDto>> GetListAsync() {
+            return await _api.GetListAsync();
+        }
+
+        public async Task<DiagnosisTreatmentDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<bool> AddAsync(DiagnosisTreatmentCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(DiagnosisTreatmentEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+    }
+}
+

--- a/LYBT.UI.WPF/Services/IDiagnosisTreatmentService.cs
+++ b/LYBT.UI.WPF/Services/IDiagnosisTreatmentService.cs
@@ -1,0 +1,14 @@
+using LYBT.Module.DiagnosisTreatment.Models.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IDiagnosisTreatmentService {
+        Task<IList<DiagnosisTreatmentDto>> GetListAsync();
+        Task<DiagnosisTreatmentDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(DiagnosisTreatmentCreateDto dto);
+        Task<bool> UpdateAsync(DiagnosisTreatmentEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+    }
+}


### PR DESCRIPTION
## Summary
- add API interface for DiagnosisTreatment module
- implement service and interface for WPF
- register new service and api in App.xaml.cs

## Testing
- `dotnet build LYBTZYZS.sln -v:m` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865af30199c83338d0804d819fd9e8c