### PR TITLE
Update user management interface

### DIFF
--- a/LYBT.Module.Users/Dtos/UserDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDto.cs
@@ -34,6 +34,12 @@ namespace LYBT.Module.Users.Dtos {
         public List<UserRole> Roles { get; set; } = new();
 
         /// <summary>
+        /// 用户角色文本，显示所有角色名称
+        /// </summary>
+        public string RolesText =>
+            Roles != null && Roles.Count > 0 ? string.Join("、", Roles) : Role.ToString();
+
+        /// <summary>
         /// 账号启用状态（true=启用，false=禁用）
         /// </summary>
         public bool IsActive { get; set; }

--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -54,7 +54,8 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                             Email = value.Email,
                             PhoneNumber = value.PhoneNumber
                         };
-                        EditModeTitle = "编辑用户";
+                        IsEditable = false;
+                        EditModeTitle = "用户详情";
                     }
                 }
             }
@@ -73,10 +74,20 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         /// </summary>
         public string EditModeTitle { get => _editModeTitle; set => SetProperty(ref _editModeTitle, value); }
 
+        private bool _isEditable;
+        /// <summary>
+        /// 详情区域是否可编辑
+        /// </summary>
+        public bool IsEditable { get => _isEditable; set => SetProperty(ref _isEditable, value); }
+
         /// <summary>
         /// 属性 AddUserCommand 的说明
         /// </summary>
         public DelegateCommand AddUserCommand { get; }
+        /// <summary>
+        /// 编辑命令
+        /// </summary>
+        public DelegateCommand EditUserCommand { get; }
         /// <summary>
         /// 属性 SaveUserCommand 的说明
         /// </summary>
@@ -103,7 +114,10 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         public UserManagementViewModel(Services.IUserService userService) {
             _userService = userService;
             AddUserCommand = new DelegateCommand(AddUser);
-            SaveUserCommand = new DelegateCommand(async () => await SaveUser(), () => EditingUser != null).ObservesProperty(() => EditingUser);
+            EditUserCommand = new DelegateCommand(EditUser, () => SelectedUser != null).ObservesProperty(() => SelectedUser);
+            SaveUserCommand = new DelegateCommand(async () => await SaveUser(), () => EditingUser != null && IsEditable)
+                .ObservesProperty(() => EditingUser)
+                .ObservesProperty(() => IsEditable);
             SearchCommand = new DelegateCommand(async () => await LoadUsers());
             DisableUserCommand = new DelegateCommand(async () => await DisableUser(), () => SelectedUser != null).ObservesProperty(() => SelectedUser);
             EnableUserCommand = new DelegateCommand(async () => await EnableUser(), () => SelectedUser != null).ObservesProperty(() => SelectedUser);
@@ -124,6 +138,14 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             };
             SelectedUser = null;
             EditModeTitle = "新增用户";
+            IsEditable = true;
+        }
+
+        private void EditUser() {
+            if (SelectedUser != null) {
+                IsEditable = true;
+                EditModeTitle = "编辑用户";
+            }
         }
 
         /// <summary>
@@ -196,7 +218,8 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             }
             // 刷新列表
             await LoadUsers();
-            EditModeTitle = "编辑用户";
+            IsEditable = false;
+            EditModeTitle = "用户详情";
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -6,48 +6,54 @@
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Control.Resources>
         <converters:NullToBoolConverter x:Key="NullToBoolConverter" />
+        <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </Control.Resources>
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-        <!-- 工具栏 -->
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="查找" Command="{Binding SearchCommand}" Margin="0,0,16,0"/>
-            <Button Content="新增用户" Command="{Binding AddUserCommand}" Margin="0,0,8,0"/>
-            <Button Content="保存" Command="{Binding SaveUserCommand}" Margin="0,0,8,0"   
-                    IsEnabled="{Binding EditingUser, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="禁用用户" Command="{Binding DisableUserCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
-                    Margin="0,0,8,0"/>
-            <Button Content="启用用户" Command="{Binding EnableUserCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
-                    Margin="0,0,8,0"/>
-            <Button Content="重置密码" Command="{Binding ResetPasswordCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
-        </StackPanel>
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.2*"/>
-                <ColumnDefinition Width="1.4*"/>
-            </Grid.ColumnDefinitions>
-            <!-- 用户列表 -->
-            <DataGrid Grid.Column="0" ItemsSource="{Binding Users}" SelectedItem="{Binding SelectedUser, Mode=TwoWay}"  
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2.2*"/>
+            <ColumnDefinition Width="1.4*"/>
+        </Grid.ColumnDefinitions>
+        <Grid Grid.Column="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
+                <Button Content="查找" Command="{Binding SearchCommand}"/>
+            </StackPanel>
+            <DataGrid Grid.Row="1" ItemsSource="{Binding Users}" SelectedItem="{Binding SelectedUser, Mode=TwoWay}"
                       AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
                 <DataGrid.Columns>
                     <DataGridTextColumn Header="账号" Binding="{Binding UserName}" Width="*"/>
                     <DataGridTextColumn Header="姓名" Binding="{Binding RealName}" Width="*"/>
-                    <DataGridTextColumn Header="角色" Binding="{Binding Role}" Width="*"/>
+                    <DataGridTextColumn Header="角色" Binding="{Binding RolesText}" Width="*"/>
                     <DataGridCheckBoxColumn Header="启用" Binding="{Binding IsActive}" Width="60"/>
                     <DataGridTextColumn Header="最近登录" Binding="{Binding LastLoginTime}" Width="130"/>
                     <DataGridTextColumn Header="邮箱" Binding="{Binding Email}" Width="110"/>
                     <DataGridTextColumn Header="手机号" Binding="{Binding PhoneNumber}" Width="90"/>
                 </DataGrid.Columns>
             </DataGrid>
-            <!-- 用户编辑表单 -->
-            <Border Grid.Column="1" Margin="0,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+        </Grid>
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                <Button Content="新增用户" Command="{Binding AddUserCommand}" Margin="0,0,8,0"/>
+                <Button Content="编辑用户" Command="{Binding EditUserCommand}" Margin="0,0,8,0"
+                        IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
+                <Button Content="禁用用户" Command="{Binding DisableUserCommand}"
+                        IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
+                        Margin="0,0,8,0"/>
+                <Button Content="启用用户" Command="{Binding EnableUserCommand}"
+                        IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
+                        Margin="0,0,8,0"/>
+                <Button Content="重置密码" Command="{Binding ResetPasswordCommand}"
+                        IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
+            </StackPanel>
+            <Border Grid.Row="1" Margin="0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1" IsEnabled="{Binding IsEditable}">
                 <StackPanel>
                     <TextBlock Text="{Binding EditModeTitle}" FontWeight="Bold" FontSize="17" Margin="0,0,0,16"/>
                     <TextBlock Text="账号" />
@@ -67,6 +73,7 @@
                     <TextBlock Text="手机号" />
                     <TextBox Text="{Binding EditingUser.PhoneNumber}" Margin="0,0,0,8"/>
                     <CheckBox Content="启用" IsChecked="{Binding EditingUser.IsActive}" Margin="0,0,0,10"/>
+                    <Button Content="保存" Command="{Binding SaveUserCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
                 </StackPanel>
             </Border>
         </Grid>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Collections.Specialized;
 using LYBT.Common.Enums.Users;
 using System.Windows.Documents;
 using System.Windows.Input;
@@ -24,21 +25,36 @@ namespace LYBT.UI.WPF.Views.Admin {
         }
 
         private void UserManagementView_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
-            if (e.OldValue is ViewModels.Admin.UserManagementViewModel oldVm)
+            if (e.OldValue is ViewModels.Admin.UserManagementViewModel oldVm) {
                 oldVm.PropertyChanged -= Vm_PropertyChanged;
-            if (e.NewValue is ViewModels.Admin.UserManagementViewModel newVm)
+                oldVm.RoleList.CollectionChanged -= RoleList_CollectionChanged;
+            }
+            if (e.NewValue is ViewModels.Admin.UserManagementViewModel newVm) {
                 newVm.PropertyChanged += Vm_PropertyChanged;
+                newVm.RoleList.CollectionChanged += RoleList_CollectionChanged;
+            }
         }
 
         private void Vm_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
             if (sender is ViewModels.Admin.UserManagementViewModel vm) {
                 if (e.PropertyName == nameof(vm.EditingUser)) {
-                    if (vm.EditingUser != null) {
-                        RolesListBox.SelectedItems.Clear();
-                        foreach (var r in vm.EditingUser.Roles)
-                            RolesListBox.SelectedItems.Add(r);
-                    }
+                    UpdateRoleSelections(vm);
                 }
+            }
+        }
+
+        private void RoleList_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) {
+            if (DataContext is ViewModels.Admin.UserManagementViewModel vm) {
+                UpdateRoleSelections(vm);
+            }
+        }
+
+        private void UpdateRoleSelections(ViewModels.Admin.UserManagementViewModel vm) {
+            RolesListBox.SelectedItems.Clear();
+            if (vm.EditingUser != null) {
+                foreach (var r in vm.EditingUser.Roles)
+                    if (vm.RoleList.Contains(r))
+                        RolesListBox.SelectedItems.Add(r);
             }
         }
 


### PR DESCRIPTION
## Summary
- show all user roles with new `RolesText` property
- restructure user management view layout and add edit capability
- add editable state and new command in `UserManagementViewModel`
- fix role list selection when switching users

## Testing
- `dotnet build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68669f509b04833387416bc05c9798b5