### PR TITLE
Add TreatmentRoom service to WPF

### DIFF
--- a/LYBT.UI.WPF/LYBT.UI.WPF.csproj
+++ b/LYBT.UI.WPF/LYBT.UI.WPF.csproj
@@ -44,6 +44,7 @@
     <ProjectReference Include="..\LYBT.Module.Logs\LYBT.Module.Logs.csproj" />
     <ProjectReference Include="..\LYBT.Module.Settings\LYBT.Module.Settings.csproj" />
     <ProjectReference Include="..\LYBT.Module.DiagnosisTreatment\LYBT.Module.DiagnosisTreatment.csproj" />
+    <ProjectReference Include="..\LYBT.Module.TreatmentRoom\LYBT.Module.TreatmentRoom.csproj" />
     <ProjectReference Include="..\LYBT.Module.Sync\LYBT.Module.Sync.csproj" />
   </ItemGroup>
 

--- a/LYBT.UI.WPF/Services/Api/ITreatmentRoomApi.cs
+++ b/LYBT.UI.WPF/Services/Api/ITreatmentRoomApi.cs
@@ -1,0 +1,24 @@
+using LYBT.Module.TreatmentRoom.Dtos;
+using Refit;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services.Api {
+    public interface ITreatmentRoomApi {
+        [Get("/api/TreatmentRoom")]
+        Task<List<TreatmentRoomDto>> GetListAsync();
+
+        [Get("/api/TreatmentRoom/{id}")]
+        Task<TreatmentRoomDetailDto> GetByIdAsync(Guid id);
+
+        [Post("/api/TreatmentRoom")]
+        Task<ApiSuccessResponse> AddAsync([Body] TreatmentRoomCreateDto dto);
+
+        [Put("/api/TreatmentRoom")]
+        Task<ApiSuccessResponse> UpdateAsync([Body] TreatmentRoomEditDto dto);
+
+        [Delete("/api/TreatmentRoom/{id}")]
+        Task<ApiSuccessResponse> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/ITreatmentRoomService.cs
+++ b/LYBT.UI.WPF/Services/ITreatmentRoomService.cs
@@ -1,0 +1,14 @@
+using LYBT.Module.TreatmentRoom.Dtos;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public interface ITreatmentRoomService {
+        Task<IList<TreatmentRoomDto>> GetListAsync();
+        Task<TreatmentRoomDetailDto?> GetByIdAsync(Guid id);
+        Task<bool> AddAsync(TreatmentRoomCreateDto dto);
+        Task<bool> UpdateAsync(TreatmentRoomEditDto dto);
+        Task<bool> DeleteAsync(Guid id);
+    }
+}

--- a/LYBT.UI.WPF/Services/TreatmentRoomService.cs
+++ b/LYBT.UI.WPF/Services/TreatmentRoomService.cs
@@ -1,0 +1,38 @@
+using LYBT.Module.TreatmentRoom.Dtos;
+using LYBT.UI.WPF.Services.Api;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.Services {
+    public class TreatmentRoomService : ITreatmentRoomService {
+        private readonly ITreatmentRoomApi _api;
+
+        public TreatmentRoomService(ITreatmentRoomApi api) {
+            _api = api;
+        }
+
+        public async Task<IList<TreatmentRoomDto>> GetListAsync() {
+            return await _api.GetListAsync();
+        }
+
+        public async Task<TreatmentRoomDetailDto?> GetByIdAsync(Guid id) {
+            return await _api.GetByIdAsync(id);
+        }
+
+        public async Task<bool> AddAsync(TreatmentRoomCreateDto dto) {
+            var resp = await _api.AddAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> UpdateAsync(TreatmentRoomEditDto dto) {
+            var resp = await _api.UpdateAsync(dto);
+            return resp.Success;
+        }
+
+        public async Task<bool> DeleteAsync(Guid id) {
+            var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ITreatmentRoomApi` interface with routes matching WebAPI controller
- implement `ITreatmentRoomService` and `TreatmentRoomService`
- reference `LYBT.Module.TreatmentRoom` in WPF project

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6865f6cb4438833393b9a66d4796b829