### PR TITLE
Add formula template management views

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -3,6 +3,7 @@ using LYBT.UI.WPF.Services;
 using LYBT.UI.WPF.Views;
 using LYBT.UI.WPF.Views.Admin;
 using LYBT.UI.WPF.Views.Main;
+using LYBT.UI.WPF.Views.Profile;
 using Refit;
 using System.Configuration;
 using System.Net.Http;
@@ -49,6 +50,7 @@ namespace LYBT.UI.WPF {
             var herbApi = RestService.For<IHerbApi>(httpClient, refitSettings);
             var billingApi = RestService.For<IBillingApi>(httpClient, refitSettings);
             var prescriptionApi = RestService.For<IPrescriptionApi>(httpClient, refitSettings);
+            var formulaTemplateApi = RestService.For<IFormulaTemplateApi>(httpClient, refitSettings);
             var logApi = RestService.For<ILogApi>(httpClient, refitSettings);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！
@@ -59,6 +61,7 @@ namespace LYBT.UI.WPF {
             var herbService = new HerbService(herbApi);
             var billingService = new BillingService(billingApi);
             var prescriptionService = new PrescriptionService(prescriptionApi);
+            var formulaTemplateService = new FormulaTemplateService(formulaTemplateApi);
             var logService = new LogService(logApi);
 
 
@@ -70,6 +73,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(herbApi);
             containerRegistry.RegisterInstance(billingService);
             containerRegistry.RegisterInstance(prescriptionApi);
+            containerRegistry.RegisterInstance(formulaTemplateApi);
             containerRegistry.RegisterInstance(logApi);
 
             containerRegistry.RegisterInstance<IAuthService>(authService);
@@ -79,6 +83,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IHerbService>(herbService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
             containerRegistry.RegisterInstance<IPrescriptionService>(prescriptionService);
+            containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);
             containerRegistry.RegisterInstance<ILogService>(logService);
 
 
@@ -91,6 +96,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<DoctorManagementView>("DoctorManagementView");
             containerRegistry.RegisterForNavigation<HerbManagementView>("HerbManagementView");
             containerRegistry.RegisterForNavigation<PrescriptionManagementView>("PrescriptionManagementView");
+            containerRegistry.RegisterForNavigation<FormulaTemplatesManagementView>("FormulaTemplatesManagementView");
             containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
             containerRegistry.RegisterForNavigation<DiagnosingDoctorView>("DiagnosingDoctorView");
             containerRegistry.RegisterForNavigation<PharmacyStaffView>("PharmacyStaffView");
@@ -100,6 +106,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<ChangeProfileView>("ChangeProfileView");
             containerRegistry.RegisterForNavigation<DoctorProfileView>("DoctorProfileView");
             containerRegistry.RegisterForNavigation<HerbProfileView>("HerbProfileView");
+            containerRegistry.RegisterForNavigation<FormulaTemplatesProfileView>("FormulaTemplatesProfileView");
             containerRegistry.RegisterForNavigation<UserProfileView>("UserProfileView");
 
         }

--- a/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
@@ -1,0 +1,80 @@
+using LYBT.Module.FormulaTemplates.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using LYBT.UI.WPF.ViewModels.Profile;
+using Prism.Commands;
+using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Admin {
+    /// <summary>
+    /// 经验方模板管理视图模型
+    /// </summary>
+    public class FormulaTemplatesManagementViewModel : BindableBase {
+        private readonly IFormulaTemplateService _service;
+        public ObservableCollection<FormulaTemplateDto> Templates { get; } = new();
+
+        private FormulaTemplateDto? _selectedTemplate;
+        public FormulaTemplateDto? SelectedTemplate {
+            get => _selectedTemplate;
+            set => SetProperty(ref _selectedTemplate, value);
+        }
+
+        public FormulaTemplatesProfileViewModel ProfileViewModel { get; }
+
+        public DelegateCommand RefreshCommand { get; }
+        public DelegateCommand AddCommand { get; }
+        public DelegateCommand EditCommand { get; }
+        public DelegateCommand DeleteCommand { get; }
+
+        public FormulaTemplatesManagementViewModel(IFormulaTemplateService service, FormulaTemplatesProfileViewModel profileViewModel) {
+            _service = service;
+            ProfileViewModel = profileViewModel;
+            RefreshCommand = new DelegateCommand(async () => await LoadAsync());
+            AddCommand = new DelegateCommand(Add);
+            EditCommand = new DelegateCommand(Edit, () => SelectedTemplate != null).ObservesProperty(() => SelectedTemplate);
+            DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), () => SelectedTemplate != null).ObservesProperty(() => SelectedTemplate);
+            _ = LoadAsync();
+        }
+
+        private async Task LoadAsync() {
+            var list = await _service.GetListAsync();
+            Templates.Clear();
+            foreach (var t in list)
+                Templates.Add(t);
+        }
+
+        private void Add() {
+            ProfileViewModel.IsEditable = true;
+            ProfileViewModel.CancelAction = async () => {
+                ProfileViewModel.IsEditable = false;
+                await LoadAsync();
+            };
+            _ = ProfileViewModel.LoadAsync();
+        }
+
+        private void Edit() {
+            if (SelectedTemplate == null)
+                return;
+            ProfileViewModel.IsEditable = true;
+            ProfileViewModel.CancelAction = async () => {
+                ProfileViewModel.IsEditable = false;
+                await LoadAsync();
+            };
+            _ = ProfileViewModel.LoadAsync(SelectedTemplate.Id);
+        }
+
+        private async Task DeleteAsync() {
+            if (SelectedTemplate == null)
+                return;
+            if (MessageBox.Show("确定删除该模板吗？", "确认", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes) {
+                var ok = await _service.DeleteAsync(SelectedTemplate.Id);
+                if (!ok)
+                    MessageBox.Show("删除失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                await LoadAsync();
+            }
+        }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
@@ -1,0 +1,113 @@
+using LYBT.Module.FormulaTemplates.Dtos;
+using LYBT.Module.Herbs.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using Prism.Commands;
+using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Profile {
+    /// <summary>
+    /// 经验方模板详情与编辑视图模型
+    /// </summary>
+    public class FormulaTemplatesProfileViewModel : BindableBase {
+        private readonly IFormulaTemplateService _service;
+
+        private FormulaTemplateDetailDto _template = new();
+        public FormulaTemplateDetailDto Template {
+            get => _template;
+            set => SetProperty(ref _template, value);
+        }
+
+        public ObservableCollection<HerbDto> Herbs { get; } = new();
+
+        private HerbDto? _selectedHerb;
+        public HerbDto? SelectedHerb {
+            get => _selectedHerb;
+            set => SetProperty(ref _selectedHerb, value);
+        }
+
+        private string _editModeTitle = "新增模板";
+        public string EditModeTitle {
+            get => _editModeTitle;
+            set => SetProperty(ref _editModeTitle, value);
+        }
+
+        private bool _isEditable;
+        public bool IsEditable {
+            get => _isEditable;
+            set => SetProperty(ref _isEditable, value);
+        }
+
+        public DelegateCommand SaveCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+        public DelegateCommand AddHerbCommand { get; }
+        public DelegateCommand RemoveHerbCommand { get; }
+
+        public Action? CancelAction { get; set; }
+
+        public FormulaTemplatesProfileViewModel(IFormulaTemplateService service) {
+            _service = service;
+            SaveCommand = new DelegateCommand(async () => await SaveAsync());
+            CancelCommand = new DelegateCommand(Cancel);
+            AddHerbCommand = new DelegateCommand(AddHerb);
+            RemoveHerbCommand = new DelegateCommand(RemoveHerb, () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
+        }
+
+        public async Task LoadAsync(Guid? id = null) {
+            if (id.HasValue && id.Value != Guid.Empty) {
+                var detail = await _service.GetByIdAsync(id.Value);
+                if (detail != null) {
+                    Template = detail;
+                    Herbs.Clear();
+                    foreach (var h in detail.Herbs)
+                        Herbs.Add(h);
+                    EditModeTitle = "编辑模板";
+                }
+            } else {
+                Template = new FormulaTemplateDetailDto();
+                Herbs.Clear();
+                EditModeTitle = "新增模板";
+            }
+        }
+
+        private void AddHerb() {
+            Herbs.Add(new HerbDto());
+        }
+
+        private void RemoveHerb() {
+            if (SelectedHerb != null)
+                Herbs.Remove(SelectedHerb);
+        }
+
+        private async Task SaveAsync() {
+            Template.Herbs = Herbs.ToList();
+            bool ok;
+            if (Template.Id == Guid.Empty) {
+                var dto = new FormulaTemplateCreateDto {
+                    Name = Template.Name,
+                    Herbs = Herbs.ToList(),
+                    Remark = Template.Remark
+                };
+                ok = await _service.AddAsync(dto);
+            } else {
+                var dto = new FormulaTemplateEditDto {
+                    Id = Template.Id,
+                    Name = Template.Name,
+                    Herbs = Herbs.ToList(),
+                    Remark = Template.Remark
+                };
+                ok = await _service.UpdateAsync(dto);
+            }
+            if (!ok)
+                MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+            else
+                CancelAction?.Invoke();
+        }
+
+        private void Cancel() => CancelAction?.Invoke();
+    }
+}

--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -1,0 +1,33 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Admin.FormulaTemplatesManagementView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:main="clr-namespace:LYBT.UI.WPF.Views.Profile"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+            <Button Content="新增" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+            <Button Content="编辑" Command="{Binding EditCommand}" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}" Margin="0,0,8,0"/>
+            <Button Content="删除" Command="{Binding DeleteCommand}" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
+        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+            <DataGrid Grid.Column="0" ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate, Mode=TwoWay}" AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+                <main:FormulaTemplatesProfileView DataContext="{Binding ProfileViewModel}" />
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Admin {
+    /// <summary>
+    /// FormulaTemplatesManagementView code-behind
+    /// </summary>
+    public partial class FormulaTemplatesManagementView : UserControl {
+        public FormulaTemplatesManagementView() {
+            InitializeComponent();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
@@ -22,5 +22,8 @@
         <TabItem Header="处方管理">
             <admin:PrescriptionManagementView/>
         </TabItem>
+        <TabItem Header="经验方模板">
+            <admin:FormulaTemplatesManagementView/>
+        </TabItem>
     </TabControl>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Profile/FormulaTemplatesProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/FormulaTemplatesProfileView.xaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Profile.FormulaTemplatesProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid>
+        <Border Padding="20" MinWidth="420" Background="#FAFAFA" CornerRadius="8" BorderBrush="#DDD" BorderThickness="1">
+            <StackPanel>
+                <TextBlock Text="{Binding EditModeTitle}" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                    <TextBlock Text="名称" Width="60"/>
+                    <TextBox Text="{Binding Template.Name}" Width="300"/>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                    <Button Content="添加药材" Command="{Binding AddHerbCommand}" Margin="0,0,5,0"/>
+                    <Button Content="删除药材" Command="{Binding RemoveHerbCommand}" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
+                </StackPanel>
+                <DataGrid ItemsSource="{Binding Herbs}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHerb}" Height="200" Margin="0,0,0,10">
+                    <DataGrid.Columns>
+                        <DataGridTextColumn Header="药材" Binding="{Binding Name}" Width="*"/>
+                    </DataGrid.Columns>
+                </DataGrid>
+                <TextBlock Text="备注"/>
+                <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,10"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,0,10,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/Profile/FormulaTemplatesProfileView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Profile/FormulaTemplatesProfileView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Profile {
+    /// <summary>
+    /// FormulaTemplatesProfileView code-behind
+    /// </summary>
+    public partial class FormulaTemplatesProfileView : UserControl {
+        public FormulaTemplatesProfileView() {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support managing formula templates in WPF client
- implement `FormulaTemplatesProfileViewModel`
- implement management view and profile view controls
- register views and services for Prism navigation
- extend admin UI with a tab for formula templates

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6871ff75f0b88333a075c24d0d71fc75