### PR TITLE
Add record management view

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -96,6 +96,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<DoctorManagementView>("DoctorManagementView");
             containerRegistry.RegisterForNavigation<HerbManagementView>("HerbManagementView");
             containerRegistry.RegisterForNavigation<PrescriptionManagementView>("PrescriptionManagementView");
+            containerRegistry.RegisterForNavigation<RecordManagementView>("RecordManagementView");
             containerRegistry.RegisterForNavigation<FormulaTemplatesManagementView>("FormulaTemplatesManagementView");
             containerRegistry.RegisterForNavigation<BillingStaffView>("BillingStaffView");
             containerRegistry.RegisterForNavigation<DiagnosingDoctorView>("DiagnosingDoctorView");

--- a/LYBT.UI.WPF/ViewModels/Admin/RecordManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/RecordManagementViewModel.cs
@@ -1,0 +1,191 @@
+using LYBT.Module.Records.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using Prism.Commands;
+using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace LYBT.UI.WPF.ViewModels.Admin {
+    /// <summary>
+    /// 病历管理视图模型
+    /// </summary>
+    public class RecordManagementViewModel : BindableBase {
+        private readonly IRecordService _recordService;
+
+        /// <summary>病历列表</summary>
+        public ObservableCollection<RecordDto> Records { get; } = new();
+
+        private RecordDto? _selectedRecord;
+        /// <summary>列表中选中的病历</summary>
+        public RecordDto? SelectedRecord {
+            get => _selectedRecord;
+            set {
+                if (SetProperty(ref _selectedRecord, value)) {
+                    if (value != null)
+                        _ = LoadDetailAsync(value.Id);
+                }
+            }
+        }
+
+        private RecordDetailDto _editingRecord = new();
+        /// <summary>右侧编辑区绑定的病历详情</summary>
+        public RecordDetailDto EditingRecord {
+            get => _editingRecord;
+            set => SetProperty(ref _editingRecord, value);
+        }
+
+        private bool _isEditable;
+        /// <summary>是否可编辑</summary>
+        public bool IsEditable {
+            get => _isEditable;
+            set => SetProperty(ref _isEditable, value);
+        }
+
+        private string _editModeTitle = "病历详情";
+        /// <summary>右侧编辑区标题</summary>
+        public string EditModeTitle {
+            get => _editModeTitle;
+            set => SetProperty(ref _editModeTitle, value);
+        }
+
+        public DelegateCommand RefreshCommand { get; }
+        public DelegateCommand AddCommand { get; }
+        public DelegateCommand EditCommand { get; }
+        public DelegateCommand SaveCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+        public DelegateCommand DeleteCommand { get; }
+        public DelegateCommand ShareCommand { get; }
+        public DelegateCommand RevokeShareCommand { get; }
+
+        public RecordManagementViewModel(IRecordService recordService) {
+            _recordService = recordService;
+            RefreshCommand = new DelegateCommand(async () => await LoadAsync());
+            AddCommand = new DelegateCommand(Add);
+            EditCommand = new DelegateCommand(Edit, () => SelectedRecord != null).ObservesProperty(() => SelectedRecord);
+            SaveCommand = new DelegateCommand(async () => await SaveAsync(), () => IsEditable).ObservesProperty(() => IsEditable);
+            CancelCommand = new DelegateCommand(CancelEdit);
+            DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), () => SelectedRecord != null).ObservesProperty(() => SelectedRecord);
+            ShareCommand = new DelegateCommand(async () => await ShareAsync(), () => SelectedRecord != null).ObservesProperty(() => SelectedRecord);
+            RevokeShareCommand = new DelegateCommand(async () => await RevokeAsync(), () => SelectedRecord != null).ObservesProperty(() => SelectedRecord);
+            _ = LoadAsync();
+        }
+
+        private async Task LoadAsync() {
+            var list = await _recordService.GetListAsync();
+            Records.Clear();
+            foreach (var r in list)
+                Records.Add(r);
+        }
+
+        private async Task LoadDetailAsync(Guid id) {
+            var detail = await _recordService.GetByIdAsync(id);
+            if (detail != null) {
+                EditingRecord = detail;
+                IsEditable = false;
+                EditModeTitle = "病历详情";
+            }
+        }
+
+        private void Add() {
+            EditingRecord = new RecordDetailDto { RecordTime = DateTime.Now };
+            SelectedRecord = null;
+            IsEditable = true;
+            EditModeTitle = "新增病历";
+        }
+
+        private void Edit() {
+            if (SelectedRecord != null) {
+                IsEditable = true;
+                EditModeTitle = "编辑病历";
+            }
+        }
+
+        private async Task SaveAsync() {
+            bool ok;
+            if (EditingRecord.Id == Guid.Empty) {
+                var dto = new RecordCreateDto {
+                    PatientId = EditingRecord.PatientId,
+                    RegistrationId = EditingRecord.RegistrationId,
+                    Diagnosis = EditingRecord.Diagnosis,
+                    ChiefComplaint = EditingRecord.ChiefComplaint,
+                    PresentIllness = EditingRecord.PresentIllness,
+                    TreatmentAdvice = EditingRecord.TreatmentAdvice,
+                    PrescriptionId = EditingRecord.PrescriptionId,
+                    DiagnosisResults = EditingRecord.DiagnosisResults.ToList(),
+                    HerbalFormula = EditingRecord.HerbalFormula,
+                    TreatmentPlans = EditingRecord.TreatmentPlans,
+                    IsShared = EditingRecord.IsShared,
+                    SharedToDoctorIds = EditingRecord.SharedToDoctorIds,
+                    CreatedBy = EditingRecord.CreatedBy,
+                    CreatedTime = EditingRecord.CreatedTime,
+                    RecordTime = EditingRecord.RecordTime
+                };
+                ok = await _recordService.AddAsync(dto);
+            } else {
+                var dto = new RecordEditDto {
+                    Id = EditingRecord.Id,
+                    Diagnosis = EditingRecord.Diagnosis,
+                    ChiefComplaint = EditingRecord.ChiefComplaint,
+                    PresentIllness = EditingRecord.PresentIllness,
+                    TreatmentAdvice = EditingRecord.TreatmentAdvice,
+                    PrescriptionId = EditingRecord.PrescriptionId,
+                    DiagnosisResults = EditingRecord.DiagnosisResults.ToList(),
+                    HerbalFormula = EditingRecord.HerbalFormula,
+                    TreatmentPlans = EditingRecord.TreatmentPlans,
+                    IsShared = EditingRecord.IsShared,
+                    SharedToDoctorIds = EditingRecord.SharedToDoctorIds,
+                    RecordTime = EditingRecord.RecordTime
+                };
+                ok = await _recordService.UpdateAsync(dto);
+            }
+            if (!ok)
+                MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+            await LoadAsync();
+            IsEditable = false;
+            EditModeTitle = "病历详情";
+        }
+
+        private void CancelEdit() {
+            if (SelectedRecord != null)
+                _ = LoadDetailAsync(SelectedRecord.Id);
+            else {
+                EditingRecord = new RecordDetailDto();
+                IsEditable = false;
+                EditModeTitle = "病历详情";
+            }
+        }
+
+        private async Task DeleteAsync() {
+            if (SelectedRecord == null)
+                return;
+            if (MessageBox.Show("确定删除该病历吗？", "确认", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes) {
+                var ok = await _recordService.DeleteAsync(SelectedRecord.Id);
+                if (!ok)
+                    MessageBox.Show("删除失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                await LoadAsync();
+            }
+        }
+
+        private async Task ShareAsync() {
+            if (SelectedRecord == null)
+                return;
+            var ok = await _recordService.MarkAsSharedAsync(SelectedRecord.Id, new List<string>());
+            if (!ok)
+                MessageBox.Show("共享失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+            await LoadAsync();
+        }
+
+        private async Task RevokeAsync() {
+            if (SelectedRecord == null)
+                return;
+            var ok = await _recordService.RevokeSharingAsync(SelectedRecord.Id);
+            if (!ok)
+                MessageBox.Show("取消共享失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+            await LoadAsync();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml
@@ -1,0 +1,59 @@
+<UserControl x:Class="LYBT.UI.WPF.Views.Admin.RecordManagementView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <!-- 操作区 -->
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+            <Button Content="新增病历" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+            <Button Content="编辑病历" Command="{Binding EditCommand}" Margin="0,0,8,0"
+                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+            <Button Content="删除病历" Command="{Binding DeleteCommand}" Margin="0,0,8,0"
+                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+            <Button Content="共享" Command="{Binding ShareCommand}" Margin="0,0,8,0"
+                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+            <Button Content="取消共享" Command="{Binding RevokeShareCommand}"
+                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+        </StackPanel>
+        <!-- 内容区 -->
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="2*"/>
+                <ColumnDefinition Width="2*"/>
+            </Grid.ColumnDefinitions>
+            <!-- 左侧列表 -->
+            <DataGrid Grid.Column="0" ItemsSource="{Binding Records}" SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                      AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="患者" Binding="{Binding PatientName}" Width="*"/>
+                    <DataGridTextColumn Header="诊断" Binding="{Binding Diagnosis}" Width="*"/>
+                    <DataGridTextColumn Header="时间" Binding="{Binding RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Width="150"/>
+                    <DataGridCheckBoxColumn Header="共享" Binding="{Binding IsShared}" Width="70"/>
+                </DataGrid.Columns>
+            </DataGrid>
+            <!-- 右侧详情区 -->
+            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+                <StackPanel>
+                    <TextBlock Text="{Binding EditModeTitle}" FontWeight="Bold" FontSize="17" Margin="0,0,0,16"/>
+                    <TextBlock Text="患者姓名" />
+                    <TextBox Text="{Binding EditingRecord.PatientName}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                    <TextBlock Text="诊断" />
+                    <TextBox Text="{Binding EditingRecord.Diagnosis}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                    <TextBlock Text="记录时间" />
+                    <TextBox Text="{Binding EditingRecord.RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Margin="0,0,0,8"/>
+                    <CheckBox Content="共享" IsChecked="{Binding EditingRecord.IsShared}" Margin="0,0,0,8"/>
+                    <StackPanel Orientation="Horizontal" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}" Margin="0,10,0,0">
+                        <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,0,8,0"/>
+                        <Button Content="取消" Command="{Binding CancelCommand}"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace LYBT.UI.WPF.Views.Admin {
+    /// <summary>
+    /// RecordManagementView.xaml 的交互逻辑
+    /// </summary>
+    public partial class RecordManagementView : UserControl {
+        public RecordManagementView() {
+            InitializeComponent();
+        }
+    }
+}

--- a/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
@@ -22,6 +22,9 @@
         <TabItem Header="处方管理">
             <admin:PrescriptionManagementView/>
         </TabItem>
+        <TabItem Header="病历管理">
+            <admin:RecordManagementView/>
+        </TabItem>
         <TabItem Header="经验方模板">
             <admin:FormulaTemplatesManagementView/>
         </TabItem>


### PR DESCRIPTION
## Summary
- add `RecordManagementViewModel` for admin record CRUD operations
- create `RecordManagementView` with list and detail panel
- add tab for record management in AdminView
- register `RecordManagementView` in Prism container

## Testing
- `dotnet build LYBT.Tests/LYBT.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6872187a9f3c83339da3be31c1257d05