### PR TITLE
Add change profile feature

### DIFF
--- a/LYBT.Module.Users/Dtos/ChangeProfileDto.cs
+++ b/LYBT.Module.Users/Dtos/ChangeProfileDto.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace LYBT.Module.Users.Dtos {
+    /// <summary>
+    /// 用户修改个人信息 DTO
+    /// </summary>
+    public class ChangeProfileDto {
+        /// <summary>用户ID</summary>
+        [Required]
+        public Guid UserId { get; set; }
+
+        /// <summary>真实姓名</summary>
+        [Required]
+        [StringLength(20)]
+        public string RealName { get; set; } = string.Empty;
+
+        /// <summary>邮箱地址</summary>
+        [EmailAddress]
+        public string? Email { get; set; }
+
+        /// <summary>联系电话</summary>
+        [Phone]
+        public string? PhoneNumber { get; set; }
+    }
+}

--- a/LYBT.Module.Users/Interfaces/IUserService.cs
+++ b/LYBT.Module.Users/Interfaces/IUserService.cs
@@ -57,6 +57,11 @@ public interface IUserService {
     Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword);
 
     /// <summary>
+    /// 用户修改个人信息
+    /// </summary>
+    Task<bool> ChangeProfileAsync(Guid id, string realName, string? email, string? phoneNumber);
+
+    /// <summary>
     /// 获取系统所有角色
     /// </summary>
     List<UserRole> GetRoles();

--- a/LYBT.Module.Users/Services/UserService.cs
+++ b/LYBT.Module.Users/Services/UserService.cs
@@ -257,6 +257,19 @@ public class UserService : IUserService {
         return await _userRepository.UpdateAsync(user);
     }
 
+    /// <summary>
+    /// 用户修改个人信息
+    /// </summary>
+    public async Task<bool> ChangeProfileAsync(Guid id, string realName, string? email, string? phoneNumber) {
+        var user = await _userRepository.GetByIdAsync(id);
+        if (user == null)
+            return false;
+        user.RealName = realName;
+        user.Email = email;
+        user.PhoneNumber = phoneNumber;
+        return await _userRepository.UpdateAsync(user);
+    }
+
     public List<UserRole> GetRoles() {
         return Enum.GetValues(typeof(UserRole)).Cast<UserRole>().ToList();
     }

--- a/LYBT.UI.WPF/Apis/IUserApi.cs
+++ b/LYBT.UI.WPF/Apis/IUserApi.cs
@@ -34,6 +34,9 @@ namespace LYBT.UI.WPF.Apis {
         [Post("/api/Users/changePassword")]
         Task<ApiSuccessResponse> ChangePasswordAsync([Body] ChangePasswordDto dto);
 
+        [Post("/api/Users/changeProfile")]
+        Task<ApiSuccessResponse> ChangeProfileAsync([Body] ChangeProfileDto dto);
+
         [Get("/api/Users/getRoles")]
         Task<List<UserRole>> GetRolesAsync();
 

--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -100,6 +100,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<UserManagementView>("UserManagementView");
             containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
             containerRegistry.RegisterForNavigation<ChangePasswordView>("ChangePasswordView");
+            containerRegistry.RegisterForNavigation<ChangeProfileView>("ChangeProfileView");
 
         }
 

--- a/LYBT.UI.WPF/Interfaces/IUserService.cs
+++ b/LYBT.UI.WPF/Interfaces/IUserService.cs
@@ -17,6 +17,7 @@ namespace LYBT.UI.WPF.Services {
         Task<int> BatchEnableAsync(List<Guid> ids);
         Task<bool> ResetPasswordAsync(Guid id);
         Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword);
+        Task<bool> ChangeProfileAsync(Guid id, string realName, string? email, string? phoneNumber);
         Task<IList<UserRole>> GetRolesAsync();
         Task<UserDto?> GetByIdAsync(Guid id);
     }

--- a/LYBT.UI.WPF/Services/UserService.cs
+++ b/LYBT.UI.WPF/Services/UserService.cs
@@ -92,6 +92,19 @@ namespace LYBT.UI.WPF.Services {
         }
 
         /// <summary>
+        /// 修改个人信息
+        /// </summary>
+        public async Task<bool> ChangeProfileAsync(Guid id, string realName, string? email, string? phoneNumber) {
+            var resp = await _userApi.ChangeProfileAsync(new ChangeProfileDto {
+                UserId = id,
+                RealName = realName,
+                Email = email,
+                PhoneNumber = phoneNumber
+            });
+            return resp.Success;
+        }
+
+        /// <summary>
         /// 方法 GetRolesAsync 的说明
         /// </summary>
         public async Task<IList<UserRole>> GetRolesAsync() {

--- a/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
@@ -1,0 +1,60 @@
+using Prism.Commands;
+using Prism.Mvvm;
+using Services = LYBT.UI.WPF.Services;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Main {
+    public class ChangeProfileViewModel : BindableBase {
+        private readonly Services.IUserService _userService;
+        private readonly Services.IAuthService _authService;
+
+        private string _realName = string.Empty;
+        public string RealName { get => _realName; set => SetProperty(ref _realName, value); }
+
+        private string? _email;
+        public string? Email { get => _email; set => SetProperty(ref _email, value); }
+
+        private string? _phoneNumber;
+        public string? PhoneNumber { get => _phoneNumber; set => SetProperty(ref _phoneNumber, value); }
+
+        private string _errorMessage = string.Empty;
+        public string ErrorMessage { get => _errorMessage; set => SetProperty(ref _errorMessage, value); }
+
+        public DelegateCommand SaveCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+
+        public ChangeProfileViewModel(Services.IUserService userService, Services.IAuthService authService) {
+            _userService = userService;
+            _authService = authService;
+            SaveCommand = new DelegateCommand(async () => await ChangeAsync(), CanSave)
+                .ObservesProperty(() => RealName);
+            CancelCommand = new DelegateCommand(OnCancel);
+        }
+
+        private bool CanSave() {
+            return !string.IsNullOrWhiteSpace(RealName);
+        }
+
+        private async Task ChangeAsync() {
+            ErrorMessage = string.Empty;
+            var ok = await _userService.ChangeProfileAsync(_authService.UserId, RealName, Email, PhoneNumber);
+            if (ok) {
+                MessageBox.Show("信息已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+                if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                    main.IsMainVisible = true;
+                    main.IsFunctionVisible = false;
+                }
+            } else {
+                ErrorMessage = "修改失败";
+            }
+        }
+
+        private void OnCancel() {
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                main.IsMainVisible = true;
+                main.IsFunctionVisible = false;
+            }
+        }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -33,6 +33,11 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         /// </summary>
         public DelegateCommand ShowChangePasswordCommand { get; }
 
+        /// <summary>
+        /// 显示修改个人信息界面
+        /// </summary>
+        public DelegateCommand ShowChangeProfileCommand { get; }
+
         private readonly IEventAggregator _eventAggregator;
         private readonly IRegionManager _regionManager;
 
@@ -49,6 +54,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             // 初始化命令
             LogoutCommand = new DelegateCommand(Logout);
             ShowChangePasswordCommand = new DelegateCommand(ShowChangePassword);
+            ShowChangeProfileCommand = new DelegateCommand(ShowChangeProfile);
         }
 
         /// <summary>
@@ -75,6 +81,12 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             IsMainVisible = false;
             IsFunctionVisible = true;
             _regionManager.RequestNavigate("FunctionRegion", "ChangePasswordView");
+        }
+
+        private void ShowChangeProfile() {
+            IsMainVisible = false;
+            IsFunctionVisible = true;
+            _regionManager.RequestNavigate("FunctionRegion", "ChangeProfileView");
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Main.ChangeProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+        <StackPanel>
+            <TextBlock Text="修改个人信息" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
+            <TextBlock Text="真实姓名"/>
+            <TextBox Text="{Binding RealName, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
+            <TextBlock Text="邮箱"/>
+            <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
+            <TextBlock Text="联系电话"/>
+            <TextBox Text="{Binding PhoneNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,20"/>
+            <Button Content="保存" Command="{Binding SaveCommand}" Height="32" Margin="0,0,0,10"/>
+            <Button Content="取消" Command="{Binding CancelCommand}" Height="32"/>
+            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" Margin="0,10,0,0" TextWrapping="Wrap"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Main {
+    public partial class ChangeProfileView : UserControl {
+        public ChangeProfileView() {
+            InitializeComponent();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Main/MainWindow.xaml
+++ b/LYBT.UI.WPF/Views/Main/MainWindow.xaml
@@ -34,6 +34,13 @@
                                 Background="#FF57606A" Foreground="White"
                                 FontWeight="Bold" BorderThickness="0"
                                 Cursor="Hand"/>
+                        <Button Content="修改个人信息"
+                                Width="100" Height="34"
+                                Margin="0,0,10,0"
+                                Command="{Binding ShowChangeProfileCommand}"
+                                Background="#FF57606A" Foreground="White"
+                                FontWeight="Bold" BorderThickness="0"
+                                Cursor="Hand"/>
                         <Button Content="退出"
                                 Width="68" Height="34"
                                 Command="{Binding LogoutCommand}"

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -131,6 +131,15 @@ public class UsersController : ControllerBase {
     }
 
     /// <summary>
+    /// 用户修改个人信息
+    /// </summary>
+    [HttpPost("changeProfile")]
+    public async Task<IActionResult> ChangeProfile([FromBody] ChangeProfileDto dto) {
+        var result = await _userService.ChangeProfileAsync(dto.UserId, dto.RealName, dto.Email, dto.PhoneNumber);
+        return result ? Ok(new { success = true }) : BadRequest(new { success = false });
+    }
+
+    /// <summary>
     /// 获取所有角色
     /// </summary>
     [HttpGet("getRoles")]


### PR DESCRIPTION
## Summary
- allow users to update personal info without changing username
- expose new API endpoint for profile updates
- support profile update in WPF client with new view

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68675d03d348833386b8bd1452179b08