### PR TITLE
Fix login overlay and add footer text

### DIFF
--- a/LYBT.UI.WPF/Views/Main/LoginView.xaml
+++ b/LYBT.UI.WPF/Views/Main/LoginView.xaml
@@ -9,7 +9,7 @@
         <Image Source="/Assets/bg.jpg"
                Stretch="UniformToFill"
                Panel.ZIndex="0"/>
-        <Border Background="#A6FFFFFF" Panel.ZIndex="1"/>
+
 
         <!-- 登录卡片部分，只修改这块为左右结构 -->
         <Border Width="520"
@@ -43,6 +43,11 @@
                                    Foreground="#F6F6F6"
                                    HorizontalAlignment="Center"
                                    Margin="0,8,0,0"/>
+                        <TextBlock Text="⊙2024 凌隐宝堂中医诊所 All Rights Reserved."
+                                   FontSize="9"
+                                   Foreground="#F6F6F6"
+                                   HorizontalAlignment="Center"
+                                   Margin="0,20,0,0"/>
                     </StackPanel>
                 </Border>
 


### PR DESCRIPTION
## Summary
- remove translucent overlay that blocked mouse clicks on LoginView
- show clinic copyright line beneath the logo

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: missing references)*

------
https://chatgpt.com/codex/tasks/task_e_68677bd2999c833394772a4aafcda7d1