### PR TITLE
Improve user creation error handling

### DIFF
--- a/LYBT.UI.WPF/Services/UserService.cs
+++ b/LYBT.UI.WPF/Services/UserService.cs
@@ -27,24 +27,16 @@ namespace LYBT.UI.WPF.Services {
         /// 方法 AddUserAsync 的说明
         /// </summary>
         public async Task<bool> AddUserAsync(UserCreateDto user) {
-            try {
-                var resp = await _userApi.AddAsync(user);
-                return resp.Success;
-            } catch {
-                return false;
-            }
+            var resp = await _userApi.AddAsync(user);
+            return resp.Success;
         }
 
         /// <summary>
         /// 方法 UpdateUserAsync 的说明
         /// </summary>
         public async Task<bool> UpdateUserAsync(UserDetailDto user) {
-            try {
-                var resp = await _userApi.UpdateAsync(user);
-                return resp.Success;
-            } catch {
-                return false;
-            }
+            var resp = await _userApi.UpdateAsync(user);
+            return resp.Success;
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -4,6 +4,8 @@ using LYBT.Module.Users.Dtos;
 using LYBT.UI.WPF.Services;
 using Prism.Commands;
 using Prism.Mvvm;
+using Refit;
+using System.Text.Json;
 using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -168,7 +170,17 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                     }
                 }
             } catch (Exception ex) {
-                MessageBox.Show($"操作失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+                string msg = ex.Message;
+                if (ex is ApiException apiEx && !string.IsNullOrEmpty(apiEx.Content)) {
+                    try {
+                        var doc = JsonDocument.Parse(apiEx.Content);
+                        if (doc.RootElement.TryGetProperty("message", out var m))
+                            msg = m.GetString() ?? msg;
+                    } catch {
+                        // ignore parse errors
+                    }
+                }
+                MessageBox.Show($"操作失败：{msg}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
             // 刷新列表

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -31,8 +31,12 @@ public class UsersController : ControllerBase {
         // 从Token/Session等获取操作人信息
         Guid operatorId = Guid.NewGuid(); // 实际开发应取登录管理员ID
         string operatorName = "管理员A";
-        var result = await _userService.AddAsync(dto, operatorId, operatorName);
-        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        try {
+            var result = await _userService.AddAsync(dto, operatorId, operatorName);
+            return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        } catch (Exception ex) {
+            return BadRequest(new { success = false, message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -42,8 +46,12 @@ public class UsersController : ControllerBase {
     public async Task<IActionResult> Update([FromBody] UserDetailDto dto) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
-        var result = await _userService.UpdateAsync(dto, operatorId, operatorName);
-        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        try {
+            var result = await _userService.UpdateAsync(dto, operatorId, operatorName);
+            return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        } catch (Exception ex) {
+            return BadRequest(new { success = false, message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -53,8 +61,12 @@ public class UsersController : ControllerBase {
     public async Task<IActionResult> Disable(Guid id) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
-        var result = await _userService.DisableAsync(id, operatorId, operatorName);
-        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        try {
+            var result = await _userService.DisableAsync(id, operatorId, operatorName);
+            return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        } catch (Exception ex) {
+            return BadRequest(new { success = false, message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -64,8 +76,12 @@ public class UsersController : ControllerBase {
     public async Task<IActionResult> Enable(Guid id) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
-        var result = await _userService.EnableAsync(id, operatorId, operatorName);
-        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        try {
+            var result = await _userService.EnableAsync(id, operatorId, operatorName);
+            return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        } catch (Exception ex) {
+            return BadRequest(new { success = false, message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -97,8 +113,12 @@ public class UsersController : ControllerBase {
     public async Task<IActionResult> ResetPassword(Guid id) {
         Guid operatorId = Guid.NewGuid();
         string operatorName = "管理员A";
-        var result = await _userService.ResetPasswordAsync(id, operatorId, operatorName);
-        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        try {
+            var result = await _userService.ResetPasswordAsync(id, operatorId, operatorName);
+            return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+        } catch (Exception ex) {
+            return BadRequest(new { success = false, message = ex.Message });
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- handle exceptions in UsersController actions and return messages
- simplify AddUserAsync and UpdateUserAsync so exceptions propagate
- show backend error messages in user management UI

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686694880e7c8333a4c638ffe2245d60