### PR TITLE
Add herb management UI

### DIFF
--- a/LYBT.Models/Queueing/QueueingModel.cs
+++ b/LYBT.Models/Queueing/QueueingModel.cs
@@ -18,6 +18,11 @@ namespace LYBT.Models.Queueing {
         public Guid PatientId { get; set; }
 
         /// <summary>
+        /// 病人姓名（仅用于快速展示）
+        /// </summary>
+        public string PatientName { get; set; } = string.Empty;
+
+        /// <summary>
         /// 排队类型（如“普通”、“急诊”）
         /// </summary>
         public string QueueType { get; set; } = "普通";

--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -46,6 +46,7 @@ namespace LYBT.UI.WPF {
             var userApi = RestService.For<IUserApi>(httpClient, refitSettings);
             var doctorApi = RestService.For<IDoctorApi>(httpClient, refitSettings);
             var patientApi = RestService.For<IPatientApi>(httpClient, refitSettings);
+            var herbApi = RestService.For<IHerbApi>(httpClient, refitSettings);
             var billingApi = RestService.For<IBillingApi>(httpClient, refitSettings);
             var logApi = RestService.For<ILogApi>(httpClient, refitSettings);
 
@@ -54,6 +55,7 @@ namespace LYBT.UI.WPF {
             var userService = new UserService(userApi);
             var doctorService = new DoctorService(doctorApi);
             var patientService = new PatientService(patientApi);
+            var herbService = new HerbService(herbApi);
             var billingService = new BillingService(billingApi);
             var logService = new LogService(logApi);
 
@@ -63,6 +65,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(userApi);
             containerRegistry.RegisterInstance(doctorApi);
             containerRegistry.RegisterInstance(patientApi);
+            containerRegistry.RegisterInstance(herbApi);
             containerRegistry.RegisterInstance(billingService);
             containerRegistry.RegisterInstance(logApi);
 
@@ -70,6 +73,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IUserService>(userService);
             containerRegistry.RegisterInstance<IDoctorService>(doctorService);
             containerRegistry.RegisterInstance<IPatientService>(patientService);
+            containerRegistry.RegisterInstance<IHerbService>(herbService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
             containerRegistry.RegisterInstance<ILogService>(logService);
 
@@ -81,6 +85,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<AdminView>("AdminView");
             containerRegistry.RegisterForNavigation<UserManagementView>("UserManagementView");
             containerRegistry.RegisterForNavigation<DoctorManagementView>("DoctorManagementView");
+            containerRegistry.RegisterForNavigation<HerbManagementView>("HerbManagementView");
             containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
             containerRegistry.RegisterForNavigation<DiagnosingDoctorView>("DiagnosingDoctorView");
             containerRegistry.RegisterForNavigation<PharmacyStaffView>("PharmacyStaffView");
@@ -89,6 +94,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<ChangePasswordView>("ChangePasswordView");
             containerRegistry.RegisterForNavigation<ChangeProfileView>("ChangeProfileView");
             containerRegistry.RegisterForNavigation<DoctorProfileView>("DoctorProfileView");
+            containerRegistry.RegisterForNavigation<HerbProfileView>("HerbProfileView");
             containerRegistry.RegisterForNavigation<UserProfileView>("UserProfileView");
 
         }

--- a/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
@@ -1,0 +1,77 @@
+using LYBT.Module.Herbs.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using LYBT.UI.WPF.ViewModels.Profile;
+using Prism.Commands;
+using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Admin {
+    public class HerbManagementViewModel : BindableBase {
+        private readonly IHerbService _herbService;
+        public ObservableCollection<HerbDto> Herbs { get; } = new();
+
+        private HerbDto? _selectedHerb;
+        public HerbDto? SelectedHerb {
+            get => _selectedHerb;
+            set {
+                if (SetProperty(ref _selectedHerb, value)) {
+                    if (value != null)
+                        _ = HerbProfileViewModel.LoadAsync(value.Id);
+                }
+            }
+        }
+
+        private string _searchKeyword = string.Empty;
+        public string SearchKeyword { get => _searchKeyword; set => SetProperty(ref _searchKeyword, value); }
+
+        public HerbProfileViewModel HerbProfileViewModel { get; }
+
+        public DelegateCommand SearchCommand { get; }
+        public DelegateCommand AddCommand { get; }
+        public DelegateCommand EditCommand { get; }
+        public DelegateCommand DeleteCommand { get; }
+
+        public HerbManagementViewModel(IHerbService herbService, HerbProfileViewModel profileViewModel) {
+            _herbService = herbService;
+            HerbProfileViewModel = profileViewModel;
+            SearchCommand = new DelegateCommand(async () => await LoadAsync());
+            AddCommand = new DelegateCommand(Add);
+            EditCommand = new DelegateCommand(Edit, () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
+            DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
+            _ = LoadAsync();
+        }
+
+        private async Task LoadAsync() {
+            var list = await _herbService.GetListAsync();
+            Herbs.Clear();
+            foreach (var item in list)
+                Herbs.Add(item);
+        }
+
+        private void Add() {
+            HerbProfileViewModel.IsEditable = true;
+            HerbProfileViewModel.LoadAsync();
+        }
+
+        private void Edit() {
+            if (SelectedHerb != null) {
+                HerbProfileViewModel.IsEditable = true;
+                HerbProfileViewModel.LoadAsync(SelectedHerb.Id);
+            }
+        }
+
+        private async Task DeleteAsync() {
+            if (SelectedHerb == null)
+                return;
+            if (MessageBox.Show("确定删除该药材吗？", "确认", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes) {
+                var success = await _herbService.DeleteAsync(SelectedHerb.Id);
+                if (!success)
+                    MessageBox.Show("删除失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                await LoadAsync();
+            }
+        }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Profile/HerbProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/HerbProfileViewModel.cs
@@ -1,0 +1,84 @@
+using LYBT.Module.Herbs.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using Prism.Commands;
+using Prism.Mvvm;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Profile {
+    public class HerbProfileViewModel : BindableBase {
+        private readonly IHerbService _herbService;
+
+        private HerbDetailDto _herb = new();
+        public HerbDetailDto Herb { get => _herb; set => SetProperty(ref _herb, value); }
+
+        private string _editModeTitle = "新增药材";
+        public string EditModeTitle { get => _editModeTitle; set => SetProperty(ref _editModeTitle, value); }
+
+        private bool _isEditable;
+        public bool IsEditable { get => _isEditable; set => SetProperty(ref _isEditable, value); }
+
+        public DelegateCommand SaveCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+
+        public Action? CancelAction { get; set; }
+
+        public HerbProfileViewModel(IHerbService herbService) {
+            _herbService = herbService;
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
+            CancelCommand = new DelegateCommand(Cancel);
+        }
+
+        public async Task LoadAsync(Guid? id = null) {
+            if (id.HasValue && id.Value != Guid.Empty) {
+                var info = await _herbService.GetByIdAsync(id.Value);
+                if (info != null) {
+                    Herb = info;
+                    EditModeTitle = "编辑药材";
+                }
+            } else {
+                Herb = new HerbDetailDto();
+                EditModeTitle = "新增药材";
+            }
+        }
+
+        private async Task SaveAsync() {
+            try {
+                bool success;
+                if (Herb.Id == Guid.Empty) {
+                    success = await _herbService.AddAsync(new HerbCreateDto {
+                        Name = Herb.Name,
+                        Pinyin = Herb.Pinyin,
+                        Origin = Herb.Origin,
+                        Spec = Herb.Spec,
+                        Unit = Herb.Unit,
+                        Price = Herb.Price,
+                        Effect = Herb.Effect,
+                        Remark = Herb.Remark
+                    });
+                } else {
+                    success = await _herbService.UpdateAsync(new HerbEditDto {
+                        Id = Herb.Id,
+                        Name = Herb.Name,
+                        Pinyin = Herb.Pinyin,
+                        Origin = Herb.Origin,
+                        Spec = Herb.Spec,
+                        Unit = Herb.Unit,
+                        Price = Herb.Price,
+                        Effect = Herb.Effect,
+                        Remark = Herb.Remark
+                    });
+                }
+                if (!success)
+                    MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+            } catch (Exception ex) {
+                MessageBox.Show($"保存失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void Cancel() {
+            CancelAction?.Invoke();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
@@ -1,0 +1,43 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Admin.HerbManagementView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:main="clr-namespace:LYBT.UI.WPF.Views.Main"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <!-- 操作区 -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Content="查找" Command="{Binding SearchCommand}" Margin="0,0,8,0"/>
+            <Button Content="新增药材" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+            <Button Content="编辑药材" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
+            <Button Content="删除药材" Command="{Binding DeleteCommand}" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
+        </StackPanel>
+        <!-- 内容区 -->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2.2*"/>
+                <ColumnDefinition Width="1.8*"/>
+            </Grid.ColumnDefinitions>
+            <!-- 左侧列表 -->
+            <DataGrid Grid.Column="0" ItemsSource="{Binding Herbs}" SelectedItem="{Binding SelectedHerb, Mode=TwoWay}" AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
+                    <DataGridTextColumn Header="拼音码" Binding="{Binding Pinyin}" Width="*"/>
+                    <DataGridTextColumn Header="产地" Binding="{Binding Origin}" Width="*"/>
+                    <DataGridTextColumn Header="规格" Binding="{Binding Spec}" Width="*"/>
+                    <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="*"/>
+                    <DataGridTextColumn Header="单价" Binding="{Binding Price}" Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <!-- 右侧详情区 -->
+            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+                <main:HerbProfileView DataContext="{Binding HerbProfileViewModel}" />
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Admin {
+    public partial class HerbManagementView : UserControl {
+        public HerbManagementView() {
+            InitializeComponent();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
@@ -17,7 +17,7 @@
             <admin:PatientManagementView/>
         </TabItem>
         <TabItem Header="药材管理">
-            <TextBlock Text="药材管理开发中..." Padding="40"/>
+            <admin:HerbManagementView/>
         </TabItem>
         <TabItem Header="药方管理">
             <TextBlock Text="药方管理开发中..." Padding="40"/>

--- a/LYBT.UI.WPF/Views/Profile/HerbProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/HerbProfileView.xaml
@@ -1,0 +1,39 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Main.HerbProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid>
+        <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
+        <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
+            <Border Padding="32" MinWidth="420" MinHeight="400" Background="#F9FAFB" CornerRadius="14" BorderBrush="#F8F8EC" BorderThickness="1">
+                <Border.Effect>
+                    <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
+                </Border.Effect>
+                <StackPanel>
+                    <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
+                    <StackPanel>
+                        <TextBlock Text="名称" />
+                        <TextBox Text="{Binding Herb.Name}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="拼音码" />
+                        <TextBox Text="{Binding Herb.Pinyin}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="产地" />
+                        <TextBox Text="{Binding Herb.Origin}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="规格" />
+                        <TextBox Text="{Binding Herb.Spec}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="单位" />
+                        <TextBox Text="{Binding Herb.Unit}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="单价" />
+                        <TextBox Text="{Binding Herb.Price}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="功效" />
+                        <TextBox Text="{Binding Herb.Effect}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="备注" />
+                        <TextBox Text="{Binding Herb.Remark}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                    </StackPanel>
+                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/Profile/HerbProfileView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Profile/HerbProfileView.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Main {
+    public partial class HerbProfileView : UserControl {
+        public HerbProfileView() {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PatientName` to `QueueingModel`
- add herb management view and profile view
- register herb services and views in `App.xaml.cs`
- hook herb management tab in `AdminView`

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686c98382d7c83339fadb70be561917c