### PR TITLE
Improve UserManagementView sync

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -35,7 +35,28 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         /// <summary>
         /// 属性 SelectedUser 的说明
         /// </summary>
-        public UserDto SelectedUser { get => _selectedUser; set => SetProperty(ref _selectedUser, value); }
+        public UserDto SelectedUser {
+            get => _selectedUser;
+            set {
+                if (SetProperty(ref _selectedUser, value)) {
+                    if (value != null) {
+                        // 选择用户时复制一份到编辑区，避免直接修改列表项
+                        EditingUser = new UserDto {
+                            Id = value.Id,
+                            UserName = value.UserName,
+                            RealName = value.RealName,
+                            Role = value.Role,
+                            Roles = new System.Collections.Generic.List<UserRole>(value.Roles),
+                            IsActive = value.IsActive,
+                            Email = value.Email,
+                            PhoneNumber = value.PhoneNumber
+                        };
+                        EditModeTitle = "编辑用户";
+                        Password = string.Empty;
+                    }
+                }
+            }
+        }
 
         private string _searchKeyword = string.Empty;
         /// <summary>
@@ -104,6 +125,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 IsActive = true,
                 Role = RoleList.Count > 0 ? RoleList[0] : UserRole.DiagnosingDoctor // 默认角色
             };
+            SelectedUser = null;
             EditModeTitle = "新增用户";
             Password = string.Empty;
         }

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
@@ -19,6 +19,23 @@ namespace LYBT.UI.WPF.Views.Admin {
     public partial class UserManagementView : UserControl {
         public UserManagementView() {
             InitializeComponent();
+            DataContextChanged += UserManagementView_DataContextChanged;
+        }
+
+        private void UserManagementView_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
+            if (e.OldValue is ViewModels.Admin.UserManagementViewModel oldVm)
+                oldVm.PropertyChanged -= Vm_PropertyChanged;
+            if (e.NewValue is ViewModels.Admin.UserManagementViewModel newVm)
+                newVm.PropertyChanged += Vm_PropertyChanged;
+        }
+
+        private void Vm_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
+            if (sender is ViewModels.Admin.UserManagementViewModel vm) {
+                if (e.PropertyName == nameof(vm.Password) || e.PropertyName == nameof(vm.EditingUser)) {
+                    if (passwordBox.Password != vm.Password)
+                        passwordBox.Password = vm.Password ?? string.Empty;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- sync selected user to editing fields
- clear password when switching selection
- keep password box in sync with view model

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686608a1396c8333ba7b26c3974ac52c