### PR TITLE
Add doctor profile management view

### DIFF
--- a/LYBT.Module.Doctors/Interfaces/IDoctorRepository.cs
+++ b/LYBT.Module.Doctors/Interfaces/IDoctorRepository.cs
@@ -14,6 +14,11 @@ namespace LYBT.Module.Doctors.Interfaces {
         Task<DoctorModel?> GetByIdAsync(Guid id);
 
         /// <summary>
+        /// 根据用户ID获取医生详情
+        /// </summary>
+        Task<DoctorModel?> GetByUserIdAsync(Guid userId);
+
+        /// <summary>
         /// 获取所有医生列表（不分页）
         /// </summary>
         Task<List<DoctorModel>> GetListAsync();

--- a/LYBT.Module.Doctors/Interfaces/IDoctorService.cs
+++ b/LYBT.Module.Doctors/Interfaces/IDoctorService.cs
@@ -14,6 +14,11 @@ namespace LYBT.Module.Doctors.Interfaces {
         Task<DoctorDetailDto?> GetByIdAsync(Guid id);
 
         /// <summary>
+        /// 根据用户ID获取医生详情
+        /// </summary>
+        Task<DoctorDetailDto?> GetByUserIdAsync(Guid userId);
+
+        /// <summary>
         /// 关键词搜索
         /// </summary>
         Task<List<DoctorDto>> SearchAsync(string keyword);

--- a/LYBT.Module.Doctors/Repositories/DoctorRepository.cs
+++ b/LYBT.Module.Doctors/Repositories/DoctorRepository.cs
@@ -30,6 +30,12 @@ namespace LYBT.Module.Doctors.Repositories {
                 .FirstOrDefaultAsync(d => d.Id == id);
         }
 
+        public async Task<DoctorModel?> GetByUserIdAsync(Guid userId) {
+            return await _appDbContext.Doctors
+                .Include(d => d.User)
+                .FirstOrDefaultAsync(d => d.UserId == userId);
+        }
+
         /// <summary>
         /// 获取所有医生
         /// </summary>

--- a/LYBT.Module.Doctors/Services/DoctorService.cs
+++ b/LYBT.Module.Doctors/Services/DoctorService.cs
@@ -34,6 +34,11 @@ namespace LYBT.Module.Doctors.Services {
             return model == null ? null : _mapper.Map<DoctorDetailDto>(model);
         }
 
+        public async Task<DoctorDetailDto?> GetByUserIdAsync(Guid userId) {
+            var model = await _doctorRepository.GetByUserIdAsync(userId);
+            return model == null ? null : _mapper.Map<DoctorDetailDto>(model);
+        }
+
         /// <summary>
         /// 关键词搜索
         /// </summary>

--- a/LYBT.UI.WPF/Apis/IDoctorApi.cs
+++ b/LYBT.UI.WPF/Apis/IDoctorApi.cs
@@ -13,6 +13,9 @@ namespace LYBT.UI.WPF.Apis {
         [Get("/api/Doctors/{id}")]
         Task<DoctorDetailDto> GetByIdAsync(Guid id);
 
+        [Get("/api/Doctors/by-user/{userId}")]
+        Task<DoctorDetailDto> GetByUserIdAsync(Guid userId);
+
         [Post("/api/Doctors/add")]
         Task<ApiSuccessResponse> AddAsync([Body] DoctorCreateDto dto);
 

--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -102,6 +102,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
             containerRegistry.RegisterForNavigation<ChangePasswordView>("ChangePasswordView");
             containerRegistry.RegisterForNavigation<ChangeProfileView>("ChangeProfileView");
+            containerRegistry.RegisterForNavigation<DoctorProfileView>("DoctorProfileView");
 
         }
 

--- a/LYBT.UI.WPF/Interfaces/IDoctorService.cs
+++ b/LYBT.UI.WPF/Interfaces/IDoctorService.cs
@@ -8,6 +8,7 @@ namespace LYBT.UI.WPF.Services {
     public interface IDoctorService {
         Task<IList<DoctorDto>> SearchAsync(string keyword = "");
         Task<DoctorDetailDto?> GetByIdAsync(Guid id);
+        Task<DoctorDetailDto?> GetByUserIdAsync(Guid userId);
         Task<bool> AddAsync(DoctorCreateDto dto);
         Task<bool> UpdateAsync(DoctorEditDto dto);
         Task<bool> DisableAsync(Guid id);

--- a/LYBT.UI.WPF/Services/DoctorService.cs
+++ b/LYBT.UI.WPF/Services/DoctorService.cs
@@ -29,6 +29,10 @@ namespace LYBT.UI.WPF.Services {
             return await _doctorApi.GetByIdAsync(id);
         }
 
+        public async Task<DoctorDetailDto?> GetByUserIdAsync(Guid userId) {
+            return await _doctorApi.GetByUserIdAsync(userId);
+        }
+
         /// <summary>
         /// 方法 AddAsync 的说明
         /// </summary>

--- a/LYBT.UI.WPF/ViewModels/Main/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/DoctorProfileViewModel.cs
@@ -1,0 +1,109 @@
+using LYBT.Common.Enums;
+using LYBT.Module.Doctors.Dtos;
+using LYBT.UI.WPF.Services;
+using Prism.Commands;
+using Prism.Mvvm;
+using Prism.Regions;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Main {
+    public class DoctorProfileViewModel : BindableBase, INavigationAware {
+        private readonly IDoctorService _doctorService;
+        private readonly IAuthService _authService;
+
+        private DoctorDetailDto _doctor = new();
+        public DoctorDetailDto Doctor { get => _doctor; set => SetProperty(ref _doctor, value); }
+
+        private string _editModeTitle = "新增医生档案";
+        public string EditModeTitle { get => _editModeTitle; set => SetProperty(ref _editModeTitle, value); }
+
+        public DelegateCommand SaveCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+
+        public DoctorProfileViewModel(IDoctorService doctorService, IAuthService authService) {
+            _doctorService = doctorService;
+            _authService = authService;
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
+            CancelCommand = new DelegateCommand(Cancel);
+        }
+
+        public async Task LoadAsync() {
+            var info = await _doctorService.GetByUserIdAsync(_authService.UserId);
+            if (info != null) {
+                Doctor = info;
+                EditModeTitle = "编辑医生档案";
+            } else {
+                Doctor = new DoctorDetailDto {
+                    Gender = Gender.Unknown,
+                    Birthday = DateTime.Now,
+                    Title = DoctorTitle.Junior,
+                    Status = DoctorStatus.Active
+                };
+                EditModeTitle = "新增医生档案";
+            }
+        }
+
+        private async Task SaveAsync() {
+            bool ok;
+            if (Doctor.Id == Guid.Empty) {
+                var dto = new DoctorCreateDto {
+                    Name = Doctor.Name,
+                    Gender = Doctor.Gender,
+                    Birthday = Doctor.Birthday,
+                    Phone = Doctor.Phone,
+                    PinyinCode = Doctor.PinyinCode,
+                    LicenseNumber = Doctor.LicenseNumber,
+                    Title = Doctor.Title,
+                    Status = Doctor.Status,
+                    Remark = Doctor.Remark,
+                    Password = "123456"
+                };
+                ok = await _doctorService.AddAsync(dto);
+            } else {
+                var dto = new DoctorEditDto {
+                    Id = Doctor.Id,
+                    Name = Doctor.Name,
+                    Gender = Doctor.Gender,
+                    Birthday = Doctor.Birthday,
+                    Phone = Doctor.Phone,
+                    PinyinCode = Doctor.PinyinCode,
+                    LicenseNumber = Doctor.LicenseNumber,
+                    Title = Doctor.Title,
+                    Status = Doctor.Status,
+                    Remark = Doctor.Remark
+                };
+                ok = await _doctorService.UpdateAsync(dto);
+            }
+
+            if (ok) {
+                MessageBox.Show("已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+                if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                    main.IsMainVisible = true;
+                    main.IsFunctionVisible = false;
+                    main.HasDoctorProfile = true;
+                    main.DoctorProfileButtonText = "编辑医生档案";
+                }
+            } else {
+                MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void Cancel() {
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                main.IsMainVisible = true;
+                main.IsFunctionVisible = false;
+            }
+        }
+
+        public void OnNavigatedTo(NavigationContext navigationContext) {
+            _ = LoadAsync();
+        }
+
+        public bool IsNavigationTarget(NavigationContext navigationContext) => true;
+
+        public void OnNavigatedFrom(NavigationContext navigationContext) { }
+    }
+}
+

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using LYBT.UI.WPF.Services;
 using Prism.Commands;
 using Prism.Mvvm;
 using System.Windows;
+using System.Threading.Tasks;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
     /// <summary>
@@ -29,6 +30,12 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         /// </summary>
         public bool IsDoctorRole { get => _isDoctorRole; set => SetProperty(ref _isDoctorRole, value); }
 
+        private bool _hasDoctorProfile;
+        public bool HasDoctorProfile { get => _hasDoctorProfile; set => SetProperty(ref _hasDoctorProfile, value); }
+
+        private string _doctorProfileButtonText = "新增医生档案";
+        public string DoctorProfileButtonText { get => _doctorProfileButtonText; set => SetProperty(ref _doctorProfileButtonText, value); }
+
         /// <summary>
         /// 退出登录命令
         /// </summary>
@@ -43,17 +50,20 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         /// 显示修改个人信息界面
         /// </summary>
         public DelegateCommand ShowChangeProfileCommand { get; }
+        public DelegateCommand ShowDoctorProfileCommand { get; }
 
 
         private readonly IEventAggregator _eventAggregator;
         private readonly IRegionManager _regionManager;
 
         private readonly IAuthService _authService;
+        private readonly IDoctorService _doctorService;
 
-        public MainWindowViewModel(IEventAggregator eventAggregator, IRegionManager regionManager, IAuthService authService) {
+        public MainWindowViewModel(IEventAggregator eventAggregator, IRegionManager regionManager, IAuthService authService, IDoctorService doctorService) {
             _eventAggregator = eventAggregator;
             _regionManager = regionManager;
             _authService = authService;
+            _doctorService = doctorService;
 
             // 订阅登录成功事件
             _eventAggregator.GetEvent<LoginSuccessEvent>().Subscribe(OnLoginSuccess);
@@ -62,6 +72,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             LogoutCommand = new DelegateCommand(Logout);
             ShowChangePasswordCommand = new DelegateCommand(ShowChangePassword);
             ShowChangeProfileCommand = new DelegateCommand(ShowChangeProfile);
+            ShowDoctorProfileCommand = new DelegateCommand(ShowDoctorProfile);
         }
 
         /// <summary>
@@ -96,18 +107,32 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             _regionManager.RequestNavigate("FunctionRegion", "ChangeProfileView");
         }
 
+        private void ShowDoctorProfile() {
+            IsMainVisible = false;
+            IsFunctionVisible = true;
+            _regionManager.RequestNavigate("FunctionRegion", "DoctorProfileView");
+        }
+
 
         /// <summary>
         /// 方法 OnLoginSuccess 的说明
         /// </summary>
-        private void OnLoginSuccess(IList<UserRole> roles) {
+        private async void OnLoginSuccess(IList<UserRole> roles) {
             IsFunctionVisible = false;
             IsMainVisible = true;
             IsDoctorRole = roles.Contains(UserRole.DiagnosingDoctor) || roles.Contains(UserRole.TreatmentDoctor);
+            if (IsDoctorRole)
+                await CheckDoctorProfileAsync();
             // 最大化窗口
             Application.Current.MainWindow.WindowState = WindowState.Maximized;
             // 导航到主内容区（如HomeView）
             _regionManager.RequestNavigate("MainContentRegion", "HomeView", new NavigationParameters { { "UserRoles", roles } });
+        }
+
+        private async Task CheckDoctorProfileAsync() {
+            var detail = await _doctorService.GetByUserIdAsync(_authService.UserId);
+            HasDoctorProfile = detail != null;
+            DoctorProfileButtonText = HasDoctorProfile ? "编辑医生档案" : "新增医生档案";
         }
     }
 }

--- a/LYBT.UI.WPF/Views/Main/DoctorProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/DoctorProfileView.xaml
@@ -1,0 +1,79 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Main.DoctorProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:enums="clr-namespace:LYBT.Common.Enums;assembly=LYBT.Common"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <UserControl.Resources>
+        <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+        <ObjectDataProvider x:Key="GenderValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="enums:Gender" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+        <ObjectDataProvider x:Key="TitleValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="enums:DoctorTitle" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+        <ObjectDataProvider x:Key="StatusValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="enums:DoctorStatus" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+    </UserControl.Resources>
+    <Grid>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+            <Border Padding="32" MinWidth="570" MinHeight="645" Background="#F9FAFB" CornerRadius="14" BorderBrush="#F8F8EC" BorderThickness="1">
+                <StackPanel>
+                    <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <TextBlock Text="姓名" />
+                            <TextBox Text="{Binding Doctor.Name, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                            <TextBlock Text="手机号" />
+                            <TextBox Text="{Binding Doctor.Phone}" Margin="0,0,0,8"/>
+                            <TextBlock Text="性别" />
+                            <ComboBox ItemsSource="{Binding Source={StaticResource GenderValues}}" SelectedItem="{Binding Doctor.Gender}" Margin="0,0,0,8">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="出生日期" />
+                            <DatePicker SelectedDate="{Binding Doctor.Birthday}" Margin="0,0,0,8"/>
+                            <TextBlock Text="拼音码" />
+                            <TextBox Text="{Binding Doctor.PinyinCode}" Margin="0,0,0,8"/>
+                            <TextBlock Text="执业证号" />
+                            <TextBox Text="{Binding Doctor.LicenseNumber}" Margin="0,0,0,8"/>
+                            <TextBlock Text="职称" />
+                            <ComboBox ItemsSource="{Binding Source={StaticResource TitleValues}}" SelectedItem="{Binding Doctor.Title}" Margin="0,0,0,8">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="状态" />
+                            <ComboBox ItemsSource="{Binding Source={StaticResource StatusValues}}" SelectedItem="{Binding Doctor.Status}" Margin="0,0,0,8">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="备注" />
+                            <TextBox Text="{Binding Doctor.Remark}" Margin="0,0,0,8"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>
+

--- a/LYBT.UI.WPF/Views/Main/DoctorProfileView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Main/DoctorProfileView.xaml.cs
@@ -1,0 +1,10 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Main {
+    public partial class DoctorProfileView : UserControl {
+        public DoctorProfileView() {
+            InitializeComponent();
+        }
+    }
+}
+

--- a/LYBT.UI.WPF/Views/Main/MainWindow.xaml
+++ b/LYBT.UI.WPF/Views/Main/MainWindow.xaml
@@ -41,6 +41,14 @@
                                 Background="#FF57606A" Foreground="White"
                                 FontWeight="Bold" BorderThickness="0"
                                 Cursor="Hand"/>
+                        <Button Content="{Binding DoctorProfileButtonText}"
+                                Width="120" Height="34"
+                                Margin="0,0,10,0"
+                                Visibility="{Binding IsDoctorRole, Converter={StaticResource BoolToVisibilityConverter}}"
+                                Command="{Binding ShowDoctorProfileCommand}"
+                                Background="#FF57606A" Foreground="White"
+                                FontWeight="Bold" BorderThickness="0"
+                                Cursor="Hand"/>
                         <Button Content="退出登录"
                                 Width="100" Height="34"
                                 Command="{Binding LogoutCommand}"

--- a/LYBT.WebAPI/Controllers/DoctorsController.cs
+++ b/LYBT.WebAPI/Controllers/DoctorsController.cs
@@ -28,6 +28,12 @@ namespace LYBT.WebAPI.Controllers {
             return item == null ? NotFound() : Ok(item);
         }
 
+        [HttpGet("by-user/{userId}")]
+        public async Task<ActionResult<DoctorDetailDto>> GetByUserId(Guid userId) {
+            var item = await _doctorService.GetByUserIdAsync(userId);
+            return item == null ? NotFound() : Ok(item);
+        }
+
         [HttpPost("add")]
         public async Task<IActionResult> Add([FromBody] DoctorCreateDto dto) {
             if (!ModelState.IsValid)


### PR DESCRIPTION
## Summary
- allow query doctor record by user ID
- expose `GetByUserIdAsync` on backend services and API
- implement doctor profile editing view
- add header button for creating/editing doctor profile

## Testing
- `dotnet build LYBTZYZS.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68686eac047c8333b87f5685143ad0af