### PR TITLE
Add Herb service for WPF client

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -31,6 +31,7 @@ namespace LYBT.UI.WPF {
             var diagnosisTreatmentApi = RestService.For<IDiagnosisTreatmentApi>(httpClient);
             var doctorApi = RestService.For<IDoctorApi>(httpClient);
             var formulaTemplateApi = RestService.For<IFormulaTemplateApi>(httpClient);
+            var herbApi = RestService.For<IHerbApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
@@ -39,6 +40,7 @@ namespace LYBT.UI.WPF {
             var diagnosisTreatmentService = new DiagnosisTreatmentService(diagnosisTreatmentApi);
             var doctorService = new DoctorService(doctorApi);
             var formulaTemplateService = new FormulaTemplateService(formulaTemplateApi);
+            var herbService = new HerbService(herbApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
@@ -47,12 +49,14 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(diagnosisTreatmentApi);
             containerRegistry.RegisterInstance(doctorApi);
             containerRegistry.RegisterInstance(formulaTemplateApi);
+            containerRegistry.RegisterInstance(herbApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
             containerRegistry.RegisterInstance<IDiagnosisTreatmentService>(diagnosisTreatmentService);
             containerRegistry.RegisterInstance<IDoctorService>(doctorService);
             containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);
+            containerRegistry.RegisterInstance<IHerbService>(herbService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");

--- a/LYBT.UI.WPF/Services/Api/IHerbApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IHerbApi.cs
@@ -1,0 +1,24 @@
+using LYBT.Module.Herbs.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IHerbApi {
+        [Get("/api/Herb")]
+        Task<List<HerbDto>> GetListAsync();
+
+        [Get("/api/Herb/{id}")]
+        Task<HerbDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/Herb")]
+        Task<ApiSuccessResponse> AddAsync([Body] HerbCreateDto dto);
+
+        [Put("/api/Herb")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] HerbEditDto dto);
+
+        [Delete("/api/Herb/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/HerbService.cs
+++ b/LYBT.UI.WPF/Services/HerbService.cs
@@ -1,0 +1,38 @@
+using LYBT.Module.Herbs.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class HerbService : IHerbService {
+        private readonly IHerbApi _api;
+
+        public HerbService(IHerbApi api) {
+            _api = api;
+        }
+
+        public async Task<IList<HerbDto>> GetListAsync() {
+            return await _api.GetListAsync();
+        }
+
+        public async Task<HerbDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<bool> AddAsync(HerbCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(HerbEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+    }
+}

--- a/LYBT.UI.WPF/Services/IHerbService.cs
+++ b/LYBT.UI.WPF/Services/IHerbService.cs
@@ -1,0 +1,14 @@
+using LYBT.Module.Herbs.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IHerbService {
+        Task<IList<HerbDto>> GetListAsync();
+        Task<HerbDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(HerbCreateDto dto);
+        Task<bool> UpdateAsync(HerbEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement Herb service API interface
- add Herb service for WPF app
- register Herb service and API in App.xaml

## Testing
- `dotnet build --no-restore` *(fails: Assets file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bb5017188333b9356c9d0deb41d1