### PR TITLE
Update profile and password UI

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
@@ -9,6 +9,15 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         private readonly Services.IUserService _userService;
         private readonly Services.IAuthService _authService;
 
+        private string _originalRealName = string.Empty;
+        public string OriginalRealName { get => _originalRealName; set => SetProperty(ref _originalRealName, value); }
+
+        private string? _originalEmail;
+        public string? OriginalEmail { get => _originalEmail; set => SetProperty(ref _originalEmail, value); }
+
+        private string? _originalPhoneNumber;
+        public string? OriginalPhoneNumber { get => _originalPhoneNumber; set => SetProperty(ref _originalPhoneNumber, value); }
+
         private string _realName = string.Empty;
         public string RealName { get => _realName; set => SetProperty(ref _realName, value); }
 
@@ -30,6 +39,20 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             SaveCommand = new DelegateCommand(async () => await ChangeAsync(), CanSave)
                 .ObservesProperty(() => RealName);
             CancelCommand = new DelegateCommand(OnCancel);
+            _ = LoadAsync();
+        }
+
+        public async Task LoadAsync() {
+            var user = await _userService.GetByIdAsync(_authService.UserId);
+            if (user != null) {
+                OriginalRealName = user.RealName;
+                OriginalEmail = user.Email;
+                OriginalPhoneNumber = user.PhoneNumber;
+
+                RealName = user.RealName;
+                Email = user.Email;
+                PhoneNumber = user.PhoneNumber;
+            }
         }
 
         private bool CanSave() {
@@ -45,6 +68,9 @@ namespace LYBT.UI.WPF.ViewModels.Main {
                     main.IsMainVisible = true;
                     main.IsFunctionVisible = false;
                 }
+                OriginalRealName = RealName;
+                OriginalEmail = Email;
+                OriginalPhoneNumber = PhoneNumber;
             } else {
                 ErrorMessage = "修改失败";
             }

--- a/LYBT.UI.WPF/Views/Main/ChangePasswordView.xaml
+++ b/LYBT.UI.WPF/Views/Main/ChangePasswordView.xaml
@@ -3,18 +3,26 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
              prism:ViewModelLocator.AutoWireViewModel="True">
-    <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
-        <StackPanel>
-            <TextBlock Text="修改密码" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
-            <TextBlock Text="旧密码"/>
-            <PasswordBox x:Name="oldPasswordBox" Margin="0,4,0,10" PasswordChanged="OldPasswordBox_PasswordChanged"/>
-            <TextBlock Text="新密码"/>
-            <PasswordBox x:Name="newPasswordBox" Margin="0,4,0,10" PasswordChanged="NewPasswordBox_PasswordChanged"/>
-            <TextBlock Text="确认新密码"/>
-            <PasswordBox x:Name="confirmPasswordBox" Margin="0,4,0,20" PasswordChanged="ConfirmPasswordBox_PasswordChanged"/>
-            <Button Content="保存" Command="{Binding SaveCommand}" Height="32" Margin="0,0,0,10"/>
-            <Button Content="取消" Command="{Binding CancelCommand}" Height="32"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" Margin="0,10,0,0" TextWrapping="Wrap"/>
-        </StackPanel>
+    <Grid>
+        <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
+            <Border Padding="32" MinWidth="380" MinHeight="430" Background="#FAFAFAEE" CornerRadius="14" BorderBrush="#CCCCCC" BorderThickness="1">
+                <Border.Effect>
+                    <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
+                </Border.Effect>
+                <StackPanel>
+                    <TextBlock Text="修改密码" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
+                    <TextBlock Text="旧密码"/>
+                    <PasswordBox x:Name="oldPasswordBox" Margin="0,4,0,10" PasswordChanged="OldPasswordBox_PasswordChanged"/>
+                    <TextBlock Text="新密码"/>
+                    <PasswordBox x:Name="newPasswordBox" Margin="0,4,0,10" PasswordChanged="NewPasswordBox_PasswordChanged"/>
+                    <TextBlock Text="确认新密码"/>
+                    <PasswordBox x:Name="confirmPasswordBox" Margin="0,4,0,20" PasswordChanged="ConfirmPasswordBox_PasswordChanged"/>
+                    <Button Content="保存" Command="{Binding SaveCommand}" Height="32" Margin="0,0,0,10"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Height="32"/>
+                    <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" Margin="0,10,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+        </Grid>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
@@ -3,18 +3,33 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
              prism:ViewModelLocator.AutoWireViewModel="True">
-    <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
-        <StackPanel>
-            <TextBlock Text="修改个人信息" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
-            <TextBlock Text="真实姓名"/>
-            <TextBox Text="{Binding RealName, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
-            <TextBlock Text="邮箱"/>
-            <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
-            <TextBlock Text="联系电话"/>
-            <TextBox Text="{Binding PhoneNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,20"/>
-            <Button Content="保存" Command="{Binding SaveCommand}" Height="32" Margin="0,0,0,10"/>
-            <Button Content="取消" Command="{Binding CancelCommand}" Height="32"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" Margin="0,10,0,0" TextWrapping="Wrap"/>
-        </StackPanel>
+    <Grid>
+        <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
+            <Border Padding="32" MinWidth="380" MinHeight="430" Background="#FAFAFAEE" CornerRadius="14" BorderBrush="#CCCCCC" BorderThickness="1">
+                <Border.Effect>
+                    <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
+                </Border.Effect>
+                <StackPanel>
+                    <TextBlock Text="修改个人信息" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
+
+                    <TextBlock><Run Text="原姓名："/><Run Text="{Binding OriginalRealName}"/></TextBlock>
+                    <TextBlock Text="现姓名" Margin="0,8,0,0"/>
+                    <TextBox Text="{Binding RealName, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
+
+                    <TextBlock><Run Text="原邮箱："/><Run Text="{Binding OriginalEmail}"/></TextBlock>
+                    <TextBlock Text="现邮箱" Margin="0,8,0,0"/>
+                    <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
+
+                    <TextBlock><Run Text="原联系电话："/><Run Text="{Binding OriginalPhoneNumber}"/></TextBlock>
+                    <TextBlock Text="现联系电话" Margin="0,8,0,0"/>
+                    <TextBox Text="{Binding PhoneNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,20"/>
+
+                    <Button Content="保存" Command="{Binding SaveCommand}" Height="32" Margin="0,0,0,10"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Height="32"/>
+                    <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" Margin="0,10,0,0" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
+        </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- adopt background style from login for change password and change profile views
- show original and new user information in change profile view
- fetch current user info on opening change profile view

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686767a616308333952efcaff5531ea2