### PR TITLE
Add sysadmin password update endpoint

### DIFF
--- a/LYBT.Module.Auth/Dtos/ChangeSysAdminPasswordDto.cs
+++ b/LYBT.Module.Auth/Dtos/ChangeSysAdminPasswordDto.cs
@@ -1,0 +1,16 @@
+namespace LYBT.Module.Auth.Dtos {
+    /// <summary>
+    /// 修改 sysadmin 密码 DTO
+    /// </summary>
+    public class ChangeSysAdminPasswordDto {
+        /// <summary>
+        /// 原密码
+        /// </summary>
+        public string OldPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// 新密码
+        /// </summary>
+        public string NewPassword { get; set; } = string.Empty;
+    }
+}

--- a/LYBT.Module.Auth/Interfaces/IAuthRepository.cs
+++ b/LYBT.Module.Auth/Interfaces/IAuthRepository.cs
@@ -23,6 +23,11 @@ namespace LYBT.Module.Auth.Interfaces {
         Task<string?> GetAdminPasswordHashAsync(string userName);
 
         /// <summary>
+        /// 更新管理员密码哈希
+        /// </summary>
+        Task UpdateAdminPasswordHashAsync(string userName, string passwordHash);
+
+        /// <summary>
         /// 更新登录防护相关字段（失败次数、锁定时间）
         /// </summary>
         Task UpdateUserLoginProtectionAsync(UserModel user);

--- a/LYBT.Module.Auth/Interfaces/IAuthService.cs
+++ b/LYBT.Module.Auth/Interfaces/IAuthService.cs
@@ -17,5 +17,10 @@ namespace LYBT.Module.Auth.Interfaces {
         /// 用户登出
         /// </summary>
         Task<bool> LogoutAsync(LogoutRequestDto dto);
+
+        /// <summary>
+        /// 修改 sysadmin 密码
+        /// </summary>
+        Task<bool> ChangeSysAdminPasswordAsync(ChangeSysAdminPasswordDto dto);
     }
 }

--- a/LYBT.Module.Auth/Repositories/AuthRepository.cs
+++ b/LYBT.Module.Auth/Repositories/AuthRepository.cs
@@ -33,6 +33,15 @@ namespace LYBT.Module.Auth.Repositories {
             return secret?.PasswordHash;
         }
 
+        public async Task UpdateAdminPasswordHashAsync(string userName, string passwordHash) {
+            var secret = await _dbContext.AdminSecrets.FirstOrDefaultAsync(s => s.UserName == userName);
+            if (secret != null) {
+                secret.PasswordHash = passwordHash;
+                _dbContext.AdminSecrets.Update(secret);
+                await _dbContext.SaveChangesAsync();
+            }
+        }
+
         public async Task UpdateUserLoginProtectionAsync(UserModel user) {
             var dbUser = await _dbContext.Users.FindAsync(user.Id);
             if (dbUser != null) {

--- a/LYBT.Module.Auth/Services/AuthService.cs
+++ b/LYBT.Module.Auth/Services/AuthService.cs
@@ -180,5 +180,26 @@ namespace LYBT.Module.Auth.Services {
             });
             return true;
         }
+
+        public async Task<bool> ChangeSysAdminPasswordAsync(ChangeSysAdminPasswordDto dto) {
+            var hash = await _authRepository.GetAdminPasswordHashAsync("sysadmin");
+            if (string.IsNullOrEmpty(hash))
+                return false;
+            if (!PasswordHelper.Verify(hash, dto.OldPassword))
+                return false;
+            var newHash = PasswordHelper.Hash(dto.NewPassword);
+            await _authRepository.UpdateAdminPasswordHashAsync("sysadmin", newHash);
+            await _logService.AddLogAsync(new LogDto {
+                LogType = LogType.Operation,
+                ObjectType = ObjectType.User,
+                ObjectId = Guid.Empty,
+                ActionType = ActionType.Edit,
+                OperatorId = Guid.Empty,
+                OperatorName = "sysadmin",
+                Content = "Change sysadmin password",
+                LogTime = DateTime.Now
+            });
+            return true;
+        }
     }
 }

--- a/LYBT.UI.WPF/Apis/IAuthApi.cs
+++ b/LYBT.UI.WPF/Apis/IAuthApi.cs
@@ -23,5 +23,11 @@ namespace LYBT.UI.WPF.Apis {
         /// <returns>登出响应</returns>
         [Post("/api/Auth/logout")]
         Task<LYBT.Common.Responses.ApiResponse<object>> LogoutAsync([Body] LogoutRequestDto dto);
+
+        /// <summary>
+        /// 修改 sysadmin 密码
+        /// </summary>
+        [Post("/api/Auth/changeSysAdminPassword")]
+        Task<LYBT.Common.Responses.ApiResponse<object>> ChangeSysAdminPasswordAsync([Body] ChangeSysAdminPasswordDto dto);
     }
 }

--- a/LYBT.UI.WPF/Interfaces/IAuthService.cs
+++ b/LYBT.UI.WPF/Interfaces/IAuthService.cs
@@ -51,5 +51,10 @@ namespace LYBT.UI.WPF.Services {
         /// 清除自动登录信息
         /// </summary>
         void ClearAutoLoginInfo();
+
+        /// <summary>
+        /// 修改 sysadmin 密码
+        /// </summary>
+        Task<bool> ChangeSysAdminPasswordAsync(string oldPassword, string newPassword);
     }
 }

--- a/LYBT.UI.WPF/Services/AuthService.cs
+++ b/LYBT.UI.WPF/Services/AuthService.cs
@@ -111,6 +111,19 @@ namespace LYBT.UI.WPF.Services {
         }
 
         /// <summary>
+        /// 修改 sysadmin 密码
+        /// </summary>
+        public async Task<bool> ChangeSysAdminPasswordAsync(string oldPassword, string newPassword) {
+            try {
+                var resp = await _authApi.ChangeSysAdminPasswordAsync(new ChangeSysAdminPasswordDto {
+                    OldPassword = oldPassword,
+                    NewPassword = newPassword
+                });
+                return resp?.Code == 200;
+            } catch { return false; }
+        }
+
+        /// <summary>
         /// 清除自动登录信息
         /// </summary>
         public void ClearAutoLoginInfo() {

--- a/LYBT.UI.WPF/ViewModels/Main/ChangePasswordViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/ChangePasswordViewModel.cs
@@ -42,7 +42,12 @@ namespace LYBT.UI.WPF.ViewModels.Main {
 
         private async Task ChangeAsync() {
             ErrorMessage = string.Empty;
-            var ok = await _userService.ChangePasswordAsync(_authService.UserId, OldPassword, NewPassword);
+            bool ok;
+            if (string.Equals(_authService.RememberedUserName, "sysadmin", StringComparison.OrdinalIgnoreCase)) {
+                ok = await _authService.ChangeSysAdminPasswordAsync(OldPassword, NewPassword);
+            } else {
+                ok = await _userService.ChangePasswordAsync(_authService.UserId, OldPassword, NewPassword);
+            }
             if (ok) {
                 MessageBox.Show("密码已修改，请重新登录", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
                 if (Application.Current.MainWindow.DataContext is MainWindowViewModel main)

--- a/LYBT.WebAPI/Controllers/AuthController.cs
+++ b/LYBT.WebAPI/Controllers/AuthController.cs
@@ -49,5 +49,16 @@ namespace LYBT.WebAPI.Controllers {
             await _authService.LogoutAsync(dto);
             return Ok(ApiResponse<object>.Success(null));
         }
+
+        /// <summary>
+        /// 修改 sysadmin 密码
+        /// </summary>
+        [HttpPost("changeSysAdminPassword")]
+        public async Task<IActionResult> ChangeSysAdminPassword([FromBody] ChangeSysAdminPasswordDto dto) {
+            if (!ModelState.IsValid)
+                return BadRequest(ApiResponse<object>.Fail("参数无效", 400));
+            var ok = await _authService.ChangeSysAdminPasswordAsync(dto);
+            return ok ? Ok(ApiResponse<object>.Success(null)) : BadRequest(ApiResponse<object>.Fail("修改失败", 400));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow updating sysadmin password stored in `AdminSecrets`
- expose new API in `AuthController` and WPF client
- handle sysadmin password change in WPF change password view

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686934bef6cc83339c6bd901a506d5c9