### PR TITLE
Implement default password reset and role selection

### DIFF
--- a/LYBT.Module.Users/Dtos/UserDetailDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDetailDto.cs
@@ -1,56 +1,36 @@
-﻿using LYBT.Common.Enums.Users;
+using LYBT.Common.Enums.Users;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace LYBT.Module.Users.Dtos {
-
     /// <summary>
-    /// 编辑用户请求 DTO，用于修改用户资料（带校验注解）
+    /// 用户详情 DTO，用于用户资料查看与编辑（不包含密码）
     /// </summary>
-    public class UserEditDto {
-
-        /// <summary>
-        /// 用户唯一标识（主键，Guid 类型，必填）
-        /// </summary>
+    public class UserDetailDto {
+        /// <summary>用户唯一标识（主键，Guid 类型，必填）</summary>
         [Required(ErrorMessage = "用户ID不能为空")]
         public Guid Id { get; set; }
 
-        /// <summary>
-        /// 真实姓名
-        /// </summary>
+        /// <summary>真实姓名</summary>
         [Required(ErrorMessage = "真实姓名不能为空")]
         [StringLength(20, ErrorMessage = "真实姓名长度不能超过20个字符")]
         public string RealName { get; set; } = string.Empty;
 
-        /// <summary>
-        /// 多个用户角色（至少一个）
-        /// </summary>
+        /// <summary>多个用户角色（至少一个）</summary>
         [Required(ErrorMessage = "用户角色不能为空")]
         [MinLength(1, ErrorMessage = "至少指定一个角色")]
         public List<UserRole> Roles { get; set; } = new();
 
-        /// <summary>
-        /// 账号启用状态（true=启用，false=禁用，必填）
-        /// </summary>
+        /// <summary>账号启用状态（true=启用，false=禁用，必填）</summary>
         [Required(ErrorMessage = "账号启用状态不能为空")]
         public bool IsActive { get; set; }
 
-        /// <summary>
-        /// 邮箱地址
-        /// </summary>
+        /// <summary>邮箱地址</summary>
         [EmailAddress(ErrorMessage = "邮箱格式不正确")]
         public string? Email { get; set; }
 
-        /// <summary>
-        /// 联系电话
-        /// </summary>
+        /// <summary>联系电话</summary>
         [Phone(ErrorMessage = "联系电话格式不正确")]
         public string? PhoneNumber { get; set; }
-
-        /// <summary>
-        /// 新密码（可选，留空表示不修改。修改密码时必须符合长度要求）
-        /// </summary>
-        [StringLength(32, MinimumLength = 6, ErrorMessage = "密码长度必须在6-32个字符之间")]
-        public string? Password { get; set; }
     }
 }

--- a/LYBT.Module.Users/Interfaces/IUserService.cs
+++ b/LYBT.Module.Users/Interfaces/IUserService.cs
@@ -24,7 +24,7 @@ public interface IUserService {
     /// <summary>
     /// 编辑用户
     /// </summary>
-    Task<bool> UpdateAsync(UserEditDto dto, Guid operatorId, string operatorName);
+    Task<bool> UpdateAsync(UserDetailDto dto, Guid operatorId, string operatorName);
 
     /// <summary>
     /// 禁用用户
@@ -47,9 +47,9 @@ public interface IUserService {
     Task<int> BatchEnableAsync(List<Guid> ids, Guid operatorId, string operatorName);
 
     /// <summary>
-    /// 管理员重置密码
+    /// 管理员重置密码为默认值
     /// </summary>
-    Task<bool> ResetPasswordAsync(Guid id, string newPassword, Guid operatorId, string operatorName);
+    Task<bool> ResetPasswordAsync(Guid id, Guid operatorId, string operatorName);
 
     /// <summary>
     /// 用户修改密码

--- a/LYBT.Module.Users/Mapping/UserMappingProfile.cs
+++ b/LYBT.Module.Users/Mapping/UserMappingProfile.cs
@@ -18,8 +18,8 @@ namespace LYBT.Module.Users.Mapping {
                     opt => opt.MapFrom(src => src.Roles.FirstOrDefault()));
             // 新增DTO转实体
             CreateMap<UserCreateDto, UserModel>();
-            // 编辑DTO转实体（密码字段需单独处理）
-            CreateMap<UserEditDto, UserModel>()
+            // 详情DTO转实体
+            CreateMap<UserDetailDto, UserModel>()
                 .ForMember(dest => dest.PasswordHash, opt => opt.Ignore());
         }
     }

--- a/LYBT.Module.Users/README.md
+++ b/LYBT.Module.Users/README.md
@@ -21,10 +21,10 @@
 
 本模块的 DTO 均使用数据注解进行参数校验，服务接口统一采用异步方式。
 
-自 `v2` 起，用户支持多角色分配，`UserCreateDto` 和 `UserEditDto` 均采用
+自 `v2` 起，用户支持多角色分配，`UserCreateDto` 和 `UserDetailDto` 均采用
 `Roles` 列表并要求至少包含一个角色。
 
 新增用户时系统会自动生成初始密码，密码值可在 `appsettings.json` 的
 `UserDefaults:DefaultUserPassword` 中配置。管理员需告知
-用户此密码以便首次登录后修改。重置密码接口仍需明确提供新密码。
+用户此密码以便首次登录后修改。重置密码操作将直接恢复为此默认密码。
 

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -109,7 +109,7 @@ public class UserService : IUserService {
     /// <summary>
     /// 编辑用户
     /// </summary>
-    public async Task<bool> UpdateAsync(UserEditDto dto, Guid operatorId, string operatorName) {
+    public async Task<bool> UpdateAsync(UserDetailDto dto, Guid operatorId, string operatorName) {
         var oldUser = await _userRepository.GetByIdAsync(dto.Id);
         if (oldUser == null)
             throw new Exception("用户不存在");
@@ -123,10 +123,6 @@ public class UserService : IUserService {
         oldUser.IsActive = dto.IsActive;
         oldUser.Email = dto.Email;
         oldUser.PhoneNumber = dto.PhoneNumber;
-
-        if (!string.IsNullOrWhiteSpace(dto.Password)) {
-            oldUser.PasswordHash = PasswordHelper.Hash(dto.Password);
-        }
 
         var result = await _userRepository.UpdateAsync(oldUser);
 
@@ -226,12 +222,12 @@ public class UserService : IUserService {
     /// <summary>
     /// 管理员重置密码
     /// </summary>
-    public async Task<bool> ResetPasswordAsync(Guid id, string newPassword, Guid operatorId, string operatorName) {
+    public async Task<bool> ResetPasswordAsync(Guid id, Guid operatorId, string operatorName) {
         var user = await _userRepository.GetByIdAsync(id);
         if (user == null)
             throw new Exception("用户不存在");
 
-        user.PasswordHash = PasswordHelper.Hash(newPassword);
+        user.PasswordHash = PasswordHelper.Hash(_options.DefaultUserPassword);
         var result = await _userRepository.UpdateAsync(user);
         if (result) {
             await _logService.AddLogAsync(new LogDto {

--- a/LYBT.UI.WPF/Apis/IUserApi.cs
+++ b/LYBT.UI.WPF/Apis/IUserApi.cs
@@ -14,7 +14,7 @@ namespace LYBT.UI.WPF.Apis {
         Task<ApiSuccessResponse> AddAsync([Body] UserCreateDto user);
 
         [Put("/api/Users/update")]
-        Task<ApiSuccessResponse> UpdateAsync([Body] UserEditDto user);
+        Task<ApiSuccessResponse> UpdateAsync([Body] UserDetailDto user);
 
         [Post("/api/Users/disable/{id}")]
         Task<ApiSuccessResponse> DisableAsync(Guid id);
@@ -29,7 +29,7 @@ namespace LYBT.UI.WPF.Apis {
         Task<ApiSuccessResponse> BatchEnableAsync([Body] BatchIdsDto dto);
 
         [Post("/api/Users/resetPassword/{id}")]
-        Task<ApiSuccessResponse> ResetPasswordAsync(Guid id, [Body] ResetPasswordDto dto);
+        Task<ApiSuccessResponse> ResetPasswordAsync(Guid id);
 
         [Post("/api/Users/changePassword")]
         Task<ApiSuccessResponse> ChangePasswordAsync([Body] ChangePasswordDto dto);

--- a/LYBT.UI.WPF/Interfaces/IUserService.cs
+++ b/LYBT.UI.WPF/Interfaces/IUserService.cs
@@ -10,12 +10,12 @@ namespace LYBT.UI.WPF.Services {
     public interface IUserService {
         Task<IList<UserDto>> SearchAsync(string keyword = "");
         Task<bool> AddUserAsync(UserCreateDto user);
-        Task<bool> UpdateUserAsync(UserEditDto user);
+        Task<bool> UpdateUserAsync(UserDetailDto user);
         Task<bool> DisableUserAsync(Guid id);
         Task<bool> EnableUserAsync(Guid id);
         Task<int> BatchDisableAsync(List<Guid> ids);
         Task<int> BatchEnableAsync(List<Guid> ids);
-        Task<bool> ResetPasswordAsync(Guid id, string newPassword);
+        Task<bool> ResetPasswordAsync(Guid id);
         Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword);
         Task<IList<UserRole>> GetRolesAsync();
         Task<UserDto?> GetByIdAsync(Guid id);

--- a/LYBT.UI.WPF/Services/UserService.cs
+++ b/LYBT.UI.WPF/Services/UserService.cs
@@ -34,7 +34,7 @@ namespace LYBT.UI.WPF.Services {
         /// <summary>
         /// 方法 UpdateUserAsync 的说明
         /// </summary>
-        public async Task<bool> UpdateUserAsync(UserEditDto user) {
+        public async Task<bool> UpdateUserAsync(UserDetailDto user) {
             var resp = await _userApi.UpdateAsync(user);
             return resp.Success;
         }
@@ -74,8 +74,8 @@ namespace LYBT.UI.WPF.Services {
         /// <summary>
         /// 方法 ResetPasswordAsync 的说明
         /// </summary>
-        public async Task<bool> ResetPasswordAsync(Guid id, string newPassword) {
-            var resp = await _userApi.ResetPasswordAsync(id, new ResetPasswordDto { NewPassword = newPassword });
+        public async Task<bool> ResetPasswordAsync(Guid id) {
+            var resp = await _userApi.ResetPasswordAsync(id);
             return resp.Success;
         }
 

--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -3,7 +3,6 @@ using LYBT.Models;
 using LYBT.Module.Users.Dtos;
 using LYBT.UI.WPF.Services;
 using Prism.Commands;
-using Microsoft.VisualBasic;
 using Prism.Mvvm;
 using System;
 using System.Collections.ObjectModel;
@@ -51,7 +50,6 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                             PhoneNumber = value.PhoneNumber
                         };
                         EditModeTitle = "编辑用户";
-                        Password = string.Empty;
                     }
                 }
             }
@@ -63,11 +61,6 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         /// </summary>
         public string SearchKeyword { get => _searchKeyword; set => SetProperty(ref _searchKeyword, value); }
 
-        private string _password;
-        /// <summary>
-        /// 属性 Password 的说明
-        /// </summary>
-        public string Password { get => _password; set => SetProperty(ref _password, value); }
 
         private string _editModeTitle = "新增用户";
         /// <summary>
@@ -122,11 +115,10 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             // 新增时，右侧表单清空
             EditingUser = new UserDto {
                 IsActive = true,
-                Roles = RoleList.Count > 0 ? new System.Collections.Generic.List<UserRole> { RoleList[0] } : new System.Collections.Generic.List<UserRole>()
+                Roles = new System.Collections.Generic.List<UserRole> { UserRole.DiagnosingDoctor }
             };
             SelectedUser = null;
             EditModeTitle = "新增用户";
-            Password = string.Empty;
         }
 
         /// <summary>
@@ -156,14 +148,13 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                     return;
                 }
             } else {
-                var editDto = new UserEditDto {
+                var editDto = new UserDetailDto {
                     Id = EditingUser.Id,
                     RealName = EditingUser.RealName,
                     Roles = EditingUser.Roles,
                     IsActive = EditingUser.IsActive,
                     Email = EditingUser.Email,
-                    PhoneNumber = EditingUser.PhoneNumber,
-                    Password = string.IsNullOrWhiteSpace(Password) ? null : Password
+                    PhoneNumber = EditingUser.PhoneNumber
                 };
                 var ok = await _userService.UpdateUserAsync(editDto);
                 if (!ok) {
@@ -226,10 +217,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         private async Task ResetPassword() {
             if (SelectedUser == null)
                 return;
-            string newPwd = Microsoft.VisualBasic.Interaction.InputBox("请输入新密码", "重置密码", "");
-            if (string.IsNullOrWhiteSpace(newPwd))
-                return;
-            if (await _userService.ResetPasswordAsync(SelectedUser.Id, newPwd))
+            if (await _userService.ResetPasswordAsync(SelectedUser.Id))
                 MessageBox.Show("密码已重置", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
             else
                 MessageBox.Show("重置密码失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -55,13 +55,17 @@
                     <TextBlock Text="姓名" />
                     <TextBox Text="{Binding EditingUser.RealName}" Margin="0,0,0,8"/>
                     <TextBlock Text="角色" />
-                    <ListBox x:Name="RolesListBox" ItemsSource="{Binding RoleList}" SelectionMode="Multiple" Margin="0,0,0,8" SelectionChanged="RolesListBox_SelectionChanged"/>
+                    <ListBox x:Name="RolesListBox" ItemsSource="{Binding RoleList}" SelectionMode="Multiple" Margin="0,0,0,8" SelectionChanged="RolesListBox_SelectionChanged">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <CheckBox Content="{Binding}" IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                     <TextBlock Text="邮箱" />
                     <TextBox Text="{Binding EditingUser.Email}" Margin="0,0,0,8"/>
                     <TextBlock Text="手机号" />
                     <TextBox Text="{Binding EditingUser.PhoneNumber}" Margin="0,0,0,8"/>
-                    <TextBlock Text="密码" />
-                    <PasswordBox x:Name="passwordBox" PasswordChanged="PasswordBox_PasswordChanged" Margin="0,0,0,8" />
                     <CheckBox Content="启用" IsChecked="{Binding EditingUser.IsActive}" Margin="0,0,0,10"/>
                 </StackPanel>
             </Border>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
@@ -32,9 +32,7 @@ namespace LYBT.UI.WPF.Views.Admin {
 
         private void Vm_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
             if (sender is ViewModels.Admin.UserManagementViewModel vm) {
-                if (e.PropertyName == nameof(vm.Password) || e.PropertyName == nameof(vm.EditingUser)) {
-                    if (passwordBox.Password != vm.Password)
-                        passwordBox.Password = vm.Password ?? string.Empty;
+                if (e.PropertyName == nameof(vm.EditingUser)) {
                     if (vm.EditingUser != null) {
                         RolesListBox.SelectedItems.Clear();
                         foreach (var r in vm.EditingUser.Roles)
@@ -44,16 +42,6 @@ namespace LYBT.UI.WPF.Views.Admin {
             }
         }
 
-        /// <summary>
-        /// 方法 PasswordBox_PasswordChanged 的说明
-        /// </summary>
-        private void PasswordBox_PasswordChanged(object sender, RoutedEventArgs e) {
-            if (DataContext is ViewModels.Admin.UserManagementViewModel vm) {
-                var pb = (PasswordBox)sender;
-                if (pb.Password != vm.Password)
-                    vm.Password = pb.Password;
-            }
-        }
 
         private void RolesListBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
             if (DataContext is ViewModels.Admin.UserManagementViewModel vm && vm.EditingUser != null) {

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml
@@ -11,7 +11,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="70"/>
@@ -25,7 +24,13 @@
         <TextBox x:Name="RealNameTextBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
 
         <TextBlock Text="角色" Grid.Row="2" VerticalAlignment="Center"/>
-        <ListBox x:Name="RoleListBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" SelectionMode="Multiple"/>
+        <ListBox x:Name="RoleListBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" SelectionMode="Multiple">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <CheckBox Content="{Binding}" IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
         <TextBlock Text="邮箱" Grid.Row="3" VerticalAlignment="Center"/>
         <TextBox x:Name="EmailTextBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
@@ -33,12 +38,9 @@
         <TextBlock Text="电话" Grid.Row="4" VerticalAlignment="Center"/>
         <TextBox x:Name="PhoneNumberTextBox" Grid.Row="4" Grid.Column="1" Margin="0,0,0,5"/>
 
-        <TextBlock Text="密码" Grid.Row="5" VerticalAlignment="Center"/>
-        <PasswordBox x:Name="PasswordBox" Grid.Row="5" Grid.Column="1" Margin="0,0,0,5"/>
+        <CheckBox x:Name="IsActiveCheckBox" Content="启用" Grid.Row="5" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
 
-        <CheckBox x:Name="IsActiveCheckBox" Content="启用" Grid.Row="6" Grid.ColumnSpan="2" Margin="0,5,0,5"/>
-
-        <StackPanel Orientation="Horizontal" Grid.Row="7" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <StackPanel Orientation="Horizontal" Grid.Row="6" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="确定" Width="60" Margin="0,0,10,0" Click="Ok_Click"/>
             <Button Content="取消" Width="60" Click="Cancel_Click"/>
         </StackPanel>

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
@@ -17,7 +17,7 @@ namespace LYBT.UI.WPF.Views {
         /// <summary>
         /// 属性 EditedUser 的说明
         /// </summary>
-        public UserEditDto? EditedUser { get; private set; }
+        public UserDetailDto? EditedUser { get; private set; }
 
         public UserEditWindow(IEnumerable<UserRole> roles, UserDto? user = null) {
             InitializeComponent();
@@ -35,8 +35,8 @@ namespace LYBT.UI.WPF.Views {
                 IsActiveCheckBox.IsChecked = user.IsActive;
             } else {
                 Title = "新增用户";
-                if (roles.Any())
-                    RoleListBox.SelectedItems.Add(roles.First());
+                if (roles.Contains(UserRole.DiagnosingDoctor))
+                    RoleListBox.SelectedItems.Add(UserRole.DiagnosingDoctor);
                 IsActiveCheckBox.IsChecked = true;
             }
         }
@@ -56,14 +56,13 @@ namespace LYBT.UI.WPF.Views {
                     PhoneNumber = PhoneNumberTextBox.Text
                 };
             } else {
-                EditedUser = new UserEditDto {
+                EditedUser = new UserDetailDto {
                     Id = _origin.Id,
                     RealName = RealNameTextBox.Text,
                     Roles = selectedRoles,
                     IsActive = IsActiveCheckBox.IsChecked == true,
                     Email = EmailTextBox.Text,
-                    PhoneNumber = PhoneNumberTextBox.Text,
-                    Password = string.IsNullOrWhiteSpace(PasswordBox.Password) ? null : PasswordBox.Password
+                    PhoneNumber = PhoneNumberTextBox.Text
                 };
             }
             DialogResult = true;

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -39,7 +39,7 @@ public class UsersController : ControllerBase {
     /// 编辑用户
     /// </summary>
     [HttpPut("update")]
-    public async Task<IActionResult> Update([FromBody] UserEditDto dto) {
+    public async Task<IActionResult> Update([FromBody] UserDetailDto dto) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
         var result = await _userService.UpdateAsync(dto, operatorId, operatorName);
@@ -91,13 +91,13 @@ public class UsersController : ControllerBase {
     }
 
     /// <summary>
-    /// 管理员重置密码，需要明确提供新密码
+    /// 管理员重置密码，恢复为默认值
     /// </summary>
     [HttpPost("resetPassword/{id}")]
-    public async Task<IActionResult> ResetPassword(Guid id, [FromBody] ResetPasswordDto dto) {
+    public async Task<IActionResult> ResetPassword(Guid id) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
-        var result = await _userService.ResetPasswordAsync(id, dto.NewPassword, operatorId, operatorName);
+        var result = await _userService.ResetPasswordAsync(id, operatorId, operatorName);
         return result ? Ok(new { success = true }) : BadRequest(new { success = false });
     }
 


### PR DESCRIPTION
## Summary
- rename `UserEditDto` to `UserDetailDto`
- reset password now sets default configured password
- remove password editing UI and API
- default new users to doctor role and show roles with checkboxes
- update docs accordingly

## Testing
- `dotnet build -c Release` *(fails: missing Auth module)*

------
https://chatgpt.com/codex/tasks/task_e_686623233e008333876cb1e2eed36e3f