### PR TITLE
Add SelectedItem binding to prescription profile view

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Profile/PrescriptionProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PrescriptionProfileViewModel.cs
@@ -23,6 +23,12 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
         public ObservableCollection<PrescriptionItemDto> Items { get; } = new();
 
+        private PrescriptionItemDto? _selectedItem;
+        public PrescriptionItemDto? SelectedItem {
+            get => _selectedItem;
+            set => SetProperty(ref _selectedItem, value);
+        }
+
         private string _editModeTitle = "新增处方";
         public string EditModeTitle {
             get => _editModeTitle;

--- a/LYBT.UI.WPF/Views/Profile/PrescriptionProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/PrescriptionProfileView.xaml
@@ -23,7 +23,7 @@
                 <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                     <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
                 </StackPanel>
-                <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" Height="200" Margin="0,0,0,10">
+                <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}" AutoGenerateColumns="False" Height="200" Margin="0,0,0,10">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
                         <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>


### PR DESCRIPTION
## Summary
- bind the selected item in `PrescriptionProfileView.xaml`
- expose a `SelectedItem` property in `PrescriptionProfileViewModel`

## Testing
- `dotnet restore LYBTZYZS.sln`
- `dotnet build LYBTZYZS.sln --no-restore -c Release` *(fails: missing `LYBT.Module.Auth` types)*

------
https://chatgpt.com/codex/tasks/task_e_687325cb1e208333881580d4fb4140e9