### PR TITLE
Bind role list to editing user via attached property

### DIFF
--- a/LYBT.UI.WPF/Helpers/ListBoxExtensions.cs
+++ b/LYBT.UI.WPF/Helpers/ListBoxExtensions.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Helpers {
+    /// <summary>
+    /// Provides binding support for <see cref="ListBox.SelectedItems"/>.
+    /// </summary>
+    public static class ListBoxExtensions {
+        public static readonly DependencyProperty BindableSelectedItemsProperty =
+            DependencyProperty.RegisterAttached(
+                "BindableSelectedItems",
+                typeof(IList),
+                typeof(ListBoxExtensions),
+                new PropertyMetadata(null, OnBindableSelectedItemsChanged));
+
+        public static IList? GetBindableSelectedItems(DependencyObject obj) =>
+            (IList?)obj.GetValue(BindableSelectedItemsProperty);
+
+        public static void SetBindableSelectedItems(DependencyObject obj, IList? value) =>
+            obj.SetValue(BindableSelectedItemsProperty, value);
+
+        private static void OnBindableSelectedItemsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is ListBox lb) {
+                lb.SelectionChanged -= ListBox_SelectionChanged;
+
+                if (e.NewValue is IList list) {
+                    lb.SelectedItems.Clear();
+                    foreach (var item in list)
+                        lb.SelectedItems.Add(item);
+                }
+
+                lb.SelectionChanged += ListBox_SelectionChanged;
+            }
+        }
+
+        private static void ListBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if (sender is ListBox lb && GetBindableSelectedItems(lb) is IList list) {
+                list.Clear();
+                foreach (var item in lb.SelectedItems)
+                    list.Add(item);
+            }
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -1,9 +1,10 @@
-﻿<UserControl x:Class="LYBT.UI.WPF.Views.Admin.UserManagementView"  
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"  
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"  
-             xmlns:prism="http://prismlibrary.com/"
-             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
-             prism:ViewModelLocator.AutoWireViewModel="True">
+﻿<UserControl x:Class="LYBT.UI.WPF.Views.Admin.UserManagementView"
+              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+              xmlns:prism="http://prismlibrary.com/"
+              xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+              xmlns:helpers="clr-namespace:LYBT.UI.WPF.Helpers"
+              prism:ViewModelLocator.AutoWireViewModel="True">
     <Control.Resources>
         <converters:NullToBoolConverter x:Key="NullToBoolConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
@@ -61,7 +62,11 @@
                     <TextBlock Text="姓名" />
                     <TextBox Text="{Binding EditingUser.RealName}" Margin="0,0,0,8"/>
                     <TextBlock Text="角色" />
-                    <ListBox x:Name="RolesListBox" ItemsSource="{Binding RoleList}" SelectionMode="Multiple" Margin="0,0,0,8" SelectionChanged="RolesListBox_SelectionChanged">
+                    <ListBox x:Name="RolesListBox"
+                             ItemsSource="{Binding RoleList}"
+                             SelectionMode="Multiple"
+                             Margin="0,0,0,8"
+                             helpers:ListBoxExtensions.BindableSelectedItems="{Binding EditingUser.Roles}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <CheckBox Content="{Binding}" IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml.cs
@@ -1,18 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Collections.Specialized;
-using LYBT.Common.Enums.Users;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
 
 namespace LYBT.UI.WPF.Views.Admin {
     /// <summary>
@@ -21,50 +7,6 @@ namespace LYBT.UI.WPF.Views.Admin {
     public partial class UserManagementView : UserControl {
         public UserManagementView() {
             InitializeComponent();
-            DataContextChanged += UserManagementView_DataContextChanged;
-        }
-
-        private void UserManagementView_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e) {
-            if (e.OldValue is ViewModels.Admin.UserManagementViewModel oldVm) {
-                oldVm.PropertyChanged -= Vm_PropertyChanged;
-                oldVm.RoleList.CollectionChanged -= RoleList_CollectionChanged;
-            }
-            if (e.NewValue is ViewModels.Admin.UserManagementViewModel newVm) {
-                newVm.PropertyChanged += Vm_PropertyChanged;
-                newVm.RoleList.CollectionChanged += RoleList_CollectionChanged;
-            }
-        }
-
-        private void Vm_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
-            if (sender is ViewModels.Admin.UserManagementViewModel vm) {
-                if (e.PropertyName == nameof(vm.EditingUser)) {
-                    UpdateRoleSelections(vm);
-                }
-            }
-        }
-
-        private void RoleList_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e) {
-            if (DataContext is ViewModels.Admin.UserManagementViewModel vm) {
-                UpdateRoleSelections(vm);
-            }
-        }
-
-        private void UpdateRoleSelections(ViewModels.Admin.UserManagementViewModel vm) {
-            RolesListBox.SelectedItems.Clear();
-            if (vm.EditingUser != null) {
-                foreach (var r in vm.EditingUser.Roles) {
-                    var item = RolesListBox.Items.Cast<UserRole>().FirstOrDefault(x => x == r);
-                    if (item != null)
-                        RolesListBox.SelectedItems.Add(item);
-                }
-            }
-        }
-
-
-        private void RolesListBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
-            if (DataContext is ViewModels.Admin.UserManagementViewModel vm && vm.EditingUser != null) {
-                vm.EditingUser.Roles = RolesListBox.SelectedItems.Cast<UserRole>().ToList();
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add ListBoxExtensions to enable binding selected items
- bind roles ListBox to EditingUser.Roles using the helper
- simplify UserManagementView code-behind

## Testing
- `dotnet restore`
- `dotnet build -c Release` *(fails: type or namespace name 'Auth' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6866b1c19d2c8333bad637fe372830b6