### PR TITLE
Add EnumExtensions with GetDescription method

### DIFF
--- a/LYBT.Common/Extensions/EnumExtensions.cs
+++ b/LYBT.Common/Extensions/EnumExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace LYBT.Common.Extensions {
+
+    /// <summary>
+    /// Enum 扩展方法
+    /// </summary>
+    public static class EnumExtensions {
+
+        /// <summary>
+        /// 获取枚举值的描述
+        /// </summary>
+        public static string GetDescription(this Enum value) {
+            var field = value.GetType().GetField(value.ToString());
+            var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+            return attribute?.Description ?? value.ToString();
+        }
+    }
+}

--- a/LYBT.Common/README.md
+++ b/LYBT.Common/README.md
@@ -1,1 +1,10 @@
-﻿
+## EnumExtensions
+
+```csharp
+using LYBT.Common.Enums.Users;
+using LYBT.Common.Extensions;
+
+var desc = UserRole.Admin.GetDescription();
+// desc == "系统管理员"
+```
+


### PR DESCRIPTION
## Summary
- add `EnumExtensions` to get `DescriptionAttribute` from enums
- document usage of the new extension in `LYBT.Common/README.md`

## Testing
- `dotnet build LYBT.Common/LYBT.Common.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6866b5c8506c8333a315abde7287d988