### PR TITLE
Convert password change to single-window user control

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -99,6 +99,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<AdminView>("AdminView");
             containerRegistry.RegisterForNavigation<UserManagementView>("UserManagementView");
             containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
+            containerRegistry.RegisterForNavigation<ChangePasswordView>("ChangePasswordView");
 
         }
 

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using LYBT.Module.Auth.Services;
 using LYBT.UI.WPF.Events;
 using LYBT.UI.WPF.Services;
 using LYBT.UI.WPF.Views;
+using System.Collections.Generic;
 using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
@@ -28,6 +29,8 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         public DelegateCommand LogoutCommand { get; }
         public DelegateCommand ChangePasswordCommand { get; }
 
+        private IList<UserRole> _currentRoles = new List<UserRole>();
+
         private readonly IEventAggregator _eventAggregator;
         private readonly IRegionManager _regionManager;
 
@@ -51,7 +54,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         /// <summary>
         /// 方法 Logout 的说明
         /// </summary>
-        private void Logout() {
+        public void Logout() {
             // 显示登录界面，隐藏主界面
             IsMainVisible = false;
             IsLoginVisible = true;
@@ -69,23 +72,22 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         }
 
         private void ChangePassword() {
-            var window = new ChangePasswordWindow(_userService, _authService) { Owner = Application.Current.MainWindow };
-            window.DataContext = new ChangePasswordViewModel();
-            if (window.ShowDialog() == true) {
-                Logout();
-            }
+            _regionManager.RequestNavigate("MainContentRegion", nameof(ChangePasswordView));
+        }
+
+        public void ShowHomeView() {
+            _regionManager.RequestNavigate("MainContentRegion", "HomeView", new NavigationParameters { { "UserRoles", _currentRoles } });
         }
 
         /// <summary>
         /// 方法 OnLoginSuccess 的说明
         /// </summary>
         private void OnLoginSuccess(IList<UserRole> roles) {
+            _currentRoles = roles;
             IsLoginVisible = false;
             IsMainVisible = true;
-            // 最大化窗口
             Application.Current.MainWindow.WindowState = WindowState.Maximized;
-            // 导航到主内容区（如HomeView）
-            _regionManager.RequestNavigate("MainContentRegion", "HomeView", new NavigationParameters { { "UserRoles", roles } });
+            ShowHomeView();
         }
     }
 }

--- a/LYBT.UI.WPF/Views/ChangePasswordView.xaml
+++ b/LYBT.UI.WPF/Views/ChangePasswordView.xaml
@@ -1,9 +1,8 @@
-<Window x:Class="LYBT.UI.WPF.Views.ChangePasswordWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:prism="http://prismlibrary.com/"
-        prism:ViewModelLocator.AutoWireViewModel="True"
-        Title="修改密码" Height="480" Width="420" WindowStartupLocation="CenterOwner" ResizeMode="NoResize">
+<UserControl x:Class="LYBT.UI.WPF.Views.ChangePasswordView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
         <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
@@ -27,4 +26,4 @@
             </Border>
         </Grid>
     </Grid>
-</Window>
+</UserControl>

--- a/LYBT.UI.WPF/Views/ChangePasswordView.xaml.cs
+++ b/LYBT.UI.WPF/Views/ChangePasswordView.xaml.cs
@@ -1,15 +1,14 @@
 using LYBT.UI.WPF.Services;
 using LYBT.UI.WPF.ViewModels.Main;
 using System;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 
 namespace LYBT.UI.WPF.Views {
-    public partial class ChangePasswordWindow : Window {
+    public partial class ChangePasswordView : UserControl {
         private readonly IUserService _userService;
         private readonly IAuthService _authService;
-        public ChangePasswordWindow(IUserService userService, IAuthService authService) {
+        public ChangePasswordView(IUserService userService, IAuthService authService) {
             InitializeComponent();
             _userService = userService;
             _authService = authService;
@@ -50,11 +49,15 @@ namespace LYBT.UI.WPF.Views {
                 return;
             }
             MessageBox.Show("密码修改成功，请使用新密码重新登录。", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
-            DialogResult = true;
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel mainVm) {
+                mainVm.Logout();
+            }
         }
 
         private void Cancel_Click(object sender, RoutedEventArgs e) {
-            DialogResult = false;
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel mainVm) {
+                mainVm.ShowHomeView();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- convert `ChangePasswordWindow` to `ChangePasswordView`
- update `MainWindowViewModel` to navigate to the user control instead of opening a new window
- register new view for Prism navigation

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6867315e5c6883338eda5d1054617428