### PR TITLE
Remove default role for new users

### DIFF
--- a/LYBT.Module.Users/Dtos/UserCreateDto.cs
+++ b/LYBT.Module.Users/Dtos/UserCreateDto.cs
@@ -26,8 +26,8 @@ namespace LYBT.Module.Users.Dtos {
         /// <summary>
         /// 用户角色集合（至少选择一个）
         /// </summary>
-        [Required(ErrorMessage = "用户角色不能为空")]
-        [MinLength(1, ErrorMessage = "至少指定一个角色")]
+        [Required(ErrorMessage = "角色不能为空")]
+        [MinLength(1, ErrorMessage = "角色不能为空")]
         public List<UserRole> Roles { get; set; } = new();
 
         /// <summary>

--- a/LYBT.Module.Users/Dtos/UserDetailDto.cs
+++ b/LYBT.Module.Users/Dtos/UserDetailDto.cs
@@ -17,8 +17,8 @@ namespace LYBT.Module.Users.Dtos {
         public string RealName { get; set; } = string.Empty;
 
         /// <summary>多个用户角色（至少一个）</summary>
-        [Required(ErrorMessage = "用户角色不能为空")]
-        [MinLength(1, ErrorMessage = "至少指定一个角色")]
+        [Required(ErrorMessage = "角色不能为空")]
+        [MinLength(1, ErrorMessage = "角色不能为空")]
         public List<UserRole> Roles { get; set; } = new();
 
         /// <summary>账号启用状态（true=启用，false=禁用，必填）</summary>

--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -144,7 +144,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             // 新增时，右侧表单清空
             EditingUser = new UserDto {
                 IsActive = true,
-                Roles = new List<UserRole> { UserRole.DiagnosingDoctor }
+                Roles = new List<UserRole>()
             };
             SelectedUser = null;
             EditModeTitle = "新增用户";
@@ -170,7 +170,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 return;
             }
             if (EditingUser.Roles == null || EditingUser.Roles.Count == 0) {
-                MessageBox.Show("请至少选择一个角色！", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                MessageBox.Show("角色不能为空！", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;
             }
             try {

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml.cs
@@ -38,11 +38,6 @@ namespace LYBT.UI.WPF.Views {
                 IsActiveCheckBox.IsChecked = user.IsActive;
             } else {
                 Title = "新增用户";
-                if (roles.Contains(UserRole.DiagnosingDoctor)) {
-                    var item = RoleListBox.Items.Cast<UserRole>().FirstOrDefault(x => x == UserRole.DiagnosingDoctor);
-                    if (item != null)
-                        RoleListBox.SelectedItems.Add(item);
-                }
                 IsActiveCheckBox.IsChecked = true;
             }
         }
@@ -52,6 +47,10 @@ namespace LYBT.UI.WPF.Views {
         /// </summary>
         private void Ok_Click(object sender, RoutedEventArgs e) {
             var selectedRoles = RoleListBox.SelectedItems.Cast<UserRole>().ToList();
+            if (selectedRoles.Count == 0) {
+                MessageBox.Show("角色不能为空！", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
             if (_origin == null) {
                 CreatedUser = new UserCreateDto {
                     UserName = UserNameTextBox.Text,


### PR DESCRIPTION
## Summary
- remove default doctor role selection when adding a user
- show message if roles are empty
- update validation messages for roles

## Testing
- `dotnet test` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672b70bb008333b53f5efb2db72b91