### PR TITLE
Fix WPF login response and unify API models

### DIFF
--- a/LYBT.Infrastructure/Auth/Extensions/JwtAuthenticationExtensions.cs
+++ b/LYBT.Infrastructure/Auth/Extensions/JwtAuthenticationExtensions.cs
@@ -12,7 +12,7 @@ namespace LYBT.Infrastructure.Auth.Extensions {
     public static class JwtAuthenticationExtensions {
 
         public static IServiceCollection AddJwtAuthentication(this IServiceCollection services, IConfiguration configuration) {
-            var jwtSection = configuration.GetSection("Jwt");
+            var jwtSection = configuration.GetSection("JwtOptions");
             services.Configure<JwtOptions>(jwtSection);
 
             var options = jwtSection.Get<JwtOptions>();

--- a/LYBT.Module.Auth/Dtos/LoginResponseDto.cs
+++ b/LYBT.Module.Auth/Dtos/LoginResponseDto.cs
@@ -1,21 +1,6 @@
 namespace LYBT.Module.Auth.Dtos {
 
     /// <summary>
-    /// 统一API响应DTO
-    /// </summary>
-    public class ApiResponse<T> {
-        public bool Success { get; set; }
-        public string? Message { get; set; }
-        public T? Data { get; set; }
-        public ApiResponse() { }
-        public ApiResponse(bool success, string? message = null, T? data = default) {
-            Success = success;
-            Message = message;
-            Data = data;
-        }
-    }
-
-    /// <summary>
     /// 登录成功返回 DTO
     /// </summary>
     public class LoginResponseDto {

--- a/LYBT.UI.WPF/Apis/IAuthApi.cs
+++ b/LYBT.UI.WPF/Apis/IAuthApi.cs
@@ -1,26 +1,27 @@
 using LYBT.Module.Auth.Dtos;
+using LYBT.Common.Responses;
 using Refit;
 using System.Threading.Tasks;
 
 namespace LYBT.UI.WPF.Apis {
     /// <summary>
-    /// 认证相关的 API 接口
+    /// 璁よ瘉鐩稿叧 API 鎺ュ彛
     /// </summary>
     public interface IAuthApi {
         /// <summary>
-        /// 用户登录
+        /// 鐢ㄦ埛鐧诲綍
         /// </summary>
-        /// <param name="dto">登录请求数据</param>
-        /// <returns>登录响应数据</returns>
+        /// <param name="dto">鐧诲綍璇锋眰</param>
+        /// <returns>鐧诲綍鍝嶅簲</returns>
         [Post("/api/Auth/login")]
-        Task<LoginResponseDto> LoginAsync([Body] LoginRequestDto dto);
+        Task<ApiResponse<LoginResponseDto>> LoginAsync([Body] LoginRequestDto dto);
 
         /// <summary>
-        /// 用户登出
+        /// 鐢ㄦ埛鐧诲嚭
         /// </summary>
-        /// <param name="dto">登出请求数据</param>
-        /// <returns>登出响应</returns>
+        /// <param name="dto">鐧诲嚭璇锋眰</param>
+        /// <returns>鐧诲嚭鍝嶅簲</returns>
         [Post("/api/Auth/logout")]
-        Task<Module.Auth.Dtos.ApiResponse<object>> LogoutAsync([Body] LogoutRequestDto dto);
+        Task<ApiResponse<object>> LogoutAsync([Body] LogoutRequestDto dto);
     }
 }

--- a/LYBT.UI.WPF/Services/AuthService.cs
+++ b/LYBT.UI.WPF/Services/AuthService.cs
@@ -54,12 +54,12 @@ namespace LYBT.UI.WPF.Services {
                 var result = await _authApi.LoginAsync(loginRequest);
 
                 // 验证返回结果
-                if (result?.User == null) {
+                if (result?.Data?.User == null) {
                     return (false, new List<UserRole>(), "登录失败：服务器返回数据异常", string.Empty);
                 }
 
                 // 获取用户角色
-                var roles = GetUserRoles(result.User);
+                var roles = GetUserRoles(result.Data.User);
 
                 // 验证角色信息
                 if (roles.Count == 0) {
@@ -67,8 +67,8 @@ namespace LYBT.UI.WPF.Services {
                 }
 
                 // 保存登录状态
-                _token = result.Token ?? string.Empty;
-                _userId = result.User.Id;
+                _token = result.Data.Token ?? string.Empty;
+                _userId = result.Data.User.Id;
                 SaveAutoLoginInfo(userName, password);
 
                 return (true, roles, string.Empty, _token);
@@ -92,8 +92,8 @@ namespace LYBT.UI.WPF.Services {
                 if (!string.IsNullOrEmpty(_rememberedUserName)) {
                     var logoutRequest = new LogoutRequestDto { Username = _rememberedUserName };
                     var response = await _authApi.LogoutAsync(logoutRequest);
-                    
-                    if (response?.Success == true) {
+
+                    if (response?.Code == 200) {
                         ClearLoginState();
                         return true;
                     }

--- a/LYBT.WebAPI/Controllers/AuthController.cs
+++ b/LYBT.WebAPI/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 using LYBT.Infrastructure.Auth;
 using LYBT.Module.Auth.Dtos;
+using LYBT.Common.Responses;
 using LYBT.Module.Auth.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -26,16 +27,16 @@ namespace LYBT.WebAPI.Controllers {
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginRequestDto dto) {
             if (!ModelState.IsValid)
-                return BadRequest(new ApiResponse<object>(false, "参数无效", null));
+                return BadRequest(ApiResponse<object>.Fail("参数无效", 400));
             // 获取客户端IP和UserAgent
             dto.ClientIp = HttpContext.Connection.RemoteIpAddress?.ToString();
             dto.UserAgent = Request.Headers["User-Agent"].ToString();
             var user = await _authService.LoginAsync(dto);
             if (user == null)
-                return Unauthorized(new ApiResponse<object>(false, "用户名或密码错误", null));
+                return Unauthorized(ApiResponse<object>.Fail("用户名或密码错误", 401));
 
             var token = JwtHelper.GenerateToken(user.Id.ToString(), user.UserName, _jwtOptions);
-            return Ok(new ApiResponse<LoginResponseDto>(true, null, new LoginResponseDto { Token = token, User = user }));
+            return Ok(ApiResponse<LoginResponseDto>.Success(new LoginResponseDto { Token = token, User = user }));
         }
 
         /// <summary>
@@ -44,9 +45,9 @@ namespace LYBT.WebAPI.Controllers {
         [HttpPost("logout")]
         public async Task<IActionResult> Logout([FromBody] LogoutRequestDto dto) {
             if (!ModelState.IsValid)
-                return BadRequest(new ApiResponse<object>(false, "参数无效", null));
+                return BadRequest(ApiResponse<object>.Fail("参数无效", 400));
             await _authService.LogoutAsync(dto);
-            return Ok(new ApiResponse<object>(true, null, null));
+            return Ok(ApiResponse<object>.Success(null));
         }
     }
 }

--- a/LYBT.WebAPI/appsettings.example.json
+++ b/LYBT.WebAPI/appsettings.example.json
@@ -6,7 +6,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=LYBTDB;User Id=sa;Password=YOUR_PASSWORD;Encrypt=True;TrustServerCertificate=True"
   },
-  "Jwt": {
+  "JwtOptions": {
     "Secret": "ChangeThisSecret",
     "Issuer": "LYBT.WebAPI",
     "Audience": "LYBT.Client",

--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -6,7 +6,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Server=localhost;Database=LYBTDB;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=True"
   },
-  "Jwt": {
+  "JwtOptions": {
     "Secret": "4/HC5fsPxo8xwjDyWCRZ96ZjD/9+pta7QyMmskmCeNLtInboBQBhaBxmriyOm93i",
     "Issuer": "LYBT.WebAPI",
     "Audience": "LYBT.Client",


### PR DESCRIPTION
## Summary
- align JWT config section with code (`JwtOptions`)
- unify `ApiResponse<T>` across projects
- return `ApiResponse<LoginResponseDto>` from WPF login API
- adjust `AuthService` to read nested response data
- update WebAPI controllers to use unified response helpers

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68691ac2a8008333b926d19c23724a45