### PR TITLE
Implement queue creation after registration

### DIFF
--- a/LYBT.Models/Queueing/QueueingModel.cs
+++ b/LYBT.Models/Queueing/QueueingModel.cs
@@ -23,6 +23,16 @@ namespace LYBT.Models.Queueing {
         public string PatientName { get; set; } = string.Empty;
 
         /// <summary>
+        /// 医生ID
+        /// </summary>
+        public Guid DoctorId { get; set; }
+
+        /// <summary>
+        /// 医生姓名
+        /// </summary>
+        public string DoctorName { get; set; } = string.Empty;
+
+        /// <summary>
         /// 排队类型（如“普通”、“急诊”）
         /// </summary>
         public string QueueType { get; set; } = "普通";

--- a/LYBT.Module.Queueing/Dtos/QueueItemCreateDto.cs
+++ b/LYBT.Module.Queueing/Dtos/QueueItemCreateDto.cs
@@ -11,6 +11,10 @@ namespace LYBT.Module.Queueing.Dtos {
         [Required(ErrorMessage = "病人ID不能为空")]
         public string PatientId { get; set; } = string.Empty;
 
+        /// <summary>医生ID</summary>
+        [Required(ErrorMessage = "医生ID不能为空")]
+        public string DoctorId { get; set; } = string.Empty;
+
         /// <summary>排队类型（如“普通”、“急诊”）</summary>
         [Required(ErrorMessage = "排队类型不能为空")]
         public string QueueType { get; set; } = "普通";

--- a/LYBT.Module.Queueing/Dtos/QueueItemDetailDto.cs
+++ b/LYBT.Module.Queueing/Dtos/QueueItemDetailDto.cs
@@ -14,6 +14,12 @@
         /// <summary>病人姓名</summary>
         public string PatientName { get; set; } = string.Empty;
 
+        /// <summary>医生ID</summary>
+        public string DoctorId { get; set; } = string.Empty;
+
+        /// <summary>医生姓名</summary>
+        public string DoctorName { get; set; } = string.Empty;
+
         /// <summary>排队类型</summary>
         public string QueueType { get; set; } = string.Empty;
 

--- a/LYBT.Module.Queueing/Dtos/QueueItemDto.cs
+++ b/LYBT.Module.Queueing/Dtos/QueueItemDto.cs
@@ -11,6 +11,9 @@
         /// <summary>病人姓名</summary>
         public string PatientName { get; set; } = string.Empty;
 
+        /// <summary>医生姓名</summary>
+        public string DoctorName { get; set; } = string.Empty;
+
         /// <summary>排队类型</summary>
         public string QueueType { get; set; } = string.Empty;
 

--- a/LYBT.Module.Queueing/Dtos/QueueItemEditDto.cs
+++ b/LYBT.Module.Queueing/Dtos/QueueItemEditDto.cs
@@ -15,6 +15,9 @@ namespace LYBT.Module.Queueing.Dtos {
         [Required(ErrorMessage = "排队类型不能为空")]
         public string QueueType { get; set; } = "普通";
 
+        /// <summary>医生ID</summary>
+        public string DoctorId { get; set; } = string.Empty;
+
         /// <summary>备注</summary>
         public string? Remark { get; set; }
     }

--- a/LYBT.Module.Queueing/Mapping/QueueingMappingProfile.cs
+++ b/LYBT.Module.Queueing/Mapping/QueueingMappingProfile.cs
@@ -13,6 +13,7 @@ namespace LYBT.Module.Queueing.Mapping {
             CreateMap<QueueingModel, QueueingDto>().ReverseMap();
             CreateMap<QueueingModel, QueueingDetailDto>().ReverseMap();
             CreateMap<QueueingCreateDto, QueueingModel>();
+            CreateMap<QueueingEditDto, QueueingModel>();
         }
     }
 }

--- a/LYBT.Module.Registration/Dtos/RegistrationCreateDto.cs
+++ b/LYBT.Module.Registration/Dtos/RegistrationCreateDto.cs
@@ -11,6 +11,10 @@ namespace LYBT.Module.Registration.Dtos {
         [Required(ErrorMessage = "病人ID不能为空")]
         public string PatientId { get; set; } = string.Empty;
 
+        /// <summary>医生ID</summary>
+        [Required(ErrorMessage = "医生ID不能为空")]
+        public string DoctorId { get; set; } = string.Empty;
+
         /// <summary>挂号类型（如“普通”、“急诊”）</summary>
         [Required(ErrorMessage = "挂号类型不能为空")]
         public string RegistrationType { get; set; } = "普通";

--- a/LYBT.Module.Registration/Dtos/RegistrationDetailDto.cs
+++ b/LYBT.Module.Registration/Dtos/RegistrationDetailDto.cs
@@ -11,6 +11,9 @@
         /// <summary>病人ID</summary>
         public string PatientId { get; set; } = string.Empty;
 
+        /// <summary>医生ID</summary>
+        public string DoctorId { get; set; } = string.Empty;
+
         /// <summary>病人姓名</summary>
         public string PatientName { get; set; } = string.Empty;
 

--- a/LYBT.Module.Registration/Dtos/RegistrationDto.cs
+++ b/LYBT.Module.Registration/Dtos/RegistrationDto.cs
@@ -11,6 +11,9 @@
         /// <summary>病人姓名</summary>
         public string PatientName { get; set; } = string.Empty;
 
+        /// <summary>医生姓名</summary>
+        public string DoctorName { get; set; } = string.Empty;
+
         /// <summary>挂号类型</summary>
         public string RegistrationType { get; set; } = string.Empty;
 

--- a/LYBT.Module.Registration/Dtos/RegistrationEditDto.cs
+++ b/LYBT.Module.Registration/Dtos/RegistrationEditDto.cs
@@ -16,6 +16,9 @@ namespace LYBT.Module.Registration.Dtos {
         [Required(ErrorMessage = "挂号类型不能为空")]
         public RegistrationType RegistrationType { get; set; } = RegistrationType.General;
 
+        /// <summary>医生ID</summary>
+        public string DoctorId { get; set; } = string.Empty;
+
         /// <summary>备注</summary>
         public string Remark { get; set; } = string.Empty;
     }

--- a/LYBT.Module.Registration/LYBT.Module.Registration.csproj
+++ b/LYBT.Module.Registration/LYBT.Module.Registration.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\LYBT.Common\LYBT.Common.csproj" />
     <ProjectReference Include="..\LYBT.Infrastructure\LYBT.Infrastructure.csproj" />
     <ProjectReference Include="..\LYBT.Models\LYBT.Models.csproj" />
+    <ProjectReference Include="..\LYBT.Module.Queueing\LYBT.Module.Queueing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LYBT.Module.Registration/RegistrationModule.cs
+++ b/LYBT.Module.Registration/RegistrationModule.cs
@@ -1,6 +1,8 @@
 ﻿using LYBT.Module.Registration.Interfaces;
 using LYBT.Module.Registration.Repositories;
 using LYBT.Module.Registration.Services;
+using LYBT.Module.Queueing.Interfaces;
+using LYBT.Module.Queueing.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LYBT.Module.Registration {
@@ -16,6 +18,7 @@ namespace LYBT.Module.Registration {
         public static void Register(IServiceCollection services) {
             services.AddScoped<IRegistrationRepository, RegistrationRepository>();
             services.AddScoped<IRegistrationService, RegistrationService>();
+            services.AddScoped<IQueueingRepository, QueueingRepository>();
         }
     }
 }

--- a/LYBT.Module.Registration/Services/RegistrationService.cs
+++ b/LYBT.Module.Registration/Services/RegistrationService.cs
@@ -3,6 +3,8 @@ using LYBT.Common.Enums;
 using LYBT.Models.Registration;
 using LYBT.Module.Registration.Dtos;
 using LYBT.Module.Registration.Interfaces;
+using LYBT.Module.Queueing.Interfaces;
+using LYBT.Models.Queueing;
 
 namespace LYBT.Module.Registration.Services {
 
@@ -11,13 +13,15 @@ namespace LYBT.Module.Registration.Services {
     /// </summary>
     public class RegistrationService : IRegistrationService {
         private readonly IRegistrationRepository _registrationRepository;
+        private readonly IQueueingRepository _queueingRepository;
         private readonly IMapper _mapper;
 
         /// <summary>
         /// 构造方法，注入仓储与对象映射
         /// </summary>
-        public RegistrationService(IRegistrationRepository registrationRepository, IMapper mapper) {
+        public RegistrationService(IRegistrationRepository registrationRepository, IQueueingRepository queueingRepository, IMapper mapper) {
             _registrationRepository = registrationRepository;
+            _queueingRepository = queueingRepository;
             _mapper = mapper;
         }
 
@@ -45,7 +49,27 @@ namespace LYBT.Module.Registration.Services {
             model.Id = Guid.NewGuid();
             model.RegistrationTime = DateTime.Now;
             model.Status = RegistrationStatus.Pending;
-            return await _registrationRepository.AddAsync(model);
+            if (Guid.TryParse(dto.PatientId, out var patId))
+                model.PatientId = patId;
+            if (Guid.TryParse(dto.DoctorId, out var docId))
+                model.DoctorId = docId;
+            var result = await _registrationRepository.AddAsync(model);
+            if (!result)
+                return false;
+
+            var queue = new QueueingModel {
+                Id = Guid.NewGuid(),
+                PatientId = Guid.TryParse(dto.PatientId, out var pid) ? pid : Guid.Empty,
+                PatientName = model.PatientName,
+                DoctorId = Guid.TryParse(dto.DoctorId, out var did) ? did : Guid.Empty,
+                DoctorName = model.DoctorName,
+                QueueType = dto.RegistrationType,
+                QueueTime = DateTime.Now,
+                Status = QueueStatus.Waiting,
+                Remark = "自动排队"
+            };
+            await _queueingRepository.AddAsync(queue);
+            return true;
         }
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/RegistrationController.cs
+++ b/LYBT.WebAPI/Controllers/RegistrationController.cs
@@ -1,6 +1,7 @@
 ﻿using LYBT.Module.Registration.Dtos;
 using LYBT.Module.Registration.Interfaces;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
 
 namespace LYBT.Module.Registration.Controllers {
 
@@ -9,6 +10,7 @@ namespace LYBT.Module.Registration.Controllers {
     /// </summary>
     [ApiController]
     [Route("api/[controller]")]
+    [Authorize]
     public class RegistrationController : ControllerBase {
         private readonly IRegistrationService _registrationService;
 


### PR DESCRIPTION
## Summary
- add doctor tracking fields to queue entries
- include doctor info in queue DTOs
- record doctor on registration creation DTO
- auto-create queue entry in `RegistrationService`
- register queue repository with registration module
- secure registration endpoints with authorization
- reference queueing module in project file

## Testing
- `dotnet build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6870695c14008333b5d2770d11fab88a