### PR TITLE
Handle API exception during doctor profile check

### DIFF
--- a/LYBT.UI.WPF/Services/DoctorService.cs
+++ b/LYBT.UI.WPF/Services/DoctorService.cs
@@ -37,6 +37,10 @@ namespace LYBT.UI.WPF.Services {
             } catch (ApiException ex) {
                 if (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
                     return null; // 没有医生档案，正常返回null
+                if (ex.StatusCode == System.Net.HttpStatusCode.BadRequest) {
+                    MessageBox.Show(ex.Content ?? "请求参数错误。", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    return null;
+                }
                 if (ex.StatusCode == System.Net.HttpStatusCode.InternalServerError) {
                     MessageBox.Show("服务器内部错误，请联系管理员。", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                     return null;

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -130,9 +130,14 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         }
 
         public async Task CheckDoctorProfileAsync() {
-            var detail = await _doctorService.GetByUserIdAsync(_authService.UserId);
-            HasDoctorProfile = detail != null;
-            DoctorProfileButtonText = HasDoctorProfile ? "编辑医生档案" : "新增医生档案";
+            try {
+                var detail = await _doctorService.GetByUserIdAsync(_authService.UserId);
+                HasDoctorProfile = detail != null;
+                DoctorProfileButtonText = HasDoctorProfile ? "编辑医生档案" : "新增医生档案";
+            } catch (Exception ex) {
+                MessageBox.Show($"医生档案检查失败：{ex.Message}",
+                    "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle exceptions when checking doctor profile so `AutoWireViewModel` doesn't crash
- show user-friendly message on HTTP 400 in `DoctorService.GetByUserIdAsync`

## Testing
- `dotnet restore LYBTZYZS.sln`
- `dotnet build LYBTZYZS.sln -c Release` *(fails: LoginRequestDto not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868dbf7a8e8833391de286665bd72ed