### PR TITLE
Fix token injection on user operations

### DIFF
--- a/LYBT.UI.WPF/Apis/TokenHandler.cs
+++ b/LYBT.UI.WPF/Apis/TokenHandler.cs
@@ -1,4 +1,3 @@
-﻿using LYBT.UI.WPF.Services;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,15 +7,10 @@ namespace LYBT.UI.WPF.Apis {
     /// 全局API Token注入Handler
     /// </summary>
     public class TokenHandler : DelegatingHandler {
-        private readonly IAuthService _authService;
-        public TokenHandler(IAuthService authService) {
-            _authService = authService;
-        }
-        /// <summary>
-        /// 方法 SendAsync 的说明
-        /// </summary>
+        public TokenHandler() { }
+
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
-            var token = _authService.Token;
+            var token = TokenProvider.Token;
             if (!string.IsNullOrEmpty(token)) {
                 request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             }

--- a/LYBT.UI.WPF/Apis/TokenProvider.cs
+++ b/LYBT.UI.WPF/Apis/TokenProvider.cs
@@ -1,0 +1,9 @@
+namespace LYBT.UI.WPF.Apis {
+    public static class TokenProvider {
+        private static string _token = string.Empty;
+        public static string Token {
+            get => _token;
+            set => _token = value ?? string.Empty;
+        }
+    }
+}

--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -28,7 +28,8 @@ namespace LYBT.UI.WPF {
                 throw new InvalidOperationException("WebApiBaseUrl is not configured in AppSettings.");
             }
 
-            var httpClient = new HttpClient() {
+            var tokenHandler = new TokenHandler { InnerHandler = new HttpClientHandler() };
+            var httpClient = new HttpClient(tokenHandler) {
                 BaseAddress = new Uri(baseUrl)
             };
 

--- a/LYBT.UI.WPF/Services/AuthService.cs
+++ b/LYBT.UI.WPF/Services/AuthService.cs
@@ -68,6 +68,7 @@ namespace LYBT.UI.WPF.Services {
 
                 // 保存登录状态
                 _token = result.Data.Token ?? string.Empty;
+                TokenProvider.Token = _token;
                 _userId = result.Data.User.Id;
                 SaveAutoLoginInfo(userName, password);
 
@@ -217,6 +218,7 @@ namespace LYBT.UI.WPF.Services {
         /// </summary>
         private void ClearLoginState() {
             _token = string.Empty;
+            TokenProvider.Token = string.Empty;
             _userId = Guid.Empty;
             ClearAutoLoginInfo();
         }


### PR DESCRIPTION
## Summary
- inject auth token via delegating handler
- expose a simple `TokenProvider` for the current JWT
- register the handler in the WPF app's HttpClient
- propagate token updates in `AuthService`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6869394adb948333a9c28c1d88974df0