### PR TITLE
Implement Registration staff view model functionality

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -47,6 +47,7 @@ namespace LYBT.UI.WPF {
             var userApi = RestService.For<IUserApi>(httpClient, refitSettings);
             var doctorApi = RestService.For<IDoctorApi>(httpClient, refitSettings);
             var patientApi = RestService.For<IPatientApi>(httpClient, refitSettings);
+            var registrationApi = RestService.For<IRegistrationApi>(httpClient, refitSettings);
             var herbApi = RestService.For<IHerbApi>(httpClient, refitSettings);
             var billingApi = RestService.For<IBillingApi>(httpClient, refitSettings);
             var prescriptionApi = RestService.For<IPrescriptionApi>(httpClient, refitSettings);
@@ -58,6 +59,7 @@ namespace LYBT.UI.WPF {
             var userService = new UserService(userApi);
             var doctorService = new DoctorService(doctorApi);
             var patientService = new PatientService(patientApi);
+            var registrationService = new RegistrationService(registrationApi);
             var herbService = new HerbService(herbApi);
             var billingService = new BillingService(billingApi);
             var prescriptionService = new PrescriptionService(prescriptionApi);
@@ -70,6 +72,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(userApi);
             containerRegistry.RegisterInstance(doctorApi);
             containerRegistry.RegisterInstance(patientApi);
+            containerRegistry.RegisterInstance(registrationApi);
             containerRegistry.RegisterInstance(herbApi);
             containerRegistry.RegisterInstance(billingService);
             containerRegistry.RegisterInstance(prescriptionApi);
@@ -81,6 +84,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IDoctorService>(doctorService);
             containerRegistry.RegisterInstance<IPatientService>(patientService);
             containerRegistry.RegisterInstance<IHerbService>(herbService);
+            containerRegistry.RegisterInstance<IRegistrationService>(registrationService);
             containerRegistry.RegisterInstance<IBillingService>(billingService);
             containerRegistry.RegisterInstance<IPrescriptionService>(prescriptionService);
             containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);

--- a/LYBT.UI.WPF/ViewModels/Navigation/RegistrationStaffViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Navigation/RegistrationStaffViewModel.cs
@@ -1,8 +1,108 @@
+using LYBT.Module.Patients.Dtos;
+using LYBT.Module.Registration.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using Prism.Commands;
 using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels.Navigation {
     /// <summary>
     /// 类 RegistrationStaffViewModel 的说明
     /// </summary>
-    public class RegistrationStaffViewModel : BindableBase { }
+    public class RegistrationStaffViewModel : BindableBase {
+        private readonly IRegistrationService _registrationService;
+        private readonly IPatientService _patientService;
+
+        public ObservableCollection<PatientDetailDto> PatientSearchResults { get; } = new();
+        public ObservableCollection<PendingPatientItem> PendingPatients { get; } = new();
+
+        private PatientDetailDto? _selectedPatient;
+        public PatientDetailDto? SelectedPatient {
+            get => _selectedPatient;
+            set => SetProperty(ref _selectedPatient, value);
+        }
+
+        private string _searchKeyword = string.Empty;
+        public string SearchKeyword {
+            get => _searchKeyword;
+            set => SetProperty(ref _searchKeyword, value);
+        }
+
+        private string _pendingPatientsInfo = "暂无待看诊患者";
+        public string PendingPatientsInfo {
+            get => _pendingPatientsInfo;
+            set => SetProperty(ref _pendingPatientsInfo, value);
+        }
+
+        public DelegateCommand ReadCardCommand { get; }
+        public DelegateCommand SearchCommand { get; }
+        public DelegateCommand NewPatientCommand { get; }
+        public DelegateCommand RegisterCommand { get; }
+        public DelegateCommand ClearCommand { get; }
+        public DelegateCommand CancelCommand { get; }
+
+        public RegistrationStaffViewModel(IRegistrationService registrationService, IPatientService patientService) {
+            _registrationService = registrationService;
+            _patientService = patientService;
+
+            ReadCardCommand = new DelegateCommand(() => MessageBox.Show("读卡功能待实现", "提示"));
+            NewPatientCommand = new DelegateCommand(() => MessageBox.Show("新建患者功能待实现", "提示"));
+            SearchCommand = new DelegateCommand(async () => await SearchAsync());
+            RegisterCommand = new DelegateCommand(async () => await RegisterAsync(), () => SelectedPatient != null)
+                .ObservesProperty(() => SelectedPatient);
+            ClearCommand = new DelegateCommand(Clear);
+            CancelCommand = new DelegateCommand(async () => await CancelAsync(), () => SelectedPatient != null)
+                .ObservesProperty(() => SelectedPatient);
+        }
+
+        private async Task SearchAsync() {
+            var list = string.IsNullOrWhiteSpace(SearchKeyword)
+                ? await _patientService.GetAllAsync()
+                : await _patientService.SearchAsync(SearchKeyword);
+            PatientSearchResults.Clear();
+            foreach (var p in list)
+                PatientSearchResults.Add(p);
+        }
+
+        private async Task RegisterAsync() {
+            if (SelectedPatient == null)
+                return;
+
+            var dto = new RegistrationCreateDto {
+                PatientId = SelectedPatient.Id.ToString(),
+                DoctorId = Guid.Empty.ToString(),
+                RegistrationType = "普通"
+            };
+
+            var ok = await _registrationService.AddAsync(dto);
+            if (ok) {
+                PendingPatients.Add(new PendingPatientItem { QueueNumber = PendingPatients.Count + 1, Name = SelectedPatient.Name });
+                PendingPatientsInfo = string.Empty;
+                SelectedPatient = null;
+            } else {
+                MessageBox.Show("挂号失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void Clear() {
+            SearchKeyword = string.Empty;
+            SelectedPatient = null;
+        }
+
+        private async Task CancelAsync() {
+            if (SelectedPatient == null)
+                return;
+            await _registrationService.DeleteAsync(SelectedPatient.Id);
+            SelectedPatient = null;
+        }
+
+        public class PendingPatientItem {
+            public int QueueNumber { get; set; }
+            public string Name { get; set; } = string.Empty;
+        }
+    }
 }

--- a/LYBT.UI.WPF/Views/Navigation/RegistrationStaffView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/RegistrationStaffView.xaml
@@ -1,6 +1,8 @@
 <UserControl x:Class="LYBT.UI.WPF.Views.Navigation.RegistrationStaffView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid Margin="15">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*" MinWidth="480"/>
@@ -25,11 +27,12 @@
 
                         <Label Grid.Row="0" Grid.Column="0" Content="查询条件：" VerticalAlignment="Center"/>
                         <TextBox x:Name="txtSearch" Grid.Row="0" Grid.Column="1" Height="25" Margin="5,0"
-                                 ToolTip="输入患者姓名或身份证号"/>
+                                 ToolTip="输入患者姓名或身份证号"
+                                 Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
                         <Button x:Name="btnReadCard" Grid.Row="0" Grid.Column="2" Content="读卡" Width="80" Height="25" Margin="5,0"
-                                Click="btnReadCard_Click"/>
+                                  Command="{Binding ReadCardCommand}"/>
                         <Button x:Name="btnSearch" Grid.Row="0" Grid.Column="3" Content="查询" Width="80" Height="25" Margin="5,0"
-                                Click="btnSearch_Click"/>
+                                  Command="{Binding SearchCommand}"/>
 
                         <Label Grid.Row="1" Grid.Column="0" Content="查询结果：" VerticalAlignment="Center"/>
                         <TextBlock x:Name="tblkSearchResultInfo" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3"
@@ -40,14 +43,13 @@
                 <GroupBox Header="历史患者数据" FontWeight="Bold" Margin="0,0,0,15">
                     <DataGrid x:Name="dgPatients" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True"
                               SelectionMode="Single" Height="200"
-                              SelectionChanged="dgPatients_SelectionChanged"
-                              ItemsSource="{Binding DtoList}"
-                              SelectedItem="{Binding DtoDetail, Mode=TwoWay}">
+                              ItemsSource="{Binding PatientSearchResults}"
+                              SelectedItem="{Binding SelectedPatient, Mode=TwoWay}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="姓名" Binding="{Binding Name}" Width="*"/>
                             <DataGridTextColumn Header="性别" Binding="{Binding Gender}" Width="80"/>
                             <DataGridTextColumn Header="年龄" Binding="{Binding Age}" Width="80"/>
-                            <DataGridTextColumn Header="身份证号" Binding="{Binding IdCard}" Width="1.5*"/>
+                            <DataGridTextColumn Header="身份证号" Binding="{Binding IDNumber}" Width="1.5*"/>
                             <DataGridTextColumn Header="联系电话" Binding="{Binding Phone}" Width="1.2*"/>
                         </DataGrid.Columns>
                     </DataGrid>
@@ -71,30 +73,30 @@
 
                         <Label Grid.Row="0" Grid.Column="0" Content="姓名：" VerticalAlignment="Center" Margin="0,5"/>
                         <TextBox x:Name="txtName" Grid.Row="0" Grid.Column="1" Height="25" IsEnabled="False"
-                                 Text="{Binding DtoDetail.Name, Mode=TwoWay}"/>
+                                   Text="{Binding SelectedPatient.Name, Mode=TwoWay}"/>
 
                         <Label Grid.Row="0" Grid.Column="2" Content="性别：" VerticalAlignment="Center" Margin="15,5,0,5"/>
                         <ComboBox x:Name="cmbGender" Grid.Row="0" Grid.Column="3" Height="25" IsEnabled="False"
-                                  Text="{Binding DtoDetail.Gender, Mode=TwoWay}"/>
+                                    Text="{Binding SelectedPatient.Gender, Mode=TwoWay}"/>
 
                         <Label Grid.Row="1" Grid.Column="0" Content="身份证号：" VerticalAlignment="Center" Margin="0,5"/>
                         <TextBox x:Name="txtIdCard" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" Height="25" IsEnabled="False"
-                                 Text="{Binding DtoDetail.IdCard, Mode=TwoWay}"/>
+                                   Text="{Binding SelectedPatient.IDNumber, Mode=TwoWay}"/>
 
                         <Label Grid.Row="2" Grid.Column="0" Content="联系电话：" VerticalAlignment="Center" Margin="0,5"/>
                         <TextBox x:Name="txtPhone" Grid.Row="2" Grid.Column="1" Height="25" IsEnabled="False"
-                                 Text="{Binding DtoDetail.Phone, Mode=TwoWay}"/>
+                                   Text="{Binding SelectedPatient.PhoneNumber, Mode=TwoWay}"/>
 
                         <Label Grid.Row="2" Grid.Column="2" Content="年龄：" VerticalAlignment="Center" Margin="15,5,0,5"/>
                         <TextBox x:Name="txtAge" Grid.Row="2" Grid.Column="3" Height="25" IsEnabled="False"
-                                 Text="{Binding DtoDetail.Age, Mode=TwoWay}"/>
+                                   Text="{Binding SelectedPatient.Age, Mode=TwoWay}"/>
 
                         <Label Grid.Row="3" Grid.Column="0" Content="地址：" VerticalAlignment="Center" Margin="0,5"/>
                         <TextBox x:Name="txtAddress" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="3" Height="25" IsEnabled="False"
-                                 Text="{Binding DtoDetail.Address, Mode=TwoWay}"/>
+                                   Text="{Binding SelectedPatient.Address, Mode=TwoWay}"/>
 
                         <Button x:Name="btnNewPatient" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="4" Content="新建患者"
-                                Height="30" Margin="0,15,0,0" Click="btnNewPatient_Click"/>
+                                  Height="30" Margin="0,15,0,0" Command="{Binding NewPatientCommand}"/>
                     </Grid>
                 </GroupBox>
             </StackPanel>
@@ -129,7 +131,7 @@
                         <Label Content="挂号患者：" FontWeight="SemiBold"/>
                         <TextBox x:Name="txtRegisteredPatientName" Height="25" Margin="0,0,0,10" IsReadOnly="True"
                                  Background="#F0F0F0" ToolTip="选中的患者姓名将显示在此处"
-                                 Text="{Binding DtoDetail.Name, Mode=TwoWay}"/>
+                                 Text="{Binding SelectedPatient.Name, Mode=TwoWay}"/>
 
                         <Label Content="挂号医生：" FontWeight="SemiBold"/>
                         <ComboBox x:Name="cmbDoctor" Height="25" Margin="0,0,0,10" SelectedIndex="0">
@@ -142,9 +144,9 @@
                         <TextBox x:Name="txtFee" Height="25" Margin="0,0,0,10" IsReadOnly="True" Background="#F0F0F0" Text="10.00"/>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,20,0,0">
-                            <Button x:Name="btnRegister" Content="挂号" Width="100" Height="35" Margin="10,0" Click="btnRegister_Click"/>
-                            <Button x:Name="btnClear" Content="清空" Width="100" Height="35" Margin="10,0" Click="btnClear_Click"/>
-                            <Button x:Name="btnCancel" Content="取消" Width="100" Height="35" Margin="10,0" Click="btnCancel_Click"/>
+                            <Button x:Name="btnRegister" Content="挂号" Width="100" Height="35" Margin="10,0" Command="{Binding RegisterCommand}"/>
+                            <Button x:Name="btnClear" Content="清空" Width="100" Height="35" Margin="10,0" Command="{Binding ClearCommand}"/>
+                            <Button x:Name="btnCancel" Content="取消" Width="100" Height="35" Margin="10,0" Command="{Binding CancelCommand}"/>
                         </StackPanel>
                     </StackPanel>
                 </GroupBox>

--- a/LYBT.UI.WPF/Views/Navigation/RegistrationStaffView.xaml.cs
+++ b/LYBT.UI.WPF/Views/Navigation/RegistrationStaffView.xaml.cs
@@ -13,15 +13,17 @@ namespace LYBT.UI.WPF.Views.Navigation {
         /// <summary>
         /// 方法 btnReadCard_Click 的说明
         /// </summary>
-        private void btnReadCard_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("读卡功能待实现", "提示");
+        private void btnReadCard_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is ViewModels.Navigation.RegistrationStaffViewModel vm)
+                vm.ReadCardCommand.Execute();
         }
 
         /// <summary>
         /// 方法 btnSearch_Click 的说明
         /// </summary>
-        private void btnSearch_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("查询功能待实现", "提示");
+        private void btnSearch_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is ViewModels.Navigation.RegistrationStaffViewModel vm)
+                vm.SearchCommand.Execute();
         }
 
         /// <summary>
@@ -34,29 +36,33 @@ namespace LYBT.UI.WPF.Views.Navigation {
         /// <summary>
         /// 方法 btnNewPatient_Click 的说明
         /// </summary>
-        private void btnNewPatient_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("新建患者功能待实现", "提示");
+        private void btnNewPatient_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is ViewModels.Navigation.RegistrationStaffViewModel vm)
+                vm.NewPatientCommand.Execute();
         }
 
         /// <summary>
         /// 方法 btnRegister_Click 的说明
         /// </summary>
-        private void btnRegister_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("挂号功能待实现", "提示");
+        private void btnRegister_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is ViewModels.Navigation.RegistrationStaffViewModel vm)
+                vm.RegisterCommand.Execute();
         }
 
         /// <summary>
         /// 方法 btnClear_Click 的说明
         /// </summary>
-        private void btnClear_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("清空表单功能待实现", "提示");
+        private void btnClear_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is ViewModels.Navigation.RegistrationStaffViewModel vm)
+                vm.ClearCommand.Execute();
         }
 
         /// <summary>
         /// 方法 btnCancel_Click 的说明
         /// </summary>
-        private void btnCancel_Click(object sender, System.Windows.RoutedEventArgs e) {
-            MessageBox.Show("取消挂号功能待实现", "提示");
+        private void btnCancel_Click(object sender, RoutedEventArgs e) {
+            if (DataContext is ViewModels.Navigation.RegistrationStaffViewModel vm)
+                vm.CancelCommand.Execute();
         }
     }
 }


### PR DESCRIPTION
## Summary
- hook up registration API service
- implement `RegistrationStaffViewModel` with patient search and registration commands
- bind `RegistrationStaffView` to new commands and collections
- forward UI button events to view model commands

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: requires .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68721bd5498083339f746140e8aadc17