### PR TITLE
Fix binding errors in prescription profile

### DIFF
--- a/LYBT.UI.WPF/Views/Profile/PrescriptionProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/PrescriptionProfileView.xaml
@@ -23,7 +23,7 @@
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                     <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
                 </StackPanel>
-                <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedItem}" Height="200" Margin="0,0,0,10">
+                <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" Height="200" Margin="0,0,0,10">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
                         <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>


### PR DESCRIPTION
## Summary
- remove unused SelectedItem binding from the prescription profile view

## Testing
- `dotnet restore`
- `dotnet build -c Release` *(fails: missing namespace `Auth`)*

------
https://chatgpt.com/codex/tasks/task_e_687323288bec83338207ce340eb21346