### PR TITLE
Add module service unit tests

### DIFF
--- a/LYBT.Tests/Services/BillingServiceTests.cs
+++ b/LYBT.Tests/Services/BillingServiceTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoMapper;
+using Moq;
+using Xunit;
+using LYBT.Module.Billing.Services;
+using LYBT.Module.Billing.Interfaces;
+using LYBT.Module.Billing.Dtos;
+using LYBT.Module.Billing.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class BillingServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<BillingMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IBillingRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Billing.BillingModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new BillingService(repo.Object, mapper);
+
+        var dto = new BillingCreateDto
+        {
+            PatientId = Guid.NewGuid(),
+            DoctorId = Guid.NewGuid()
+        };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Billing.BillingModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/DiagnosisTreatmentServiceTests.cs
+++ b/LYBT.Tests/Services/DiagnosisTreatmentServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.DiagnosisTreatment.Services;
+using LYBT.Module.DiagnosisTreatment.Interfaces;
+using LYBT.Module.DiagnosisTreatment.Models.Dtos;
+using LYBT.Module.DiagnosisTreatment.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class DiagnosisTreatmentServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<DiagnosisTreatmentMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IDiagnosisTreatmentRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.DiagnosisTreatment.DiagnosisTreatmentModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new DiagnosisTreatmentService(repo.Object, mapper);
+
+        var dto = new DiagnosisTreatmentCreateDto { PatientId = Guid.NewGuid(), Diagnosis = "" };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.DiagnosisTreatment.DiagnosisTreatmentModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/DoctorServiceTests.cs
+++ b/LYBT.Tests/Services/DoctorServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Doctors.Services;
+using LYBT.Module.Doctors.Interfaces;
+using LYBT.Module.Doctors.Dtos;
+using LYBT.Module.Doctors.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class DoctorServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<DoctorMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IDoctorRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Doctors.DoctorModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new DoctorService(repo.Object, mapper);
+
+        var dto = new DoctorDetailDto { UserId = Guid.NewGuid() };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Doctors.DoctorModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/FormulaTemplatesServiceTests.cs
+++ b/LYBT.Tests/Services/FormulaTemplatesServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.FormulaTemplates.Services;
+using LYBT.Module.FormulaTemplates.Interfaces;
+using LYBT.Module.FormulaTemplates.Dtos;
+using LYBT.Module.FormulaTemplates.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class FormulaTemplatesServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<FormulaTemplateMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IFormulaTemplateRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.FormulaTemplates.FormulaTemplateModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new FormulaTemplateService(repo.Object, mapper);
+
+        var dto = new FormulaTemplateCreateDto { Name = "test" };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.FormulaTemplates.FormulaTemplateModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/HerbServiceTests.cs
+++ b/LYBT.Tests/Services/HerbServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Herbs.Services;
+using LYBT.Module.Herbs.Interfaces;
+using LYBT.Module.Herbs.Dtos;
+using LYBT.Module.Herbs.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class HerbServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<HerbMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IHerbRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.HerbModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new HerbService(repo.Object, mapper);
+
+        var dto = new HerbCreateDto { Name = "test" };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.HerbModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/LogsServiceTests.cs
+++ b/LYBT.Tests/Services/LogsServiceTests.cs
@@ -1,0 +1,27 @@
+using System;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+using LYBT.Module.Logs.Services;
+using LYBT.Module.Logs.Interfaces;
+using LYBT.Module.Logs.Dtos;
+using LYBT.Common.Enums.Logs;
+
+namespace LYBT.Tests.Services;
+
+public class LogsServiceTests
+{
+    [Fact]
+    public async Task AddLogAsync_CallsRepository()
+    {
+        var repo = new Mock<ILogRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Logs.LogModel>())).ReturnsAsync(true);
+        var service = new LogService(repo.Object);
+
+        var dto = new LogDto { LogType = LogType.Operation };
+        var result = await service.AddLogAsync(dto);
+
+        Assert.NotEqual(Guid.Empty, result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Logs.LogModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/PatientsServiceTests.cs
+++ b/LYBT.Tests/Services/PatientsServiceTests.cs
@@ -1,0 +1,40 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Patients.Services;
+using LYBT.Module.Patients.Interfaces;
+using LYBT.Module.Patients.Dtos;
+using LYBT.Module.Patients.Mapping;
+using LYBT.Module.Logs.Interfaces;
+using LYBT.Module.Records.Interfaces;
+
+namespace LYBT.Tests.Services;
+
+public class PatientsServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<PatientMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepositoryAndLogs()
+    {
+        var repo = new Mock<IPatientRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Patients.PatientModel>())).ReturnsAsync(true);
+        var logSvc = new Mock<ILogService>();
+        var recordSvc = new Mock<IRecordService>();
+        var mapper = CreateMapper();
+        var service = new PatientService(repo.Object, mapper, logSvc.Object, recordSvc.Object);
+
+        var dto = new PatientDetailDto { Name = "test" };
+        var result = await service.AddAsync(dto, Guid.Empty, "sys");
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Patients.PatientModel>()), Times.Once);
+        logSvc.Verify(l => l.AddLogAsync(It.IsAny<LYBT.Module.Logs.Dtos.LogDto>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/PharmacyServiceTests.cs
+++ b/LYBT.Tests/Services/PharmacyServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Pharmacy.Services;
+using LYBT.Module.Pharmacy.Interfaces;
+using LYBT.Module.Pharmacy.Dtos;
+using LYBT.Module.Pharmacy.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class PharmacyServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<PharmacyMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IPharmacyRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Pharmacy.PharmacyModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new PharmacyService(repo.Object, mapper);
+
+        var dto = new PharmacyCreateDto { PrescriptionId = Guid.NewGuid() };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Pharmacy.PharmacyModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/PrescriptionsServiceTests.cs
+++ b/LYBT.Tests/Services/PrescriptionsServiceTests.cs
@@ -1,0 +1,38 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Prescriptions.Services;
+using LYBT.Module.Prescriptions.Repositories;
+using LYBT.Module.Prescriptions.Dtos;
+using LYBT.Module.Prescriptions.Mapping;
+using LYBT.Module.Logs.Interfaces;
+
+namespace LYBT.Tests.Services;
+
+public class PrescriptionsServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<PrescriptionMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task CreateAsync_CallsRepositoryAndLogs()
+    {
+        var repo = new Mock<IPrescriptionRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Prescriptions.PrescriptionModel>())).ReturnsAsync(true);
+        var logSvc = new Mock<ILogService>();
+        var mapper = CreateMapper();
+        var service = new PrescriptionService(repo.Object, logSvc.Object, mapper);
+
+        var dto = new PrescriptionCreateDto { PatientId = Guid.NewGuid() };
+        var result = await service.CreateAsync(dto, Guid.Empty, "sys");
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Prescriptions.PrescriptionModel>()), Times.Once);
+        logSvc.Verify(l => l.AddLogAsync(It.IsAny<LYBT.Module.Logs.Dtos.LogDto>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/QueueingServiceTests.cs
+++ b/LYBT.Tests/Services/QueueingServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Queueing.Services;
+using LYBT.Module.Queueing.Interfaces;
+using LYBT.Module.Queueing.Dtos;
+using LYBT.Module.Queueing.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class QueueingServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<QueueingMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<IQueueingRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Queueing.QueueingModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new QueueingService(repo.Object, mapper);
+
+        var dto = new QueueingCreateDto { PatientId = Guid.NewGuid().ToString(), DoctorId = Guid.NewGuid().ToString() };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Queueing.QueueingModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/RecordsServiceTests.cs
+++ b/LYBT.Tests/Services/RecordsServiceTests.cs
@@ -1,0 +1,38 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Records.Services;
+using LYBT.Module.Records.Interfaces;
+using LYBT.Module.Records.Dtos;
+using LYBT.Module.Records.Mapping;
+using LYBT.Module.Logs.Interfaces;
+
+namespace LYBT.Tests.Services;
+
+public class RecordsServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<RecordMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepositoryAndLogs()
+    {
+        var repo = new Mock<IRecordRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Records.RecordModel>())).ReturnsAsync(true);
+        var logSvc = new Mock<ILogService>();
+        var mapper = CreateMapper();
+        var service = new RecordService(repo.Object, mapper, logSvc.Object);
+
+        var dto = new RecordCreateDto { PatientId = Guid.NewGuid().ToString() };
+        var result = await service.AddAsync(dto, Guid.Empty, "sys");
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Records.RecordModel>()), Times.Once);
+        logSvc.Verify(l => l.AddLogAsync(It.IsAny<LYBT.Module.Logs.Dtos.LogDto>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/RegistrationServiceTests.cs
+++ b/LYBT.Tests/Services/RegistrationServiceTests.cs
@@ -1,0 +1,38 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Registration.Services;
+using LYBT.Module.Registration.Interfaces;
+using LYBT.Module.Registration.Dtos;
+using LYBT.Module.Registration.Mapping;
+using LYBT.Module.Queueing.Interfaces;
+
+namespace LYBT.Tests.Services;
+
+public class RegistrationServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<RegistrationMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CreatesQueueEntry()
+    {
+        var regRepo = new Mock<IRegistrationRepository>();
+        regRepo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Registration.RegistrationModel>())).ReturnsAsync(true);
+        var queueRepo = new Mock<IQueueingRepository>();
+        var mapper = CreateMapper();
+        var service = new RegistrationService(regRepo.Object, queueRepo.Object, mapper);
+
+        var dto = new RegistrationCreateDto { PatientId = Guid.NewGuid().ToString(), DoctorId = Guid.NewGuid().ToString(), RegistrationType = "General" };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        regRepo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Registration.RegistrationModel>()), Times.Once);
+        queueRepo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Queueing.QueueingModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/SettingsServiceTests.cs
+++ b/LYBT.Tests/Services/SettingsServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Settings.Services;
+using LYBT.Module.Settings.Interfaces;
+using LYBT.Module.Settings.Dtos;
+using LYBT.Module.Settings.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class SettingsServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<SettingsMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<ISettingsRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.Settings.SettingsModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new SettingsService(repo.Object, mapper);
+
+        var dto = new SettingsCreateDto { Key = "k" };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Settings.SettingsModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/SyncServiceTests.cs
+++ b/LYBT.Tests/Services/SyncServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.Sync.Services;
+using LYBT.Module.Sync.Interfaces;
+using LYBT.Module.Sync.Dtos;
+using LYBT.Module.Sync.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class SyncServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<SyncMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddLogAsync_CallsRepository()
+    {
+        var repo = new Mock<ISyncRepository>();
+        repo.Setup(r => r.AddLogAsync(It.IsAny<LYBT.Models.SyncLogModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new SyncService(repo.Object, mapper);
+
+        var dto = new SyncLogCreateDto { Message = "ok" };
+        var result = await service.AddLogAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddLogAsync(It.IsAny<LYBT.Models.SyncLogModel>()), Times.Once);
+    }
+}

--- a/LYBT.Tests/Services/TreatmentRoomServiceTests.cs
+++ b/LYBT.Tests/Services/TreatmentRoomServiceTests.cs
@@ -1,0 +1,35 @@
+using System;
+using AutoMapper;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using LYBT.Module.TreatmentRoom.Services;
+using LYBT.Module.TreatmentRoom.Interfaces;
+using LYBT.Module.TreatmentRoom.Dtos;
+using LYBT.Module.TreatmentRoom.Mapping;
+
+namespace LYBT.Tests.Services;
+
+public class TreatmentRoomServiceTests
+{
+    private static IMapper CreateMapper()
+    {
+        var config = new MapperConfiguration(cfg => cfg.AddProfile<TreatmentRoomMappingProfile>());
+        return config.CreateMapper();
+    }
+
+    [Fact]
+    public async Task AddAsync_CallsRepository()
+    {
+        var repo = new Mock<ITreatmentRoomRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.TreatmentRoom.TreatmentRoomModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new TreatmentRoomService(repo.Object, mapper);
+
+        var dto = new TreatmentRoomCreateDto { TreatmentItem = "t" };
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.TreatmentRoom.TreatmentRoomModel>()), Times.Once);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ Execute all unit tests with:
 ```
 
 
+
+Unit tests now cover service ports of all modules and can be run with `dotnet test`.


### PR DESCRIPTION
## Summary
- add unit tests for billing, diagnosis, doctors, formula templates, herbs, logs, patients, pharmacy, prescriptions, queueing, records, registration, settings, sync and treatment room services
- update README with note about running tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6871f7a3b88c8333b481cf5f19401451