### PR TITLE
Move infrastructure helpers into common

### DIFF
--- a/LYBT.Common/Helpers/LogHelper.cs
+++ b/LYBT.Common/Helpers/LogHelper.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Common.Enums.Logs;
 
-namespace LYBT.Infrastructure.Helpers {
+namespace LYBT.Common.Helpers {
 
     /// <summary>
     /// 日志工具类（简化示例）

--- a/LYBT.Common/Helpers/NetworkHelper.cs
+++ b/LYBT.Common/Helpers/NetworkHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.NetworkInformation;
 
-namespace LYBT.Infrastructure.Helpers {
+namespace LYBT.Common.Helpers {
 
     /// <summary>
     /// 网络状态检查工具类

--- a/LYBT.Common/README.md
+++ b/LYBT.Common/README.md
@@ -57,4 +57,5 @@ var isOk = Validator.CheckIdNumber("440101199912121234");
 - `ApiResponse<T>`、`PagedResult<T>` 通用返回对象
 - `EnumHelper`、`StringHelper`、`Validator` 等扩展方法类
 - 枚举转中文辅助（`.ToChinese()`）
+- `LogHelper`、`NetworkHelper` 基础日志与网络工具（从 Infrastructure 移至此模块）
 

--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -4,6 +4,7 @@
 using LYBT.Infrastructure;
 using LYBT.Infrastructure.Auth.Extensions;
 using LYBT.Infrastructure.Exceptions;
+using LYBT.Common.Helpers;
 using LYBT.Infrastructure.Helpers;
 using LYBT.Module.Auth.Interfaces;
 using LYBT.Module.Auth.Repositories;


### PR DESCRIPTION
## Summary
- relocate `LogHelper` and `NetworkHelper` from Infrastructure to Common
- update namespaces and using directives
- document the new helper locations

## Testing
- `dotnet build LYBT.Common/LYBT.Common.csproj -c Release`
- `dotnet build LYBT.Infrastructure/LYBT.Infrastructure.csproj -c Release`
- `dotnet build LYBT.WebAPI/LYBT.WebAPI.csproj -c Release`
- `dotnet test LYBTZYZS.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6871a90e07ac83338bb98989b3b2050c