### PR TITLE
Add missing profile VM registrations

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -105,6 +105,9 @@ namespace LYBT.UI.WPF {
             containerRegistry.Register<HerbProfileViewModel>();
             containerRegistry.Register<PrescriptionProfileViewModel>();
             containerRegistry.Register<FormulaTemplatesProfileViewModel>();
+            containerRegistry.Register<DoctorProfileViewModel>();
+            containerRegistry.Register<PatientProfileViewModel>();
+            containerRegistry.Register<UserProfileViewModel>();
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");
             containerRegistry.RegisterForNavigation<MainWindow>("MainWindow");


### PR DESCRIPTION
## Summary
- register DoctorProfileViewModel, PatientProfileViewModel and UserProfileViewModel in the DI container

## Testing
- `dotnet build LYBTZYZS.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet test LYBTZYZS.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6873271155d883339524f3b046d635d6