### PR TITLE
Fix doctor profile loading error

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangeProfileViewModel.cs
@@ -78,8 +78,13 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             }
         }
 
-        public void OnNavigatedTo(NavigationContext navigationContext) {
-            _ = LoadAsync();
+        public async void OnNavigatedTo(NavigationContext navigationContext) {
+            try {
+                await LoadAsync();
+            } catch (Exception ex) {
+                MessageBox.Show($"加载用户信息失败：{ex.Message}", "错误",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         public bool IsNavigationTarget(NavigationContext navigationContext) => true;

--- a/LYBT.UI.WPF/ViewModels/Main/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/DoctorProfileViewModel.cs
@@ -100,8 +100,13 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             }
         }
 
-        public void OnNavigatedTo(NavigationContext navigationContext) {
-            _ = LoadAsync();
+        public async void OnNavigatedTo(NavigationContext navigationContext) {
+            try {
+                await LoadAsync();
+            } catch (Exception ex) {
+                MessageBox.Show($"加载医生档案失败：{ex.Message}", "错误",
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         public bool IsNavigationTarget(NavigationContext navigationContext) => true;


### PR DESCRIPTION
## Summary
- catch exceptions when loading doctor profile or user profile so Prism ViewModelLocator doesn't crash

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6868d9a9931083339e6a2b2102d05f58