### PR TITLE
Implement Pharmacy service in WPF

### DIFF
--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -37,6 +37,7 @@
     <ProjectReference Include="..\LYBT.Module.Doctors\LYBT.Module.Doctors.csproj" />
     <ProjectReference Include="..\LYBT.Module.FormulaTemplates\LYBT.Module.FormulaTemplates.csproj" />
     <ProjectReference Include="..\LYBT.Module.Patients\LYBT.Module.Patients.csproj" />
+    <ProjectReference Include="..\LYBT.Module.Pharmacy\LYBT.Module.Pharmacy.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LYBT.UI.WPF/Services/Api/IPharmacyApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IPharmacyApi.cs
@@ -1,0 +1,30 @@
+using LYBT.Module.Pharmacy.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IPharmacyApi {
+        [Get("/api/Pharmacy/waiting")]
+        Task<List<PharmacyDto>> GetWaitingListAsync();
+
+        [Get("/api/Pharmacy")]
+        Task<List<PharmacyDto>> GetListAsync();
+
+        [Get("/api/Pharmacy/{id}")]
+        Task<PharmacyDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/Pharmacy")]
+        Task<ApiSuccessResponse> AddAsync([Body] PharmacyCreateDto dto);
+
+        [Put("/api/Pharmacy")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] PharmacyEditDto dto);
+
+        [Delete("/api/Pharmacy/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+
+        [Post("/api/Pharmacy/{id}/prepared")]
+        Task<ApiSuccessResponse> MarkAsPreparedAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/IPharmacyService.cs
+++ b/LYBT.UI.WPF/Services/IPharmacyService.cs
@@ -1,0 +1,16 @@
+using LYBT.Module.Pharmacy.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IPharmacyService {
+        Task<IList<PharmacyDto>> GetWaitingListAsync();
+        Task<IList<PharmacyDto>> GetListAsync();
+        Task<PharmacyDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(PharmacyCreateDto dto);
+        Task<bool> UpdateAsync(PharmacyEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+        Task<bool> MarkAsPreparedAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/PharmacyService.cs
+++ b/LYBT.UI.WPF/Services/PharmacyService.cs
@@ -1,0 +1,47 @@
+using LYBT.Module.Pharmacy.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class PharmacyService : IPharmacyService {
+        private readonly IPharmacyApi _api;
+
+        public PharmacyService(IPharmacyApi api) {
+            _api = api;
+        }
+
+        public async Task<IList<PharmacyDto>> GetWaitingListAsync() {
+            return await _api.GetWaitingListAsync();
+        }
+
+        public async Task<IList<PharmacyDto>> GetListAsync() {
+            return await _api.GetListAsync();
+        }
+
+        public async Task<PharmacyDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<bool> AddAsync(PharmacyCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(PharmacyEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+
+        public async Task<bool> MarkAsPreparedAsync(Guid id) {
+            var resp = await _api.MarkAsPreparedAsync(id);
+            return resp.Success;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add IPharmacyApi to call Pharmacy endpoints
- add PharmacyService and interface in WPF
- reference Pharmacy module in WPF project

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865e7b9998883339af26956ab255a48