### PR TITLE
Resize login and settings screens

### DIFF
--- a/LYBT.UI.WPF/Views/Main/ChangePasswordView.xaml
+++ b/LYBT.UI.WPF/Views/Main/ChangePasswordView.xaml
@@ -6,7 +6,7 @@
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
         <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
-            <Border Padding="32" MinWidth="380" MinHeight="430" Background="#F9FAFB" CornerRadius="14" BorderBrush="#19b5fe" BorderThickness="1">
+            <Border Padding="32" MinWidth="570" MinHeight="645" Background="#F9FAFB" CornerRadius="14" BorderBrush="#19b5fe" BorderThickness="1">
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
                 </Border.Effect>

--- a/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/ChangeProfileView.xaml
@@ -6,7 +6,7 @@
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
         <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
-            <Border Padding="32" MinWidth="380" MinHeight="430" Background="#F9FAFB" CornerRadius="14" BorderBrush="#19b5fe" BorderThickness="1">
+            <Border Padding="32" MinWidth="570" MinHeight="645" Background="#F9FAFB" CornerRadius="14" BorderBrush="#19b5fe" BorderThickness="1">
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
                 </Border.Effect>

--- a/LYBT.UI.WPF/Views/Main/LoginView.xaml
+++ b/LYBT.UI.WPF/Views/Main/LoginView.xaml
@@ -12,8 +12,8 @@
 
 
         <!-- 登录卡片部分，只修改这块为左右结构 -->
-        <Border Width="520"
-                Height="340"
+        <Border Width="780"
+                Height="510"
                 CornerRadius="14"
                 Background="#F9FAFB"
                 HorizontalAlignment="Center"
@@ -30,25 +30,31 @@
                 <Border Grid.Column="0"
                         Background="#19b5fe"
                         CornerRadius="14,0,0,14">
-                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Margin="8">
-                        <Image Source="/Assets/Logo.jpg"
-                               Width="72" Height="72" Margin="0,0,0,22"/>
-                        <TextBlock Text="凌隐宝堂中医诊所"
-                                   FontSize="22"
-                                   FontWeight="Bold"
-                                   Foreground="White"
-                                   HorizontalAlignment="Center"/>
-                        <TextBlock Text="LYBT TCM CLINIC"
-                                   FontSize="14"
-                                   Foreground="#F6F6F6"
-                                   HorizontalAlignment="Center"
-                                   Margin="0,8,0,0"/>
-                        <TextBlock Text="⊙2024 凌隐宝堂中医诊所 All Rights Reserved."
+                    <Grid Margin="8">
+                        <Grid.RowDefinitions>
+                            <RowDefinition/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+                        <StackPanel Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <Image Source="/Assets/Logo.jpg"
+                                   Width="72" Height="72" Margin="0,0,0,22"/>
+                            <TextBlock Text="凌隐宝堂中医诊所"
+                                       FontSize="22"
+                                       FontWeight="Bold"
+                                       Foreground="White"
+                                       HorizontalAlignment="Center"/>
+                            <TextBlock Text="LYBT TCM CLINIC"
+                                       FontSize="14"
+                                       Foreground="#F6F6F6"
+                                       HorizontalAlignment="Center"
+                                       Margin="0,8,0,0"/>
+                        </StackPanel>
+                        <TextBlock Grid.Row="1" Text="⊙2024 凌隐宝堂中医诊所 All Rights Reserved."
                                    FontSize="9"
                                    Foreground="#F6F6F6"
                                    HorizontalAlignment="Center"
-                                   Margin="0,20,0,0"/>
-                    </StackPanel>
+                                   Margin="0,20,0,10"/>
+                    </Grid>
                 </Border>
 
                 <!-- 右侧：登录表单 -->


### PR DESCRIPTION
## Summary
- enlarge Login, ChangePassword, ChangeProfile windows by 1.5x
- keep login copyright text closer to bottom

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867865c8f88833389f2d98b81a0fe40