### PR TITLE
Add cancel button in user creation view

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -98,6 +98,10 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         /// </summary>
         public DelegateCommand SaveUserCommand { get; }
         /// <summary>
+        /// 取消编辑命令
+        /// </summary>
+        public DelegateCommand CancelCommand { get; }
+        /// <summary>
         /// 属性 SearchCommand 的说明
         /// </summary>
         public DelegateCommand SearchCommand { get; }
@@ -127,6 +131,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             DisableUserCommand = new DelegateCommand(async () => await DisableUser(), () => SelectedUser != null).ObservesProperty(() => SelectedUser);
             EnableUserCommand = new DelegateCommand(async () => await EnableUser(), () => SelectedUser != null).ObservesProperty(() => SelectedUser);
             ResetPasswordCommand = new DelegateCommand(async () => await ResetPassword(), () => SelectedUser != null).ObservesProperty(() => SelectedUser);
+            CancelCommand = new DelegateCommand(CancelEdit);
 
             _ = LoadRoles();
             _ = LoadUsers();
@@ -281,6 +286,15 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 MessageBox.Show("密码已重置", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
             else
                 MessageBox.Show("重置密码失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+        }
+
+        private void CancelEdit() {
+            if (SelectedUser != null)
+                _ = LoadSelectedUserAsync(SelectedUser);
+            else
+                EditingUser = null;
+            IsEditable = false;
+            EditModeTitle = "用户详情";
         }
     }
 }

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -81,6 +81,7 @@
                     <TextBox Text="{Binding EditingUser.PhoneNumber}" Margin="0,0,0,8"/>
                     <CheckBox Content="启用" IsChecked="{Binding EditingUser.IsActive}" Margin="0,0,0,10"/>
                     <Button Content="保存" Command="{Binding SaveUserCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
                 </StackPanel>
             </Border>
         </Grid>


### PR DESCRIPTION
## Summary
- add CancelCommand in `UserManagementViewModel`
- implement `CancelEdit` to revert editing state
- show new "取消" button next to "保存" in `UserManagementView`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68672517e57c83338489e5f3a6b62b90