### PR TITLE
Add formula template service support in WPF

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -30,6 +30,7 @@ namespace LYBT.UI.WPF {
             var billingApi = RestService.For<IBillingApi>(httpClient);
             var diagnosisTreatmentApi = RestService.For<IDiagnosisTreatmentApi>(httpClient);
             var doctorApi = RestService.For<IDoctorApi>(httpClient);
+            var formulaTemplateApi = RestService.For<IFormulaTemplateApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
@@ -37,6 +38,7 @@ namespace LYBT.UI.WPF {
             var billingService = new BillingService(billingApi);
             var diagnosisTreatmentService = new DiagnosisTreatmentService(diagnosisTreatmentApi);
             var doctorService = new DoctorService(doctorApi);
+            var formulaTemplateService = new FormulaTemplateService(formulaTemplateApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
@@ -44,11 +46,13 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(billingApi);
             containerRegistry.RegisterInstance(diagnosisTreatmentApi);
             containerRegistry.RegisterInstance(doctorApi);
+            containerRegistry.RegisterInstance(formulaTemplateApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
             containerRegistry.RegisterInstance<IDiagnosisTreatmentService>(diagnosisTreatmentService);
             containerRegistry.RegisterInstance<IDoctorService>(doctorService);
+            containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");

--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\LYBT.Module.Users\LYBT.Module.Users.csproj" />
     <ProjectReference Include="..\LYBT.Module.Billing\LYBT.Module.Billing.csproj" />
     <ProjectReference Include="..\LYBT.Module.Doctors\LYBT.Module.Doctors.csproj" />
+    <ProjectReference Include="..\LYBT.Module.FormulaTemplates\LYBT.Module.FormulaTemplates.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LYBT.UI.WPF/Services/Api/IFormulaTemplateApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IFormulaTemplateApi.cs
@@ -1,0 +1,24 @@
+using LYBT.Module.FormulaTemplates.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IFormulaTemplateApi {
+        [Get("/api/FormulaTemplate")]
+        Task<List<FormulaTemplateDto>> GetListAsync();
+
+        [Get("/api/FormulaTemplate/{id}")]
+        Task<FormulaTemplateDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/FormulaTemplate")]
+        Task<ApiSuccessResponse> AddAsync([Body] FormulaTemplateCreateDto dto);
+
+        [Put("/api/FormulaTemplate")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] FormulaTemplateEditDto dto);
+
+        [Delete("/api/FormulaTemplate/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/FormulaTemplateService.cs
+++ b/LYBT.UI.WPF/Services/FormulaTemplateService.cs
@@ -1,0 +1,38 @@
+using LYBT.Module.FormulaTemplates.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class FormulaTemplateService : IFormulaTemplateService {
+        private readonly IFormulaTemplateApi _api;
+
+        public FormulaTemplateService(IFormulaTemplateApi api) {
+            _api = api;
+        }
+
+        public async Task<IList<FormulaTemplateDto>> GetListAsync() {
+            return await _api.GetListAsync();
+        }
+
+        public async Task<FormulaTemplateDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<bool> AddAsync(FormulaTemplateCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(FormulaTemplateEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+    }
+}

--- a/LYBT.UI.WPF/Services/IFormulaTemplateService.cs
+++ b/LYBT.UI.WPF/Services/IFormulaTemplateService.cs
@@ -1,0 +1,14 @@
+using LYBT.Module.FormulaTemplates.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IFormulaTemplateService {
+        Task<IList<FormulaTemplateDto>> GetListAsync();
+        Task<FormulaTemplateDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(FormulaTemplateCreateDto dto);
+        Task<bool> UpdateAsync(FormulaTemplateEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement FormulaTemplate WPF service and API interface
- register FormulaTemplate service in App.xaml and add module reference

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: Unable to restore packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6865b45300d88333b0aa2a5d63f8a8ee