### PR TITLE
Add log service for WPF

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -36,6 +36,7 @@ namespace LYBT.UI.WPF {
             var queueingApi = RestService.For<IQueueingApi>(httpClient);
             var recordApi = RestService.For<IRecordApi>(httpClient);
             var registrationApi = RestService.For<IRegistrationApi>(httpClient);
+            var logApi = RestService.For<ILogApi>(httpClient);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！  
             var authService = new AuthService(authApi);
@@ -49,6 +50,7 @@ namespace LYBT.UI.WPF {
             var queueingService = new QueueingService(queueingApi);
             var recordService = new RecordService(recordApi);
             var registrationService = new RegistrationService(registrationApi);
+            var logService = new LogService(logApi);
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
@@ -62,6 +64,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(queueingApi);
             containerRegistry.RegisterInstance(recordApi);
             containerRegistry.RegisterInstance(registrationApi);
+            containerRegistry.RegisterInstance(logApi);
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserManagementService>(userService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
@@ -73,6 +76,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IQueueingService>(queueingService);
             containerRegistry.RegisterInstance<IRecordService>(recordService);
             containerRegistry.RegisterInstance<IRegistrationService>(registrationService);
+            containerRegistry.RegisterInstance<ILogService>(logService);
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");

--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\LYBT.Module.Queueing\LYBT.Module.Queueing.csproj" />
     <ProjectReference Include="..\LYBT.Module.Records\LYBT.Module.Records.csproj" />
     <ProjectReference Include="..\LYBT.Module.Registration\LYBT.Module.Registration.csproj" />
+    <ProjectReference Include="..\LYBT.Module.Logs\LYBT.Module.Logs.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LYBT.UI.WPF/Services/Api/ILogApi.cs
+++ b/LYBT.UI.WPF/Services/Api/ILogApi.cs
@@ -1,0 +1,30 @@
+using LYBT.Module.Logs.Dtos;
+using Refit;
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface ILogApi {
+        [Post("/api/Log")]
+        Task<AddLogResponse> AddAsync([Body] LogDto dto);
+
+        [Get("/api/Log")]
+        Task<GetLogsResponse> GetLogsAsync([Query] LogQueryDto query);
+
+        [Get("/api/Log/user/{userId}")]
+        Task<GetLogsResponse> GetUserLogsAsync(Guid userId, [Query] int page = 1, [Query] int pageSize = 20);
+
+        [Get("/api/Log/patient/{patientId}")]
+        Task<GetLogsResponse> GetPatientLogsAsync(Guid patientId, [Query] int page = 1, [Query] int pageSize = 20);
+
+        [Get("/api/Log/record/{recordId}")]
+        Task<GetLogsResponse> GetRecordLogsAsync(Guid recordId, [Query] int page = 1, [Query] int pageSize = 20);
+
+        [Get("/api/Log/prescription/{prescriptionId}")]
+        Task<GetLogsResponse> GetPrescriptionLogsAsync(Guid prescriptionId, [Query] int page = 1, [Query] int pageSize = 20);
+
+        [Get("/api/Log/{id}")]
+        Task<LogDto> GetByIdAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/Api/LogApiModels.cs
+++ b/LYBT.UI.WPF/Services/Api/LogApiModels.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using LYBT.Module.Logs.Dtos;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public class AddLogResponse {
+        public bool Success { get; set; }
+        public Guid Id { get; set; }
+    }
+
+    public class GetLogsResponse {
+        public int Total { get; set; }
+        public List<LogDto> Logs { get; set; } = new();
+    }
+}

--- a/LYBT.UI.WPF/Services/ILogService.cs
+++ b/LYBT.UI.WPF/Services/ILogService.cs
@@ -1,0 +1,16 @@
+using LYBT.Module.Logs.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface ILogService {
+        Task<Guid?> AddAsync(LogDto dto);
+        Task<(IList<LogDto> Logs, int Total)> GetLogsAsync(LogQueryDto query);
+        Task<(IList<LogDto> Logs, int Total)> GetUserLogsAsync(Guid userId, int page = 1, int pageSize = 20);
+        Task<(IList<LogDto> Logs, int Total)> GetPatientLogsAsync(Guid patientId, int page = 1, int pageSize = 20);
+        Task<(IList<LogDto> Logs, int Total)> GetRecordLogsAsync(Guid recordId, int page = 1, int pageSize = 20);
+        Task<(IList<LogDto> Logs, int Total)> GetPrescriptionLogsAsync(Guid prescriptionId, int page = 1, int pageSize = 20);
+        Task<LogDto?> GetByIdAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/LogService.cs
+++ b/LYBT.UI.WPF/Services/LogService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using LYBT.Module.Logs.Dtos;
+using LYBT.UI.WPF.Services.Api;
+
+namespace LYBT.UI.WPF.Services {
+    public class LogService : ILogService {
+        private readonly ILogApi _api;
+
+        public LogService(ILogApi api) {
+            _api = api;
+        }
+
+        public async Task<Guid?> AddAsync(LogDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success ? resp.Id : null;
+        }
+
+        public async Task<(IList<LogDto> Logs, int Total)> GetLogsAsync(LogQueryDto query) {
+            var resp = await _api.GetLogsAsync(query);
+            return (resp.Logs, resp.Total);
+        }
+
+        public async Task<(IList<LogDto> Logs, int Total)> GetUserLogsAsync(Guid userId, int page = 1, int pageSize = 20) {
+            var resp = await _api.GetUserLogsAsync(userId, page, pageSize);
+            return (resp.Logs, resp.Total);
+        }
+
+        public async Task<(IList<LogDto> Logs, int Total)> GetPatientLogsAsync(Guid patientId, int page = 1, int pageSize = 20) {
+            var resp = await _api.GetPatientLogsAsync(patientId, page, pageSize);
+            return (resp.Logs, resp.Total);
+        }
+
+        public async Task<(IList<LogDto> Logs, int Total)> GetRecordLogsAsync(Guid recordId, int page = 1, int pageSize = 20) {
+            var resp = await _api.GetRecordLogsAsync(recordId, page, pageSize);
+            return (resp.Logs, resp.Total);
+        }
+
+        public async Task<(IList<LogDto> Logs, int Total)> GetPrescriptionLogsAsync(Guid prescriptionId, int page = 1, int pageSize = 20) {
+            var resp = await _api.GetPrescriptionLogsAsync(prescriptionId, page, pageSize);
+            return (resp.Logs, resp.Total);
+        }
+
+        public async Task<LogDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add WPF log api interfaces and models
- add WPF log service implementation
- register log service and api in App.xaml
- reference Log module in WPF project

## Testing
- `dotnet build LYBTZYZS.sln -v q` *(fails: unable to restore nuget packages)*

------
https://chatgpt.com/codex/tasks/task_e_6865ef91a7ec8333bc5149393b32e580