### PR TITLE
Update auth docs and module statistics

### DIFF
--- a/LYBT.Module.Auth/README.md
+++ b/LYBT.Module.Auth/README.md
@@ -50,7 +50,18 @@ await _logService.WriteAsync(userId, "登录", "Auth", "Success", "登录成功"
 
 ### 6. 接口列表
 
-- `Task<UserDto?> LoginAsync(LoginRequestDto dto)`
-- `Task<bool> LogoutAsync(LogoutRequestDto dto)`
-- `Task<bool> ChangeSysAdminPasswordAsync(ChangeSysAdminPasswordDto dto)`
+- `Task<UserDto?> LoginAsync(LoginRequestDto dto)` - 用户登录并返回用户信息
+- `Task<bool> LogoutAsync(LogoutRequestDto dto)` - 用户登出
+- `Task<bool> ChangeSysAdminPasswordAsync(ChangeSysAdminPasswordDto dto)` - 修改系统管理员密码
 
+
+### Web API 接口对照
+
+| 设计接口 | 接口说明 | 状态 |
+| --- | --- | --- |
+| `POST /api/auth/login` | 用户登录 | 已实现 |
+| `POST /api/auth/logout` | 用户登出 | 已实现 |
+| `POST /api/auth/changeSysAdminPassword` | 修改 sysadmin 密码 | 已实现 |
+
+接口数量：3
+已实现 Web API 数量：3

--- a/LYBT.Module.Users/README.md
+++ b/LYBT.Module.Users/README.md
@@ -65,27 +65,29 @@ await _userService.ChangePasswordAsync(userId, oldPwd, newPwd);
 
 ### 6. 接口列表
 
-- `Task<(IList<UserDto>, int)> SearchAsync(UserQueryDto dto)`
-- `Task<UserDetailDto?> GetByIdAsync(Guid id)`
-- `Task<bool> AddAsync(UserCreateDto dto, Guid operatorId, string operatorName)`
-- `Task<bool> UpdateAsync(UserDetailDto dto, Guid operatorId, string operatorName)`
-- `Task<bool> DisableAsync(Guid id, Guid operatorId, string operatorName)`
-- `Task<bool> EnableAsync(Guid id, Guid operatorId, string operatorName)`
-- `Task<bool> BatchDisableAsync(List<Guid> ids, Guid operatorId, string operatorName)`
-- `Task<bool> BatchEnableAsync(List<Guid> ids, Guid operatorId, string operatorName)`
-- `Task<bool> ResetPasswordAsync(Guid id, Guid operatorId, string operatorName)`
-- `Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword)`
-- `Task<bool> ChangeProfileAsync(Guid id, string realName, string? phone, string? email)`
-- `Task<IList<string>> GetRoles()`
+- `Task<(IList<UserDto>, int)> SearchAsync(UserQueryDto dto)` - 搜索用户
+- `Task<UserDetailDto?> GetByIdAsync(Guid id)` - 根据ID获取用户
+- `Task<bool> AddAsync(UserCreateDto dto, Guid operatorId, string operatorName)` - 新增用户
+- `Task<bool> UpdateAsync(UserDetailDto dto, Guid operatorId, string operatorName)` - 更新用户
+- `Task<bool> DisableAsync(Guid id, Guid operatorId, string operatorName)` - 禁用用户
+- `Task<bool> EnableAsync(Guid id, Guid operatorId, string operatorName)` - 启用用户
+- `Task<bool> BatchDisableAsync(List<Guid> ids, Guid operatorId, string operatorName)` - 批量禁用
+- `Task<bool> BatchEnableAsync(List<Guid> ids, Guid operatorId, string operatorName)` - 批量启用
+- `Task<bool> ResetPasswordAsync(Guid id, Guid operatorId, string operatorName)` - 重置密码
+- `Task<bool> ChangePasswordAsync(Guid id, string oldPassword, string newPassword)` - 修改密码
+- `Task<bool> ChangeProfileAsync(Guid id, string realName, string? phone, string? email)` - 修改个人资料
+- `Task<IList<string>> GetRoles()` - 获取角色列表
 
 ### Web API 接口对照
 
-| 设计接口 | 状态 | 备注 |
-| --- | --- | --- |
-| `POST /api/users` | 未实现 | 实际路径 `POST /api/Users/add` |
-| `PUT /api/users/{id}` | 未实现 | 实际路径 `PUT /api/Users/update` |
-| `POST /api/auth/login` | 已实现 | 由 `AuthController` 提供 |
-| `GET /api/users` | 未实现 | 实际路径 `GET /api/Users/search` |
-| `DELETE /api/users/{id}` | 未实现 | 仅提供 `disable/{id}` 与 `enable/{id}` |
+| 设计接口 | 接口说明 | 状态 | 备注 |
+| --- | --- | --- | --- |
+| `POST /api/users` | 新增用户 | 未实现 | 实际路径 `POST /api/Users/add` |
+| `PUT /api/users/{id}` | 更新用户 | 未实现 | 实际路径 `PUT /api/Users/update` |
+| `GET /api/users` | 查询用户 | 未实现 | 实际路径 `GET /api/Users/search` |
+| `DELETE /api/users/{id}` | 删除用户 | 未实现 | 仅提供 `disable/{id}` 与 `enable/{id}` |
 
 
+
+接口数量：12
+已实现 Web API 数量：0

--- a/README.md
+++ b/README.md
@@ -60,6 +60,27 @@
 
 ---
 
+## 模块接口统计
+
+| 模块 | 接口数量 | 已实现 WebAPI |
+| --- | --- | --- |
+| Auth | 3 | 3 |
+| Billing | 11 | 5 |
+| DiagnosisTreatment | 5 | 4 |
+| Doctors | 10 | 0 |
+| FormulaTemplates | 5 | 5 |
+| Herbs | 5 | 5 |
+| Logs | 2 | 0 |
+| Patients | 14 | 0 |
+| Pharmacy | 7 | 0 |
+| Prescriptions | 6 | 0 |
+| Queueing | 6 | 3 |
+| Records | 7 | 2 |
+| Registration | 6 | 4 |
+| Settings | 11 | 4 |
+| Sync | 11 | 0 |
+| TreatmentRoom | 5 | 3 |
+| Users | 12 | 0 |
 ## 典型接口结构（以用户模块为例）
 
 - `Task<(IList<UserDto>, int)> SearchAsync(UserQueryDto dto)`


### PR DESCRIPTION
## Summary
- move login API docs from Users to Auth
- add Chinese descriptions and counts in Users and Auth READMEs
- list interface/API statistics for all modules in main README

## Testing
- `dotnet build LYBTZYZS.sln`

------
https://chatgpt.com/codex/tasks/task_e_6871bcb1e95c8333994d1aa3f2c1877f