### PR TITLE
完善 PatientProfile 并统一档案界面风格

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Main/PatientProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/PatientProfileViewModel.cs
@@ -1,23 +1,32 @@
 using LYBT.Module.Patients.Dtos;
 using LYBT.UI.WPF.Interfaces;
-using LYBT.UI.WPF.Services;
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
 using System.Threading.Tasks;
+using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
     public class PatientProfileViewModel : BindableBase {
         private readonly IPatientService _patientService;
 
         private PatientDetailDto _patient = new();
-        public PatientDetailDto Patient { get => _patient; set => SetProperty(ref _patient, value); }
+        public PatientDetailDto Patient {
+            get => _patient;
+            set => SetProperty(ref _patient, value);
+        }
 
-        private string _editModeTitle = "ĞÂÔö»¼Õßµµ°¸";
-        public string EditModeTitle { get => _editModeTitle; set => SetProperty(ref _editModeTitle, value); }
+        private string _editModeTitle = "æ–°å¢æ‚£è€…æ¡£æ¡ˆ";
+        public string EditModeTitle {
+            get => _editModeTitle;
+            set => SetProperty(ref _editModeTitle, value);
+        }
 
         private bool _isEditable;
-        public bool IsEditable { get => _isEditable; set => SetProperty(ref _isEditable, value); }
+        public bool IsEditable {
+            get => _isEditable;
+            set => SetProperty(ref _isEditable, value);
+        }
 
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
@@ -31,22 +40,35 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         }
 
         public async Task LoadAsync(Guid patientId) {
-            var info = await _patientService.GetByIdAsync(patientId);
-            if (info != null) {
-                Patient = info;
-                EditModeTitle = "±à¼­»¼Õßµµ°¸";
+            if (patientId != Guid.Empty) {
+                var info = await _patientService.GetByIdAsync(patientId);
+                if (info != null) {
+                    Patient = info;
+                    EditModeTitle = "ç¼–è¾‘æ‚£è€…æ¡£æ¡ˆ";
+                } else {
+                    Patient = new PatientDetailDto();
+                    EditModeTitle = "æ–°å¢æ‚£è€…æ¡£æ¡ˆ";
+                }
             } else {
                 Patient = new PatientDetailDto();
-                EditModeTitle = "ĞÂÔö»¼Õßµµ°¸";
+                EditModeTitle = "æ–°å¢æ‚£è€…æ¡£æ¡ˆ";
             }
+            IsEditable = true;
         }
 
         private async Task SaveAsync() {
+            bool ok;
             if (Patient.Id == Guid.Empty)
-                await _patientService.AddAsync(Patient);
+                ok = await _patientService.AddAsync(Patient);
             else
-                await _patientService.UpdateAsync(Patient);
-            IsEditable = false;
+                ok = await _patientService.UpdateAsync(Patient);
+
+            if (ok) {
+                MessageBox.Show("å·²ä¿å­˜", "æç¤º", MessageBoxButton.OK, MessageBoxImage.Information);
+                IsEditable = false;
+            } else {
+                MessageBox.Show("ä¿å­˜å¤±è´¥", "æç¤º", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private void Cancel() {

--- a/LYBT.UI.WPF/Views/Main/DoctorProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/DoctorProfileView.xaml
@@ -1,10 +1,10 @@
-<UserControl x:Class="LYBT.UI.WPF.Views.Main.DoctorProfileView"  
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"  
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"  
-             xmlns:prism="http://prismlibrary.com/"  
-             xmlns:sys="clr-namespace:System;assembly=mscorlib"  
-             xmlns:enums="clr-namespace:LYBT.Common.Enums;assembly=LYBT.Common"  
-             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"  
+<UserControl x:Class="LYBT.UI.WPF.Views.Main.DoctorProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:enums="clr-namespace:LYBT.Common.Enums;assembly=LYBT.Common"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <UserControl.Resources>
         <ObjectDataProvider x:Key="GenderValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
@@ -24,8 +24,12 @@
         </ObjectDataProvider>
     </UserControl.Resources>
     <Grid>
-        <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+        <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
             <Border Padding="32" MinWidth="570" MinHeight="645" Background="#F9FAFB" CornerRadius="14" BorderBrush="#F8F8EC" BorderThickness="1">
+                <Border.Effect>
+                    <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
+                </Border.Effect>
                 <StackPanel>
                     <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
                     <ScrollViewer VerticalScrollBarVisibility="Auto">
@@ -35,10 +39,10 @@
                             <TextBlock Text="姓名" />
                             <TextBox Text="{Binding Doctor.RealName, Mode=OneWay}" IsReadOnly="True" Margin="0,0,0,8"/>
                             <TextBlock Text="联系号码" />
-                            <TextBox Text="{Binding Doctor.ContactNumber}" Margin="0,0,0,8"  
+                            <TextBox Text="{Binding Doctor.ContactNumber}" Margin="0,0,0,8"
                                      IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
                             <TextBlock Text="性别" />
-                            <ComboBox ItemsSource="{Binding Source={StaticResource GenderValues}}" SelectedItem="{Binding Doctor.Gender}" Margin="0,0,0,8"  
+                            <ComboBox ItemsSource="{Binding Source={StaticResource GenderValues}}" SelectedItem="{Binding Doctor.Gender}" Margin="0,0,0,8"
                                      IsEnabled="{Binding IsEditable}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
@@ -47,16 +51,16 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                             <TextBlock Text="出生日期" />
-                            <DatePicker SelectedDate="{Binding Doctor.Birthday}" Margin="0,0,0,8"  
+                            <DatePicker SelectedDate="{Binding Doctor.Birthday}" Margin="0,0,0,8"
                                         IsEnabled="{Binding IsEditable}"/>
                             <TextBlock Text="拼音码" />
-                            <TextBox Text="{Binding Doctor.PinyinCode}" Margin="0,0,0,8"  
+                            <TextBox Text="{Binding Doctor.PinyinCode}" Margin="0,0,0,8"
                                      IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
                             <TextBlock Text="执业证号" />
-                            <TextBox Text="{Binding Doctor.LicenseNumber}" Margin="0,0,0,8"  
+                            <TextBox Text="{Binding Doctor.LicenseNumber}" Margin="0,0,0,8"
                                      IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
                             <TextBlock Text="职称" />
-                            <ComboBox ItemsSource="{Binding Source={StaticResource TitleValues}}" SelectedItem="{Binding Doctor.Title}" Margin="0,0,0,8"  
+                            <ComboBox ItemsSource="{Binding Source={StaticResource TitleValues}}" SelectedItem="{Binding Doctor.Title}" Margin="0,0,0,8"
                                      IsEnabled="{Binding IsEditable}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
@@ -65,7 +69,7 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                             <TextBlock Text="状态" />
-                            <ComboBox ItemsSource="{Binding Source={StaticResource StatusValues}}" SelectedItem="{Binding Doctor.Status}" Margin="0,0,0,8"  
+                            <ComboBox ItemsSource="{Binding Source={StaticResource StatusValues}}" SelectedItem="{Binding Doctor.Status}" Margin="0,0,0,8"
                                      IsEnabled="{Binding IsEditable}">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate>
@@ -74,13 +78,13 @@
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
                             <TextBlock Text="备注" />
-                            <TextBox Text="{Binding Doctor.Remark}" Margin="0,0,0,8"  
+                            <TextBox Text="{Binding Doctor.Remark}" Margin="0,0,0,8"
                                      IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
                         </StackPanel>
                     </ScrollViewer>
-                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0"  
+                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0"
                             Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0"  
+                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0"
                             Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
                 </StackPanel>
             </Border>

--- a/LYBT.UI.WPF/Views/Main/PatientProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Main/PatientProfileView.xaml
@@ -1,24 +1,68 @@
-﻿<UserControl x:Class="LYBT.UI.WPF.Views.Main.PatientProfileView"
+<UserControl x:Class="LYBT.UI.WPF.Views.Main.PatientProfileView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:LYBT.UI.WPF.Views.Main"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:sys="clr-namespace:System;assembly=mscorlib"
+             xmlns:enums="clr-namespace:LYBT.Common.Enums;assembly=LYBT.Common"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <UserControl.Resources>
+        <ObjectDataProvider x:Key="GenderValues" MethodName="GetValues" ObjectType="{x:Type sys:Enum}">
+            <ObjectDataProvider.MethodParameters>
+                <x:Type TypeName="enums:Gender" />
+            </ObjectDataProvider.MethodParameters>
+        </ObjectDataProvider>
+    </UserControl.Resources>
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="{Binding EditModeTitle}" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
-            <TextBox Text="{Binding Patient.Name}" Margin="0,0,0,5" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}" />
-            <TextBox Text="{Binding Patient.Gender}" Margin="0,0,0,5" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}" />
-            <TextBox Text="{Binding Patient.Age}" Margin="0,0,0,5" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}" />
-            <TextBox Text="{Binding Patient.PhoneNumber}" Margin="0,0,0,5" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}" />
-            <TextBox Text="{Binding Patient.Address}" Margin="0,0,0,5" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}" />
-            <!-- 可补充更多字段 -->
-            <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                <Button Content="保存" Command="{Binding SaveCommand}" IsEnabled="{Binding IsEditable}" Margin="0,0,10,0"/>
-                <Button Content="取消" Command="{Binding CancelCommand}"/>
-            </StackPanel>
-        </StackPanel>
+        <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
+            <Border Padding="32" MinWidth="570" MinHeight="645" Background="#F9FAFB" CornerRadius="14" BorderBrush="#F8F8EC" BorderThickness="1">
+                <Border.Effect>
+                    <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
+                </Border.Effect>
+                <StackPanel>
+                    <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <StackPanel>
+                            <TextBlock Text="姓名" />
+                            <TextBox Text="{Binding Patient.Name}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="性别" />
+                            <ComboBox ItemsSource="{Binding Source={StaticResource GenderValues}}" SelectedItem="{Binding Patient.Gender}" Margin="0,0,0,8" IsEnabled="{Binding IsEditable}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}"/>
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+                            <TextBlock Text="年龄" />
+                            <TextBox Text="{Binding Patient.Age}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="过敏史" />
+                            <TextBox Text="{Binding Patient.AllergyHistory}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="民族" />
+                            <TextBox Text="{Binding Patient.Ethnicity}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="联系电话" />
+                            <TextBox Text="{Binding Patient.PhoneNumber}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="地址" />
+                            <TextBox Text="{Binding Patient.Address}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="学历" />
+                            <TextBox Text="{Binding Patient.Education}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="职业" />
+                            <TextBox Text="{Binding Patient.Profession}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="证件类型" />
+                            <TextBox Text="{Binding Patient.IDType}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="证件号" />
+                            <TextBox Text="{Binding Patient.IDNumber}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="婚姻状况" />
+                            <TextBox Text="{Binding Patient.MaritalStatus}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="拼音码" />
+                            <TextBox Text="{Binding Patient.PinyinCode}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <CheckBox Content="特殊患者" IsChecked="{Binding Patient.IsSpecial}" Margin="0,0,0,8" IsEnabled="{Binding IsEditable}"/>
+                        </StackPanel>
+                    </ScrollViewer>
+                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                </StackPanel>
+            </Border>
+        </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- rebuild PatientProfileViewModel to support editing and save feedback
- redesign PatientProfileView with all PatientDetailDto fields
- add background and drop shadow to DoctorProfileView and PatientProfileView for consistent look

## Testing
- `dotnet build LYBTZYZS.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_686a0a04f3c4833394caa48e7dc9a6a1