### PR TITLE
Fix converter namespaces

### DIFF
--- a/LYBT.UI.WPF/App.xaml
+++ b/LYBT.UI.WPF/App.xaml
@@ -3,7 +3,7 @@
                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:prism="http://prismlibrary.com/"
-                xmlns:local="clr-namespace:LYBT.UI.WPF.Converters">
+                xmlns:local="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF">
     <!-- 注意：移除了 StartupUri，以避免启动两个窗口 -->
     <Application.Resources>
         <!-- 添加 BoolToVisibilityConverter 资源 -->

--- a/LYBT.UI.WPF/Views/Admin/DoctorManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/DoctorManagementView.xaml
@@ -5,7 +5,7 @@
              xmlns:sys="clr-namespace:System;assembly=mscorlib"
              xmlns:enums="clr-namespace:LYBT.Common.Enums;assembly=LYBT.Common"
              xmlns:helpers="clr-namespace:LYBT.UI.WPF.Helpers"
-             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
              xmlns:main="clr-namespace:LYBT.UI.WPF.Views.Main"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <UserControl.Resources>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -2,7 +2,7 @@
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
               xmlns:prism="http://prismlibrary.com/"
-              xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+              xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
               xmlns:helpers="clr-namespace:LYBT.UI.WPF.Helpers"
               prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>

--- a/LYBT.UI.WPF/Views/Navigation/BillingStaffView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/BillingStaffView.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Grid.RowDefinitions>

--- a/LYBT.UI.WPF/Views/Navigation/PharmacyStaffView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/PharmacyStaffView.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <UserControl.Resources>
         <converters:NullToBoolConverter x:Key="NullToBoolConverter" />

--- a/LYBT.UI.WPF/Views/Navigation/TreatmentDoctorView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/TreatmentDoctorView.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Grid.RowDefinitions>

--- a/LYBT.UI.WPF/Views/Profile/DoctorProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/DoctorProfileView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
             xmlns:common="clr-namespace:LYBT.Common.Models;assembly=LYBT.Common"
-            xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+            xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
             prism:ViewModelLocator.AutoWireViewModel="True">
     <UserControl.Resources>
     </UserControl.Resources>

--- a/LYBT.UI.WPF/Views/Profile/PatientProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/PatientProfileView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
             xmlns:common="clr-namespace:LYBT.Common.Models;assembly=LYBT.Common"
-            xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+            xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
             prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>

--- a/LYBT.UI.WPF/Views/UserEditWindow.xaml
+++ b/LYBT.UI.WPF/Views/UserEditWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="LYBT.UI.WPF.Views.UserEditWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters"
+        xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
         Title="用户" Height="300" Width="300">
     <Window.Resources>
         <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />


### PR DESCRIPTION
## Summary
- point converter references to LYBT.UI.WPF assembly

## Testing
- `dotnet build LYBT.UI.WPF -c Release` *(fails: BoolToVisibilityConverter not found)*
- `dotnet test` *(fails: missing framework Microsoft.NETCore.App 8.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68730aad68808333bd648d7d4cca811d