### PR TITLE
Implement treatment doctor task queue

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -52,6 +52,7 @@ namespace LYBT.UI.WPF {
             var prescriptionApi = RestService.For<IPrescriptionApi>(httpClient, refitSettings);
             var formulaTemplateApi = RestService.For<IFormulaTemplateApi>(httpClient, refitSettings);
             var logApi = RestService.For<ILogApi>(httpClient, refitSettings);
+            var treatmentRoomApi = RestService.For<ITreatmentRoomApi>(httpClient, refitSettings);
 
             // 3. 手动new AuthService（注入authApi实例），不让Unity自动构造！
             var authService = new AuthService(authApi);
@@ -63,6 +64,7 @@ namespace LYBT.UI.WPF {
             var prescriptionService = new PrescriptionService(prescriptionApi);
             var formulaTemplateService = new FormulaTemplateService(formulaTemplateApi);
             var logService = new LogService(logApi);
+            var treatmentRoomService = new TreatmentRoomService(treatmentRoomApi);
 
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
@@ -75,6 +77,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance(prescriptionApi);
             containerRegistry.RegisterInstance(formulaTemplateApi);
             containerRegistry.RegisterInstance(logApi);
+            containerRegistry.RegisterInstance(treatmentRoomApi);
 
             containerRegistry.RegisterInstance<IAuthService>(authService);
             containerRegistry.RegisterInstance<IUserService>(userService);
@@ -85,6 +88,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IPrescriptionService>(prescriptionService);
             containerRegistry.RegisterInstance<IFormulaTemplateService>(formulaTemplateService);
             containerRegistry.RegisterInstance<ILogService>(logService);
+            containerRegistry.RegisterInstance<ITreatmentRoomService>(treatmentRoomService);
 
 
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  

--- a/LYBT.UI.WPF/ViewModels/Navigation/TreatmentDoctorViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Navigation/TreatmentDoctorViewModel.cs
@@ -1,9 +1,91 @@
+using LYBT.Module.TreatmentRoom.Dtos;
+using LYBT.UI.WPF.Interfaces;
+using Prism.Commands;
 using Prism.Mvvm;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows;
+using LYBT.Common.Enums;
 
 namespace LYBT.UI.WPF.ViewModels.Navigation {
     /// <summary>
-    /// 类 TreatmentDoctorViewModel 的说明
+    /// 理疗医生页面 ViewModel
     /// </summary>
     public class TreatmentDoctorViewModel : BindableBase {
+        public ObservableCollection<TreatmentRoomDto> Tasks { get; } = new();
+
+        private TreatmentRoomDto? _selectedTask;
+        public TreatmentRoomDto? SelectedTask {
+            get => _selectedTask;
+            set => SetProperty(ref _selectedTask, value);
+        }
+
+        public DelegateCommand RefreshCommand { get; }
+        public DelegateCommand StartCommand { get; }
+        public DelegateCommand FinishCommand { get; }
+
+        private readonly ITreatmentRoomService _treatmentRoomService;
+
+        public TreatmentDoctorViewModel(ITreatmentRoomService treatmentRoomService) {
+            _treatmentRoomService = treatmentRoomService;
+            RefreshCommand = new DelegateCommand(async () => await LoadTasks());
+            StartCommand = new DelegateCommand(async () => await StartTask(), () => SelectedTask != null)
+                .ObservesProperty(() => SelectedTask);
+            FinishCommand = new DelegateCommand(async () => await FinishTask(), () => SelectedTask != null)
+                .ObservesProperty(() => SelectedTask);
+            _ = LoadTasks();
+        }
+
+        private async Task LoadTasks() {
+            var list = await _treatmentRoomService.GetListAsync();
+            Tasks.Clear();
+            foreach (var t in list)
+                Tasks.Add(t);
+        }
+
+        private async Task StartTask() {
+            if (SelectedTask == null)
+                return;
+            var detail = await _treatmentRoomService.GetByIdAsync(SelectedTask.Id);
+            if (detail == null) {
+                MessageBox.Show("无法获取任务详情", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            var dto = new TreatmentRoomEditDto {
+                Id = detail.Id,
+                TreatmentItem = detail.TreatmentItem,
+                Count = detail.Count,
+                Status = TreatmentTaskStatus.InProgress.ToString(),
+                EndTime = detail.EndTime ?? DateTime.Now,
+                Remark = detail.Remark
+            };
+            bool ok = await _treatmentRoomService.UpdateAsync(dto);
+            if (!ok)
+                MessageBox.Show("开始治疗失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            await LoadTasks();
+        }
+
+        private async Task FinishTask() {
+            if (SelectedTask == null)
+                return;
+            var detail = await _treatmentRoomService.GetByIdAsync(SelectedTask.Id);
+            if (detail == null) {
+                MessageBox.Show("无法获取任务详情", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                return;
+            }
+            var dto = new TreatmentRoomEditDto {
+                Id = detail.Id,
+                TreatmentItem = detail.TreatmentItem,
+                Count = detail.Count,
+                Status = TreatmentTaskStatus.Completed.ToString(),
+                EndTime = DateTime.Now,
+                Remark = detail.Remark
+            };
+            bool ok = await _treatmentRoomService.UpdateAsync(dto);
+            if (!ok)
+                MessageBox.Show("完成治疗失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            await LoadTasks();
+        }
     }
 }

--- a/LYBT.UI.WPF/Views/Navigation/TreatmentDoctorView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/TreatmentDoctorView.xaml
@@ -1,7 +1,29 @@
 <UserControl x:Class="LYBT.UI.WPF.Views.Navigation.TreatmentDoctorView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <TextBlock Text="TreatmentDoctor 页面" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+            <Button Content="开始治疗" Command="{Binding StartCommand}" Margin="0,0,8,0"
+                    IsEnabled="{Binding SelectedTask, Converter={StaticResource NullToBoolConverter}}"/>
+            <Button Content="完成治疗" Command="{Binding FinishCommand}"
+                    IsEnabled="{Binding SelectedTask, Converter={StaticResource NullToBoolConverter}}"/>
+        </StackPanel>
+        <DataGrid Grid.Row="1" ItemsSource="{Binding Tasks}" SelectedItem="{Binding SelectedTask, Mode=TwoWay}"
+                  AutoGenerateColumns="False" IsReadOnly="True">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="病人" Binding="{Binding PatientName}" Width="*"/>
+                <DataGridTextColumn Header="项目" Binding="{Binding TreatmentItem}" Width="*"/>
+                <DataGridTextColumn Header="状态" Binding="{Binding Status}" Width="80"/>
+                <DataGridTextColumn Header="开始时间" Binding="{Binding StartTime, StringFormat=yyyy-MM-dd HH:mm}" Width="150"/>
+            </DataGrid.Columns>
+        </DataGrid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- add treatment room API/service registration
- implement TreatmentDoctorViewModel with queue logic
- design TreatmentDoctorView for task controls

## Testing
- `dotnet build -v q`
- `dotnet test --no-build -v q` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68721bd6fff083338adafd3a099a9017