### PR TITLE
完善药方管理模块

### DIFF
--- a/LYBT.Module.Prescriptions/Interfaces/IPrescriptionApi.cs
+++ b/LYBT.Module.Prescriptions/Interfaces/IPrescriptionApi.cs
@@ -17,6 +17,8 @@ namespace LYBT.Module.Prescriptions.Interfaces {
 
         Task<bool> DeletePrescriptionAsync(string id);
 
+        Task<bool> CancelPrescriptionAsync(string id);
+
         // 可以扩展更多接口，如状态流转
     }
 }

--- a/LYBT.Module.Prescriptions/Repositories/IPrescriptionRepository.cs
+++ b/LYBT.Module.Prescriptions/Repositories/IPrescriptionRepository.cs
@@ -7,5 +7,6 @@ namespace LYBT.Module.Prescriptions.Repositories {
         Task<bool> AddAsync(PrescriptionModel model);
         Task<bool> UpdateAsync(PrescriptionModel model);
         Task<bool> DeleteAsync(Guid id);
+        Task<bool> CancelAsync(Guid id);
     }
 }

--- a/LYBT.Module.Prescriptions/Repositories/PrescriptionRepository.cs
+++ b/LYBT.Module.Prescriptions/Repositories/PrescriptionRepository.cs
@@ -1,5 +1,7 @@
 using LYBT.Infrastructure;
 using LYBT.Models.Prescriptions;
+using LYBT.Common.Enums.Prescriptions;
+using Microsoft.EntityFrameworkCore;
 
 namespace LYBT.Module.Prescriptions.Repositories {
     public class PrescriptionRepository : IPrescriptionRepository {
@@ -9,11 +11,15 @@ namespace LYBT.Module.Prescriptions.Repositories {
         }
 
         public async Task<PrescriptionModel?> GetByIdAsync(Guid id) {
-            return await _db.Prescriptions.FindAsync(id);
+            return await _db.Prescriptions
+                .Include(p => p.Items)
+                .FirstOrDefaultAsync(p => p.Id == id);
         }
 
         public async Task<List<PrescriptionModel>> GetListAsync() {
-            return await Task.FromResult(_db.Prescriptions.ToList());
+            return await _db.Prescriptions
+                .Include(p => p.Items)
+                .ToListAsync();
         }
 
         public async Task<bool> AddAsync(PrescriptionModel model) {
@@ -31,6 +37,15 @@ namespace LYBT.Module.Prescriptions.Repositories {
             if (m == null)
                 return false;
             _db.Prescriptions.Remove(m);
+            return await _db.SaveChangesAsync() > 0;
+        }
+
+        public async Task<bool> CancelAsync(Guid id) {
+            var model = await _db.Prescriptions.FindAsync(id);
+            if (model == null)
+                return false;
+            model.Status = PrescriptionStatus.Cancelled;
+            _db.Prescriptions.Update(model);
             return await _db.SaveChangesAsync() > 0;
         }
     }

--- a/LYBT.Module.Prescriptions/Services/IPrescriptionService.cs
+++ b/LYBT.Module.Prescriptions/Services/IPrescriptionService.cs
@@ -16,5 +16,7 @@ namespace LYBT.Module.Prescriptions.Services {
         Task<bool> UpdateAsync(PrescriptionEditDto dto, Guid operatorId, string operatorName);
 
         Task<bool> DeleteAsync(string id, Guid operatorId, string operatorName);
+
+        Task<bool> CancelAsync(string id, Guid operatorId, string operatorName);
     }
 }

--- a/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -3,6 +3,7 @@ using AutoMapper;
 using LYBT.Module.Logs.Dtos;
 using LYBT.Module.Logs.Interfaces;
 using LYBT.Common.Enums.Logs;
+using LYBT.Common.Enums.Prescriptions;
 using LYBT.Module.Prescriptions.Dtos;
 using LYBT.Models.Prescriptions;
 using LYBT.Module.Prescriptions.Repositories;
@@ -89,6 +90,27 @@ namespace LYBT.Module.Prescriptions.Services {
                 LogTime = DateTime.Now,
                 Content = "删除处方",
                 OldValue = JsonSerializer.Serialize(item)
+            });
+            return success;
+        }
+
+        public async Task<bool> CancelAsync(string id, Guid operatorId, string operatorName) {
+            if (!Guid.TryParse(id, out var gid))
+                return false;
+            var model = await _repository.GetByIdAsync(gid);
+            if (model == null)
+                return false;
+            var success = await _repository.CancelAsync(gid);
+            await _logService.AddLogAsync(new LogDto {
+                LogType = LogType.Operation,
+                ObjectType = ObjectType.Prescription,
+                ObjectId = gid,
+                ActionType = ActionType.Edit,
+                OperatorId = operatorId,
+                OperatorName = operatorName,
+                LogTime = DateTime.Now,
+                Content = "作废处方",
+                OldValue = JsonSerializer.Serialize(model)
             });
             return success;
         }

--- a/LYBT.UI.WPF/Apis/IPrescriptionApi.cs
+++ b/LYBT.UI.WPF/Apis/IPrescriptionApi.cs
@@ -24,5 +24,8 @@ namespace LYBT.UI.WPF.Apis {
 
         [Delete("/api/Prescriptions/{id}")]
         Task<ApiSuccessResponse> DeleteAsync(Guid id);
+
+        [Post("/api/Prescriptions/void/{id}")]
+        Task<ApiSuccessResponse> CancelAsync(Guid id);
     }
 }

--- a/LYBT.UI.WPF/Interfaces/IPrescriptionService.cs
+++ b/LYBT.UI.WPF/Interfaces/IPrescriptionService.cs
@@ -13,5 +13,6 @@ namespace LYBT.UI.WPF.Interfaces {
         Task<bool> AddAsync(PrescriptionCreateDto dto);
         Task<bool> UpdateAsync(PrescriptionEditDto dto);
         Task<bool> DeleteAsync(Guid id);
+        Task<bool> CancelAsync(Guid id);
     }
 }

--- a/LYBT.UI.WPF/Services/PrescriptionService.cs
+++ b/LYBT.UI.WPF/Services/PrescriptionService.cs
@@ -34,5 +34,10 @@ namespace LYBT.UI.WPF.Services {
             var resp = await _api.DeleteAsync(id);
             return resp.Success;
         }
+
+        public async Task<bool> CancelAsync(Guid id) {
+            var resp = await _api.CancelAsync(id);
+            return resp.Success;
+        }
     }
 }

--- a/LYBT.UI.WPF/ViewModels/Admin/PrescriptionManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/PrescriptionManagementViewModel.cs
@@ -70,9 +70,9 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             if (SelectedPrescription == null)
                 return;
             if (MessageBox.Show("确定删除该处方吗？", "确认", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes) {
-                var ok = await _service.DeleteAsync(SelectedPrescription.Id);
+                var ok = await _service.CancelAsync(SelectedPrescription.Id);
                 if (!ok)
-                    MessageBox.Show("删除失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    MessageBox.Show("作废失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
                 await LoadAsync();
             }
         }

--- a/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -49,5 +49,11 @@ namespace LYBT.WebAPI.Controllers {
             var result = await _service.DeleteAsync(id, Guid.Empty, "system");
             return result ? Ok() : NotFound();
         }
+
+        [HttpPost("void/{id}")]
+        public async Task<ActionResult> Cancel(string id) {
+            var result = await _service.CancelAsync(id, Guid.Empty, "system");
+            return result ? Ok() : NotFound();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- load prescription items from DB
- allow cancelling prescriptions instead of hard deletes
- expose cancellation endpoint and client API
- update UI to use cancellation

## Testing
- `dotnet restore LYBTZYZS.sln`
- `dotnet build LYBTZYZS.sln -c Release` *(fails: IAuthService missing)*

------
https://chatgpt.com/codex/tasks/task_e_68712c1aa348833386aad3c0e788ae59