### PR TITLE
Fix cancel button losing details

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
@@ -56,6 +56,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         public DoctorManagementViewModel(IDoctorService doctorService) {
             _doctorService = doctorService;
             DoctorProfileViewModel = new DoctorProfileViewModel(_doctorService, null, null); // 依赖注入可根据实际情况调整
+            DoctorProfileViewModel.CancelAction = CancelEdit;
             AddDoctorCommand = new DelegateCommand(AddDoctor);
             EditDoctorCommand = new DelegateCommand(EditDoctor, () => SelectedDoctor != null).ObservesProperty(() => SelectedDoctor);
             SaveDoctorCommand = new DelegateCommand(async () => await SaveDoctor(), () => IsEditable).ObservesProperty(() => IsEditable);

--- a/LYBT.UI.WPF/ViewModels/Main/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/DoctorProfileViewModel.cs
@@ -30,6 +30,12 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
 
+        /// <summary>
+        /// Optional action invoked when canceling editing. If not set,
+        /// the view model falls back to its default behavior.
+        /// </summary>
+        public Action? CancelAction { get; set; }
+
         public DoctorProfileViewModel(IDoctorService doctorService, IAuthService authService, LYBT.UI.WPF.Services.IUserService userService) {
             _doctorService = doctorService;
             _authService = authService;
@@ -110,6 +116,10 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         }
 
         private void Cancel() {
+            if (CancelAction != null) {
+                CancelAction.Invoke();
+                return;
+            }
             if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
                 main.IsMainVisible = true;
                 main.IsFunctionVisible = false;


### PR DESCRIPTION
## Summary
- ensure DoctorProfileViewModel allows custom cancel logic
- wire DoctorManagementViewModel to restore doctor detail on cancel

## Testing
- `dotnet build -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_6869ce87a6e08333b4beec1b5382c324