### PR TITLE
Add change password workflow to header

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Main/ChangePasswordViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangePasswordViewModel.cs
@@ -45,13 +45,21 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             var ok = await _userService.ChangePasswordAsync(_authService.UserId, OldPassword, NewPassword);
             if (ok) {
                 MessageBox.Show("密码已修改，请重新登录", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+                if (Application.Current.MainWindow.DataContext is MainWindowViewModel main)
+                {
+                    main.LogoutCommand.Execute();
+                }
             } else {
                 ErrorMessage = "修改失败";
             }
         }
 
         private void OnCancel() {
-            // 该命令在功能区内可用于返回登录等操作，暂留空实现
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main)
+            {
+                main.IsMainVisible = true;
+                main.IsFunctionVisible = false;
+            }
         }
     }
 }

--- a/LYBT.UI.WPF/Views/Main/MainWindow.xaml
+++ b/LYBT.UI.WPF/Views/Main/MainWindow.xaml
@@ -25,15 +25,22 @@
                    VerticalAlignment="Center"
                    HorizontalAlignment="Left"
                    Margin="20,0,0,0"/>
-                    <!-- 右上角退出按钮 -->
-                    <Button Content="退出"
-                Width="68" Height="34"
-                HorizontalAlignment="Right" VerticalAlignment="Center"
-                Margin="0,0,22,0"
-                Command="{Binding LogoutCommand}"
-                Background="#FF57606A" Foreground="White"
-                FontWeight="Bold" BorderThickness="0"
-                Cursor="Hand"/>
+                    <!-- 右上角功能按钮 -->
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,22,0">
+                        <Button Content="修改密码"
+                                Width="80" Height="34"
+                                Margin="0,0,10,0"
+                                Command="{Binding ShowChangePasswordCommand}"
+                                Background="#FF57606A" Foreground="White"
+                                FontWeight="Bold" BorderThickness="0"
+                                Cursor="Hand"/>
+                        <Button Content="退出"
+                                Width="68" Height="34"
+                                Command="{Binding LogoutCommand}"
+                                Background="#FF57606A" Foreground="White"
+                                FontWeight="Bold" BorderThickness="0"
+                                Cursor="Hand"/>
+                    </StackPanel>
                 </Grid>
             </Border>
             <!-- 主内容区域，加载 HomeView -->


### PR DESCRIPTION
## Summary
- add '修改密码' button to main window header
- log out after password change and show login view
- allow canceling password changes to return to the main screen

## Testing
- `dotnet build LYBTZYZS.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6867573a080c8333800d81f2969099aa