### PR TITLE
Implement queueing WPF service

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -33,6 +33,7 @@ namespace LYBT.UI.WPF {
             var formulaTemplateApi = RestService.For<IFormulaTemplateApi>(httpClient);
             var herbApi = RestService.For<IHerbApi>(httpClient);
             var patientApi = RestService.For<IPatientApi>(httpClient);
+            var queueingApi = RestService.For<IQueueingApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
@@ -43,6 +44,7 @@ namespace LYBT.UI.WPF {
             var formulaTemplateService = new FormulaTemplateService(formulaTemplateApi);
             var herbService = new HerbService(herbApi);
             var patientService = new PatientService(patientApi);
+            var queueingService = new QueueingService(queueingApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
@@ -53,6 +55,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(formulaTemplateApi);
             containerRegistry.RegisterInstance(herbApi);
             containerRegistry.RegisterInstance(patientApi);
+            containerRegistry.RegisterInstance(queueingApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
@@ -61,6 +64,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);
             containerRegistry.RegisterInstance<IHerbService>(herbService);
             containerRegistry.RegisterInstance<IPatientService>(patientService);
+            containerRegistry.RegisterInstance<IQueueingService>(queueingService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");

--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\LYBT.Module.FormulaTemplates\LYBT.Module.FormulaTemplates.csproj" />
     <ProjectReference Include="..\LYBT.Module.Patients\LYBT.Module.Patients.csproj" />
     <ProjectReference Include="..\LYBT.Module.Pharmacy\LYBT.Module.Pharmacy.csproj" />
+    <ProjectReference Include="..\LYBT.Module.Queueing\LYBT.Module.Queueing.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LYBT.UI.WPF/Services/Api/IQueueingApi.cs
+++ b/LYBT.UI.WPF/Services/Api/IQueueingApi.cs
@@ -1,0 +1,24 @@
+using LYBT.Module.Queueing.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface IQueueingApi {
+        [Get("/api/Queueing")]
+        Task<List<QueueingDto>> GetListAsync();
+
+        [Get("/api/Queueing/{id}")]
+        Task<QueueingDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/Queueing")]
+        Task<ApiSuccessResponse> AddAsync([Body] QueueingCreateDto dto);
+
+        [Put("/api/Queueing")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] QueueingEditDto dto);
+
+        [Delete("/api/Queueing/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/IQueueingService.cs
+++ b/LYBT.UI.WPF/Services/IQueueingService.cs
@@ -1,0 +1,14 @@
+using LYBT.Module.Queueing.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface IQueueingService {
+        Task<IList<QueueingDto>> GetListAsync();
+        Task<QueueingDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(QueueingCreateDto dto);
+        Task<bool> UpdateAsync(QueueingEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/QueueingService.cs
+++ b/LYBT.UI.WPF/Services/QueueingService.cs
@@ -1,0 +1,38 @@
+using LYBT.Module.Queueing.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class QueueingService : IQueueingService {
+        private readonly IQueueingApi _api;
+
+        public QueueingService(IQueueingApi api) {
+            _api = api;
+        }
+
+        public async Task<IList<QueueingDto>> GetListAsync() {
+            return await _api.GetListAsync();
+        }
+
+        public async Task<QueueingDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<bool> AddAsync(QueueingCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(QueueingEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add queueing API definitions for WPF
- create queueing service interface and implementation
- register new service and API in the WPF app startup
- reference queueing module in WPF project

## Testing
- `dotnet build -c Release` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*
- `dotnet format --verify-no-changes` *(fails: Restore operation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6865e9ffc6008333acc06f6fd15460a8