### PR TITLE
Fix profile screen layout

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
@@ -1,11 +1,12 @@
 using Prism.Commands;
 using Prism.Mvvm;
+using Prism.Regions;
 using Services = LYBT.UI.WPF.Services;
 using System.Threading.Tasks;
 using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
-    public class ChangeProfileViewModel : BindableBase {
+    public class ChangeProfileViewModel : BindableBase, INavigationAware {
         private readonly Services.IUserService _userService;
         private readonly Services.IAuthService _authService;
 
@@ -39,7 +40,6 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             SaveCommand = new DelegateCommand(async () => await ChangeAsync(), CanSave)
                 .ObservesProperty(() => RealName);
             CancelCommand = new DelegateCommand(OnCancel);
-            _ = LoadAsync();
         }
 
         public async Task LoadAsync() {
@@ -82,5 +82,13 @@ namespace LYBT.UI.WPF.ViewModels.Main {
                 main.IsFunctionVisible = false;
             }
         }
+
+        public void OnNavigatedTo(NavigationContext navigationContext) {
+            _ = LoadAsync();
+        }
+
+        public bool IsNavigationTarget(NavigationContext navigationContext) => true;
+
+        public void OnNavigatedFrom(NavigationContext navigationContext) { }
     }
 }

--- a/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
@@ -13,17 +13,38 @@
                 <StackPanel>
                     <TextBlock Text="修改个人信息" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
 
-                    <TextBlock><Run Text="原姓名："/><Run Text="{Binding OriginalRealName}"/></TextBlock>
-                    <TextBlock Text="现姓名" Margin="0,8,0,0"/>
-                    <TextBox Text="{Binding RealName, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
+                    <Grid>
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                            <RowDefinition/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
 
-                    <TextBlock><Run Text="原邮箱："/><Run Text="{Binding OriginalEmail}"/></TextBlock>
-                    <TextBlock Text="现邮箱" Margin="0,8,0,0"/>
-                    <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,10"/>
+                        <TextBlock Text="原姓名：" Grid.Row="0" Grid.Column="0"/>
+                        <TextBlock Text="{Binding OriginalRealName}" Grid.Row="0" Grid.Column="1"/>
 
-                    <TextBlock><Run Text="原联系电话："/><Run Text="{Binding OriginalPhoneNumber}"/></TextBlock>
-                    <TextBlock Text="现联系电话" Margin="0,8,0,0"/>
-                    <TextBox Text="{Binding PhoneNumber, UpdateSourceTrigger=PropertyChanged}" Margin="0,4,0,20"/>
+                        <TextBlock Text="现姓名：" Grid.Row="1" Grid.Column="0" Margin="0,8,0,0"/>
+                        <TextBox Text="{Binding RealName, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Grid.Column="1" Margin="0,4,0,0"/>
+
+                        <TextBlock Text="原邮箱：" Grid.Row="2" Grid.Column="0" Margin="0,8,0,0"/>
+                        <TextBlock Text="{Binding OriginalEmail}" Grid.Row="2" Grid.Column="1" Margin="0,8,0,0"/>
+
+                        <TextBlock Text="现邮箱：" Grid.Row="3" Grid.Column="0" Margin="0,8,0,0"/>
+                        <TextBox Text="{Binding Email, UpdateSourceTrigger=PropertyChanged}" Grid.Row="3" Grid.Column="1" Margin="0,4,0,0"/>
+
+                        <TextBlock Text="原联系电话：" Grid.Row="4" Grid.Column="0" Margin="0,8,0,0"/>
+                        <TextBlock Text="{Binding OriginalPhoneNumber}" Grid.Row="4" Grid.Column="1" Margin="0,8,0,0"/>
+
+                        <TextBlock Text="现联系电话：" Grid.Row="5" Grid.Column="0" Margin="0,8,0,0"/>
+                        <TextBox Text="{Binding PhoneNumber, UpdateSourceTrigger=PropertyChanged}" Grid.Row="5" Grid.Column="1" Margin="0,4,0,20"/>
+                    </Grid>
 
                     <Button Content="保存" Command="{Binding SaveCommand}" Height="32" Margin="0,0,0,10"/>
                     <Button Content="取消" Command="{Binding CancelCommand}" Height="32"/>


### PR DESCRIPTION
## Summary
- show original values and editing inputs in aligned grid rows
- reload personal info when navigating to the screen

## Testing
- `dotnet build LYBTZYZS.sln -v q` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676eba327083339e1f84004fd62c37