### PR TITLE
Add enum description converter

### DIFF
--- a/LYBT.Common/Extensions/EnumExtensions.cs
+++ b/LYBT.Common/Extensions/EnumExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.ComponentModel;
+using System.Reflection;
+
+namespace LYBT.Common.Extensions {
+
+    /// <summary>
+    /// Enum 扩展方法
+    /// </summary>
+    public static class EnumExtensions {
+
+        /// <summary>
+        /// 获取枚举值的描述
+        /// </summary>
+        public static string GetDescription(this Enum value) {
+            var field = value.GetType().GetField(value.ToString());
+            var attribute = field?.GetCustomAttribute<DescriptionAttribute>();
+            return attribute?.Description ?? value.ToString();
+        }
+    }
+}

--- a/LYBT.Common/README.md
+++ b/LYBT.Common/README.md
@@ -1,1 +1,10 @@
-﻿
+## EnumExtensions
+
+```csharp
+using LYBT.Common.Enums.Users;
+using LYBT.Common.Extensions;
+
+var desc = UserRole.Admin.GetDescription();
+// desc == "系统管理员"
+```
+

--- a/LYBT.Module.Users/Dtos/UserDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDto.cs
@@ -1,5 +1,7 @@
 using LYBT.Common.Enums.Users;
+using LYBT.Common.Extensions;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LYBT.Module.Users.Dtos {
 
@@ -37,7 +39,9 @@ namespace LYBT.Module.Users.Dtos {
         /// 用户角色文本，显示所有角色名称
         /// </summary>
         public string RolesText =>
-            Roles != null && Roles.Count > 0 ? string.Join("、", Roles) : Role.ToString();
+            Roles != null && Roles.Count > 0 ?
+                string.Join("、", Roles.Select(r => r.GetDescription())) :
+                Role.GetDescription();
 
         /// <summary>
         /// 账号启用状态（true=启用，false=禁用）

--- a/LYBT.UI.WPF/Converters/EnumDescriptionConverter.cs
+++ b/LYBT.UI.WPF/Converters/EnumDescriptionConverter.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using LYBT.Common.Extensions;
+
+namespace LYBT.UI.WPF.Converters {
+    /// <summary>
+    /// Converts an enum value to its DescriptionAttribute text.
+    /// </summary>
+    public class EnumDescriptionConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value is Enum e ? e.GetDescription() : string.Empty;
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => throw new NotImplementedException();
+    }
+}

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -8,6 +8,7 @@
     <Control.Resources>
         <converters:NullToBoolConverter x:Key="NullToBoolConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
     </Control.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -69,7 +70,8 @@
                              helpers:ListBoxExtensions.BindableSelectedItems="{Binding EditingUser.Roles}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
-                                <CheckBox Content="{Binding}" IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
+                                <CheckBox Content="{Binding Converter={StaticResource EnumDescriptionConverter}}"
+                                          IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
                             </DataTemplate>
                         </ListBox.ItemTemplate>
                     </ListBox>

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml
@@ -1,7 +1,11 @@
 <Window x:Class="LYBT.UI.WPF.Views.UserEditWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
         Title="用户" Height="300" Width="300">
+    <Window.Resources>
+        <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+    </Window.Resources>
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -27,7 +31,8 @@
         <ListBox x:Name="RoleListBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5" SelectionMode="Multiple">
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <CheckBox Content="{Binding}" IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
+                    <CheckBox Content="{Binding Converter={StaticResource EnumDescriptionConverter}}"
+                             IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>


### PR DESCRIPTION
## Summary
- convert enum values to DescriptionAttribute text in user management views
- create `EnumDescriptionConverter` and use it for role display
- update `UserDto.RolesText` to use `GetDescription`

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: missing modules)*
- `dotnet build LYBT.Common/LYBT.Common.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6866b5c8506c8333a315abde7287d988