### PR TITLE
Add patient service to WPF

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -32,6 +32,7 @@ namespace LYBT.UI.WPF {
             var doctorApi = RestService.For<IDoctorApi>(httpClient);
             var formulaTemplateApi = RestService.For<IFormulaTemplateApi>(httpClient);
             var herbApi = RestService.For<IHerbApi>(httpClient);
+            var patientApi = RestService.For<IPatientApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
@@ -41,6 +42,7 @@ namespace LYBT.UI.WPF {
             var doctorService = new DoctorService(doctorApi);
             var formulaTemplateService = new FormulaTemplateService(formulaTemplateApi);
             var herbService = new HerbService(herbApi);
+            var patientService = new PatientService(patientApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
@@ -50,6 +52,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(doctorApi);
             containerRegistry.RegisterInstance(formulaTemplateApi);
             containerRegistry.RegisterInstance(herbApi);
+            containerRegistry.RegisterInstance(patientApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
@@ -57,6 +60,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IDoctorService>(doctorService);
             containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);
             containerRegistry.RegisterInstance<IHerbService>(herbService);
+            containerRegistry.RegisterInstance<IPatientService>(patientService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");

--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\LYBT.Module.Billing\LYBT.Module.Billing.csproj" />
     <ProjectReference Include="..\LYBT.Module.Doctors\LYBT.Module.Doctors.csproj" />
     <ProjectReference Include="..\LYBT.Module.FormulaTemplates\LYBT.Module.FormulaTemplates.csproj" />
+    <ProjectReference Include="..\LYBT.Module.Patients\LYBT.Module.Patients.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LYBT.UI.WPF/Services/Api/IPatientApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IPatientApi.cs
@@ -1,0 +1,56 @@
+using LYBT.Common.Models;
+using LYBT.Module.Patients.Dtos;
+using LYBT.Module.Records.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IPatientApi {
+        [Post("/api/Patients/add")]
+        Task<ApiSuccessResponse> AddAsync([Body] PatientCreateDto dto);
+
+        [Put("/api/Patients/edit")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] PatientEditDto dto);
+
+        [Put("/api/Patients/enable/{id}")]
+        Task<ApiSuccessResponse> EnableAsync(Guid id);
+
+        [Put("/api/Patients/disable/{id}")]
+        Task<ApiSuccessResponse> DisableAsync(Guid id);
+
+        [Get("/api/Patients/get/{id}")]
+        Task<PatientDetailDto> GetByIdAsync(Guid id);
+
+        [Get("/api/Patients/all")]
+        Task<List<PatientDto>> GetAllAsync();
+
+        [Post("/api/Patients/paged")]
+        Task<PagedResultDto<PatientDto>> GetPagedAsync([Body] PatientPagedQueryDto query);
+
+        [Post("/api/Patients/batchDelete")]
+        Task<ApiSuccessResponse> BatchDeleteAsync([Body] List<string> ids);
+
+        [Put("/api/Patients/batch-disable")]
+        Task<ApiSuccessResponse> BatchDisableAsync([Body] BatchIdsDto dto);
+
+        [Get("/api/Patients/search")]
+        Task<List<PatientDto>> SearchAsync([Query] string keyword);
+
+        [Get("/api/Patients/doctor/{doctorId}")]
+        Task<List<PatientDto>> GetForDoctorAsync(Guid doctorId);
+
+        [Post("/api/Patients/{id}/assign-doctor")]
+        Task<ApiSuccessResponse> AssignDoctorAsync(Guid id, [Body] AssignDoctorDto dto);
+
+        [Post("/api/Patients/import")]
+        Task<ApiSuccessResponse> ImportAsync([Body] List<PatientCreateDto> dtos);
+
+        [Post("/api/Patients/export")]
+        Task<List<PatientDto>> ExportAsync();
+
+        [Get("/api/Patients/{id}/records")]
+        Task<List<RecordDto>> GetHistoryAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/IPatientService.cs
+++ b/LYBT.UI.WPF/Services/IPatientService.cs
@@ -1,0 +1,26 @@
+using LYBT.Common.Models;
+using LYBT.Module.Patients.Dtos;
+using LYBT.Module.Records.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IPatientService {
+        Task<bool> AddAsync(PatientCreateDto dto);
+        Task<bool> UpdateAsync(PatientEditDto dto);
+        Task<bool> EnableAsync(Guid id);
+        Task<bool> DisableAsync(Guid id);
+        Task<PatientDetailDto?> GetByIdAsync(Guid id);
+        Task<IList<PatientDto>> GetAllAsync();
+        Task<PagedResultDto<PatientDto>> GetPagedAsync(PatientPagedQueryDto query);
+        Task<int> BatchDeleteAsync(List<string> ids);
+        Task<int> BatchDisableAsync(List<Guid> ids);
+        Task<IList<PatientDto>> SearchAsync(string keyword);
+        Task<IList<PatientDto>> GetForDoctorAsync(Guid doctorId);
+        Task<bool> AssignDoctorAsync(Guid patientId, Guid doctorId);
+        Task<int> ImportAsync(List<PatientCreateDto> dtos);
+        Task<IList<PatientDto>> ExportAsync();
+        Task<IList<RecordDto>> GetHistoryAsync(Guid patientId);
+    }
+}

--- a/LYBT.UI.WPF/Services/PatientService.cs
+++ b/LYBT.UI.WPF/Services/PatientService.cs
@@ -1,0 +1,84 @@
+using LYBT.Common.Models;
+using LYBT.Module.Patients.Dtos;
+using LYBT.Module.Records.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class PatientService : IPatientService {
+        private readonly IPatientApi _api;
+        public PatientService(IPatientApi api) {
+            _api = api;
+        }
+
+        public async Task<bool> AddAsync(PatientCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(PatientEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> EnableAsync(Guid id) {
+            var resp = await _api.EnableAsync(id);
+            return resp.Success;
+        }
+
+        public async Task<bool> DisableAsync(Guid id) {
+            var resp = await _api.DisableAsync(id);
+            return resp.Success;
+        }
+
+        public async Task<PatientDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<IList<PatientDto>> GetAllAsync() {
+            return await _api.GetAllAsync();
+        }
+
+        public async Task<PagedResultDto<PatientDto>> GetPagedAsync(PatientPagedQueryDto query) {
+            return await _api.GetPagedAsync(query);
+        }
+
+        public async Task<int> BatchDeleteAsync(List<string> ids) {
+            var resp = await _api.BatchDeleteAsync(ids);
+            return resp.Count ?? 0;
+        }
+
+        public async Task<int> BatchDisableAsync(List<Guid> ids) {
+            var resp = await _api.BatchDisableAsync(new BatchIdsDto { Ids = ids });
+            return resp.Count ?? 0;
+        }
+
+        public async Task<IList<PatientDto>> SearchAsync(string keyword) {
+            return await _api.SearchAsync(keyword);
+        }
+
+        public async Task<IList<PatientDto>> GetForDoctorAsync(Guid doctorId) {
+            return await _api.GetForDoctorAsync(doctorId);
+        }
+
+        public async Task<bool> AssignDoctorAsync(Guid patientId, Guid doctorId) {
+            var resp = await _api.AssignDoctorAsync(patientId, new AssignDoctorDto { DoctorId = doctorId });
+            return resp.Success;
+        }
+
+        public async Task<int> ImportAsync(List<PatientCreateDto> dtos) {
+            var resp = await _api.ImportAsync(dtos);
+            return resp.Count ?? 0;
+        }
+
+        public async Task<IList<PatientDto>> ExportAsync() {
+            return await _api.ExportAsync();
+        }
+
+        public async Task<IList<RecordDto>> GetHistoryAsync(Guid patientId) {
+            return await _api.GetHistoryAsync(patientId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `IPatientApi` for Web API endpoints
- add `IPatientService` and `PatientService` to call the API
- register the service in `App.xaml.cs`
- reference patients module in WPF csproj

## Testing
- `dotnet build LYBT.UI.WPF/LYBT.UI.WPF.csproj -nologo` *(fails: Unable to load the service index for nuget.org)*

------
https://chatgpt.com/codex/tasks/task_e_6865e12f15a88333b4f1fedebc8f6324