### PR TITLE
支持通过配置文件控制默认密码

### DIFF
--- a/LYBT.Module.Users/README.md
+++ b/LYBT.Module.Users/README.md
@@ -24,7 +24,7 @@
 自 `v2` 起，用户支持多角色分配，`UserCreateDto` 和 `UserEditDto` 均采用
 `Roles` 列表并要求至少包含一个角色。
 
-新增用户时系统会自动生成初始密码，其规则可在 `appsettings.json` 的
-`UserDefaults` 节点中配置（如 `InitialPasswordLength`）。管理员需告知
+新增用户时系统会自动生成初始密码，密码值可在 `appsettings.json` 的
+`UserDefaults:DefaultUserPassword` 中配置。管理员需告知
 用户此密码以便首次登录后修改。重置密码接口仍需明确提供新密码。
 

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -8,6 +8,7 @@ using LYBT.Module.Logs.Interfaces;
 using LYBT.Module.Users.Dtos;
 using LYBT.Module.Users.Models;
 using LYBT.Module.Users;
+using Microsoft.Extensions.Options;
 
 /// <summary>
 /// 用户服务实现类（集成日志模块）
@@ -15,10 +16,12 @@ using LYBT.Module.Users;
 public class UserService : IUserService {
     private readonly IUserRepository _userRepository;
     private readonly ILogService _logService; // 日志服务
+    private readonly UserOptions _options;
 
-    public UserService(IUserRepository userRepository, ILogService logService) {
+    public UserService(IUserRepository userRepository, ILogService logService, IOptions<UserOptions> options) {
         _userRepository = userRepository;
         _logService = logService;
+        _options = options.Value;
     }
 
     /// <summary>
@@ -83,7 +86,7 @@ public class UserService : IUserService {
             PhoneNumber = dto.PhoneNumber,
             CreatedTime = DateTime.Now,
 
-            PasswordHash = PasswordHelper.Hash(UserDefaults.DefaultUserPassword)
+            PasswordHash = PasswordHelper.Hash(_options.DefaultUserPassword)
         };
         var result = await _userRepository.AddAsync(user);
 

--- a/LYBT.Module.Users/UserDefaults.cs
+++ b/LYBT.Module.Users/UserDefaults.cs
@@ -1,9 +1,0 @@
-namespace LYBT.Module.Users;
-
-/// <summary>
-/// Provides default values related to the Users module.
-/// </summary>
-public static class UserDefaults {
-    /// <summary>Default password assigned when creating new users.</summary>
-    public const string DefaultUserPassword = "ChangeMe123";
-}

--- a/LYBT.Module.Users/UserOptions.cs
+++ b/LYBT.Module.Users/UserOptions.cs
@@ -1,0 +1,9 @@
+namespace LYBT.Module.Users;
+
+/// <summary>
+/// 用户模块的配置项
+/// </summary>
+public class UserOptions {
+    /// <summary>新建用户的默认密码</summary>
+    public string DefaultUserPassword { get; set; } = "ChangeMe123";
+}

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -24,7 +24,7 @@ public class UsersController : ControllerBase {
     }
 
     /// <summary>
-    /// 新增用户，密码将设为 <see cref="UserDefaults.DefaultUserPassword"/>
+    /// 新增用户，密码将设为配置的默认值
     /// </summary>
     [HttpPost("add")]
     public async Task<IActionResult> Add([FromBody] UserCreateDto dto) {

--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -48,11 +48,14 @@ using LYBT.Module.Sync.Mapping;
 using LYBT.Module.Sync.Repositories;
 using LYBT.Module.Sync.Services;
 using LYBT.Module.Users.Mapping;
+using LYBT.Module.Users;
 using LYBT.WebAPI.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<UserOptions>(builder.Configuration.GetSection("UserDefaults"));
 
 // =========== 1. 注册所有模块的 Service 和 Repository ===========
 

--- a/LYBT.WebAPI/README.md
+++ b/LYBT.WebAPI/README.md
@@ -1,10 +1,5 @@
 # LYBT.WebAPI
 
-The ASP.NET Core API project that wires up all modules, registers their services and dependencies, and exposes REST endpoints for clients.
+ASP.NET Core API 项目，负责整合所有业务模块并向客户端提供 REST 接口。
 
-
-When creating users, the API automatically assigns an initial password based on
-`UserDefaults` settings in `appsettings.json`. Password reset operations still
-require callers to provide the new password in the request body.
-
-
+创建用户时，系统会根据 `appsettings.json` 中 `UserDefaults:DefaultUserPassword` 的设置自动生成初始密码。重置密码操作仍需在请求体中提供新密码。

--- a/LYBT.WebAPI/appsettings.example.json
+++ b/LYBT.WebAPI/appsettings.example.json
@@ -12,6 +12,9 @@
     "Audience": "LYBT.Client",
     "ExpireMinutes": 60
   },
+  "UserDefaults": {
+    "DefaultUserPassword": "ChangeMe123"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -12,6 +12,9 @@
     "Audience": "LYBT.Client",
     "ExpireMinutes": 60
   },
+  "UserDefaults": {
+    "DefaultUserPassword": "ChangeMe123"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
- 删除硬编码的 `UserDefaults.DefaultUserPassword`
- 新增 `UserOptions` 配置类
- `UserService` 注入 `UserOptions` 并使用配置的默认密码
- `Program` 注册 `UserOptions`
- 更新 `appsettings.json` 与示例配置
- 更新用户与 WebAPI 的说明文档

## Testing
- `dotnet build -c Release` *(fails: missing namespaces)*
- `dotnet test --no-build` *(produces only welcome output)*

------
https://chatgpt.com/codex/tasks/task_e_68660e99bca0833383d5195f5407f876