### PR TITLE
Add change password feature

### DIFF
--- a/LYBT.UI.WPF/Interfaces/IAuthService.cs
+++ b/LYBT.UI.WPF/Interfaces/IAuthService.cs
@@ -1,4 +1,5 @@
 using LYBT.Common.Enums.Users;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,5 +15,7 @@ namespace LYBT.UI.WPF.Services {
         void ClearAutoLoginInfo();
         string RememberedUserName { get; }
         string RememberedPassword { get; }
+
+        Guid CurrentUserId { get; }
     }
 }

--- a/LYBT.UI.WPF/Services/AuthService.cs
+++ b/LYBT.UI.WPF/Services/AuthService.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace LYBT.UI.WPF.Services {
@@ -18,11 +20,13 @@ namespace LYBT.UI.WPF.Services {
         private bool _hasRemembered;
         private string _rememberedUserName;
         private string _rememberedPassword;
+        private Guid _currentUserId;
 
         public string Token => _token;
         public bool HasRemembered => _hasRemembered;
         public string RememberedUserName => _rememberedUserName;
         public string RememberedPassword => _rememberedPassword;
+        public Guid CurrentUserId => _currentUserId;
 
         private readonly string _autoLoginPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "autologin.json");
 
@@ -54,6 +58,15 @@ namespace LYBT.UI.WPF.Services {
                     roles = new List<UserRole> { result.User.Role };
 
                 _token = result.Token;
+                try {
+                    var handler = new JwtSecurityTokenHandler();
+                    var jwt = handler.ReadJwtToken(_token);
+                    var claim = jwt.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub);
+                    if (claim != null && Guid.TryParse(claim.Value, out var id))
+                        _currentUserId = id;
+                } catch {
+                    _currentUserId = Guid.Empty;
+                }
                 SaveAutoLoginInfo(userName, password);
 
                 return (true, roles, null, _token);
@@ -86,6 +99,7 @@ namespace LYBT.UI.WPF.Services {
             _hasRemembered = false;
             _rememberedUserName = null;
             _rememberedPassword = null;
+            _currentUserId = Guid.Empty;
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/ViewModels/Main/ChangePasswordViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangePasswordViewModel.cs
@@ -1,0 +1,16 @@
+using Prism.Mvvm;
+using System;
+using LYBT.UI.WPF.Services;
+
+namespace LYBT.UI.WPF.ViewModels.Main {
+    public class ChangePasswordViewModel : BindableBase {
+        private string _oldPassword = string.Empty;
+        public string OldPassword { get => _oldPassword; set => SetProperty(ref _oldPassword, value); }
+
+        private string _newPassword = string.Empty;
+        public string NewPassword { get => _newPassword; set => SetProperty(ref _newPassword, value); }
+
+        private string _confirmPassword = string.Empty;
+        public string ConfirmPassword { get => _confirmPassword; set => SetProperty(ref _confirmPassword, value); }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using LYBT.Module.Auth.Services;
 using LYBT.UI.WPF.Events;
 using LYBT.UI.WPF.Services;
+using LYBT.UI.WPF.Views;
 using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
@@ -25,22 +26,26 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         /// 属性 LogoutCommand 的说明
         /// </summary>
         public DelegateCommand LogoutCommand { get; }
+        public DelegateCommand ChangePasswordCommand { get; }
 
         private readonly IEventAggregator _eventAggregator;
         private readonly IRegionManager _regionManager;
 
         private readonly IAuthService _authService;
+        private readonly IUserService _userService;
 
-        public MainWindowViewModel(IEventAggregator eventAggregator, IRegionManager regionManager, IAuthService authService) {
+        public MainWindowViewModel(IEventAggregator eventAggregator, IRegionManager regionManager, IAuthService authService, IUserService userService) {
             _eventAggregator = eventAggregator;
             _regionManager = regionManager;
             _authService = authService;
+            _userService = userService;
 
             // 订阅登录成功事件
             _eventAggregator.GetEvent<LoginSuccessEvent>().Subscribe(OnLoginSuccess);
 
             // 初始化退出命令
             LogoutCommand = new DelegateCommand(Logout);
+            ChangePasswordCommand = new DelegateCommand(ChangePassword);
         }
 
         /// <summary>
@@ -61,6 +66,14 @@ namespace LYBT.UI.WPF.ViewModels.Main {
 
             // 清除自动登录信息
             _authService.ClearAutoLoginInfo();
+        }
+
+        private void ChangePassword() {
+            var window = new ChangePasswordWindow(_userService, _authService) { Owner = Application.Current.MainWindow };
+            window.DataContext = new ChangePasswordViewModel();
+            if (window.ShowDialog() == true) {
+                Logout();
+            }
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/Views/ChangePasswordWindow.xaml
+++ b/LYBT.UI.WPF/Views/ChangePasswordWindow.xaml
@@ -1,0 +1,30 @@
+<Window x:Class="LYBT.UI.WPF.Views.ChangePasswordWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:prism="http://prismlibrary.com/"
+        prism:ViewModelLocator.AutoWireViewModel="True"
+        Title="修改密码" Height="480" Width="420" WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+    <Grid>
+        <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
+            <Border Padding="32" MinWidth="380" MinHeight="360" Background="#FAFAFAEE" CornerRadius="14" BorderBrush="#CCCCCC" BorderThickness="1">
+                <Border.Effect>
+                    <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
+                </Border.Effect>
+                <StackPanel>
+                    <TextBlock Text="修改密码" FontWeight="Bold" FontSize="22" HorizontalAlignment="Center" Margin="0,0,0,20"/>
+                    <TextBlock Text="原密码" Margin="0,0,0,4" FontSize="15"/>
+                    <PasswordBox x:Name="OldPasswordBox" Height="32" FontSize="15" Margin="0,0,0,16" PasswordChanged="OldPasswordBox_PasswordChanged"/>
+                    <TextBlock Text="新密码" Margin="0,0,0,4" FontSize="15"/>
+                    <PasswordBox x:Name="NewPasswordBox" Height="32" FontSize="15" Margin="0,0,0,16" PasswordChanged="NewPasswordBox_PasswordChanged"/>
+                    <TextBlock Text="确认新密码" Margin="0,0,0,4" FontSize="15"/>
+                    <PasswordBox x:Name="ConfirmPasswordBox" Height="32" FontSize="15" Margin="0,0,0,20" PasswordChanged="ConfirmPasswordBox_PasswordChanged"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                        <Button Content="确定" Width="80" Height="34" Margin="0,0,10,0" Click="Ok_Click"/>
+                        <Button Content="取消" Width="80" Height="34" Click="Cancel_Click"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</Window>

--- a/LYBT.UI.WPF/Views/ChangePasswordWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/ChangePasswordWindow.xaml.cs
@@ -1,0 +1,60 @@
+using LYBT.UI.WPF.Services;
+using LYBT.UI.WPF.ViewModels.Main;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.Views {
+    public partial class ChangePasswordWindow : Window {
+        private readonly IUserService _userService;
+        private readonly IAuthService _authService;
+        public ChangePasswordWindow(IUserService userService, IAuthService authService) {
+            InitializeComponent();
+            _userService = userService;
+            _authService = authService;
+        }
+
+        private void OldPasswordBox_PasswordChanged(object sender, RoutedEventArgs e) {
+            if (DataContext is ChangePasswordViewModel vm) {
+                vm.OldPassword = OldPasswordBox.Password;
+            }
+        }
+
+        private void NewPasswordBox_PasswordChanged(object sender, RoutedEventArgs e) {
+            if (DataContext is ChangePasswordViewModel vm) {
+                vm.NewPassword = NewPasswordBox.Password;
+            }
+        }
+
+        private void ConfirmPasswordBox_PasswordChanged(object sender, RoutedEventArgs e) {
+            if (DataContext is ChangePasswordViewModel vm) {
+                vm.ConfirmPassword = ConfirmPasswordBox.Password;
+            }
+        }
+
+        private async void Ok_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is not ChangePasswordViewModel vm) return;
+            if (vm.NewPassword != vm.ConfirmPassword) {
+                MessageBox.Show("两次输入的新密码不一致！", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            var userId = _authService.CurrentUserId;
+            if (userId == Guid.Empty) {
+                MessageBox.Show("无法获取当前用户信息！", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+            var ok = await _userService.ChangePasswordAsync(userId, vm.OldPassword, vm.NewPassword);
+            if (!ok) {
+                MessageBox.Show("修改密码失败！", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
+            MessageBox.Show("密码修改成功，请使用新密码重新登录。", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e) {
+            DialogResult = false;
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Main/MainWindow.xaml
+++ b/LYBT.UI.WPF/Views/Main/MainWindow.xaml
@@ -25,15 +25,20 @@
                    VerticalAlignment="Center"
                    HorizontalAlignment="Left"
                    Margin="20,0,0,0"/>
-                    <!-- 右上角退出按钮 -->
-                    <Button Content="退出"
-                Width="68" Height="34"
-                HorizontalAlignment="Right" VerticalAlignment="Center"
-                Margin="0,0,22,0"
-                Command="{Binding LogoutCommand}"
-                Background="#FF57606A" Foreground="White"
-                FontWeight="Bold" BorderThickness="0"
-                Cursor="Hand"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,22,0">
+                        <Button Content="修改密码"
+                                Width="80" Height="34" Margin="0,0,10,0"
+                                Command="{Binding ChangePasswordCommand}"
+                                Background="#FF57606A" Foreground="White"
+                                FontWeight="Bold" BorderThickness="0"
+                                Cursor="Hand"/>
+                        <Button Content="退出"
+                                Width="68" Height="34"
+                                Command="{Binding LogoutCommand}"
+                                Background="#FF57606A" Foreground="White"
+                                FontWeight="Bold" BorderThickness="0"
+                                Cursor="Hand"/>
+                    </StackPanel>
                 </Grid>
             </Border>
             <!-- 主内容区域，加载 HomeView -->


### PR DESCRIPTION
## Summary
- extend auth service to keep logged-in user's id
- add change password view and view model
- integrate change password button in main window
- show modal dialog for password change and logout after success

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68672d26fce483338370b9bb21476133