### PR TITLE
Implement queue cancel endpoint

### DIFF
--- a/LYBT.Module.Queueing/Interfaces/IQueueRepository.cs
+++ b/LYBT.Module.Queueing/Interfaces/IQueueRepository.cs
@@ -31,5 +31,10 @@ namespace LYBT.Module.Queueing.Interfaces {
         /// 删除排队信息
         /// </summary>
         Task<bool> DeleteAsync(Guid id);
+
+        /// <summary>
+        /// 将排队信息标记为已取消
+        /// </summary>
+        Task<bool> CancelAsync(Guid id);
     }
 }

--- a/LYBT.Module.Queueing/Interfaces/IQueueService.cs
+++ b/LYBT.Module.Queueing/Interfaces/IQueueService.cs
@@ -31,5 +31,10 @@ namespace LYBT.Module.Queueing.Interfaces {
         /// 删除排队信息
         /// </summary>
         Task<bool> DeleteAsync(Guid id);
+
+        /// <summary>
+        /// 取消排队
+        /// </summary>
+        Task<bool> CancelAsync(Guid id);
     }
 }

--- a/LYBT.Module.Queueing/Repositories/QueueRepository.cs
+++ b/LYBT.Module.Queueing/Repositories/QueueRepository.cs
@@ -57,5 +57,17 @@ namespace LYBT.Module.Queueing.Repositories {
             _appDbContext.Queueings.Remove(model);
             return await _appDbContext.SaveChangesAsync() > 0;
         }
+
+        /// <summary>
+        /// 取消排队信息，标记状态为已取消
+        /// </summary>
+        public async Task<bool> CancelAsync(Guid id) {
+            var model = await _appDbContext.Queueings.FindAsync(id);
+            if (model == null)
+                return false;
+            model.Status = LYBT.Common.Enums.QueueStatus.Cancelled;
+            _appDbContext.Queueings.Update(model);
+            return await _appDbContext.SaveChangesAsync() > 0;
+        }
     }
 }

--- a/LYBT.Module.Queueing/Services/QueueService.cs
+++ b/LYBT.Module.Queueing/Services/QueueService.cs
@@ -66,5 +66,12 @@ namespace LYBT.Module.Queueing.Services {
         public async Task<bool> DeleteAsync(Guid id) {
             return await _repository.DeleteAsync(id);
         }
+
+        /// <summary>
+        /// 取消排队，更新状态为已取消
+        /// </summary>
+        public async Task<bool> CancelAsync(Guid id) {
+            return await _repository.CancelAsync(id);
+        }
     }
 }

--- a/LYBT.WebAPI/Controllers/QueueingController.cs
+++ b/LYBT.WebAPI/Controllers/QueueingController.cs
@@ -75,5 +75,16 @@ namespace LYBT.Module.Queueing.Controllers {
                 return NotFound();
             return Ok("删除排队成功");
         }
+
+        /// <summary>
+        /// 取消排队
+        /// </summary>
+        [HttpPost("cancel/{id}")]
+        public async Task<ActionResult> Cancel(Guid id) {
+            var result = await _queueingService.CancelAsync(id);
+            if (!result)
+                return NotFound();
+            return Ok();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support cancelling queue entries instead of deleting them
- wire up repository, service and controller methods for cancellation

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6870cab0772083339df0e90a7ea38f68