### PR TITLE
Implement registration cancel workflow

### DIFF
--- a/LYBT.Tests/Services/RegistrationServiceTests.cs
+++ b/LYBT.Tests/Services/RegistrationServiceTests.cs
@@ -35,4 +35,22 @@ public class RegistrationServiceTests
         regRepo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Registration.RegistrationModel>()), Times.Once);
         queueRepo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Queueing.QueueingModel>()), Times.Once);
     }
+
+    [Fact]
+    public async Task CancelAsync_UpdatesRepositories()
+    {
+        var regRepo = new Mock<IRegistrationRepository>();
+        regRepo.Setup(r => r.CancelAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+        var queueRepo = new Mock<IQueueingRepository>();
+        queueRepo.Setup(q => q.CancelAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new RegistrationService(regRepo.Object, queueRepo.Object, mapper);
+
+        var id = Guid.NewGuid();
+        var result = await service.CancelAsync(id);
+
+        Assert.True(result);
+        regRepo.Verify(r => r.CancelAsync(id), Times.Once);
+        queueRepo.Verify(q => q.CancelAsync(id), Times.Once);
+    }
 }

--- a/LYBT.UI.WPF/Apis/IRegistrationApi.cs
+++ b/LYBT.UI.WPF/Apis/IRegistrationApi.cs
@@ -14,12 +14,15 @@ namespace LYBT.UI.WPF.Apis {
         Task<RegistrationDetailDto> GetByIdAsync(Guid id);
 
         [Post("/api/Registration")]
-        Task<ApiSuccessResponse> AddAsync([Body] RegistrationCreateDto dto);
+        Task<AddRegistrationResponse> AddAsync([Body] RegistrationCreateDto dto);
 
         [Put("/api/Registration")]
         Task<ApiSuccessResponse> UpdateAsync([Body] RegistrationEditDto dto);
 
         [Delete("/api/Registration/{id}")]
         Task<ApiSuccessResponse> DeleteAsync(Guid id);
+
+        [Post("/api/Registration/cancel/{id}")]
+        Task<ApiSuccessResponse> CancelAsync(Guid id);
     }
 }

--- a/LYBT.UI.WPF/Apis/RegistrationApiModels.cs
+++ b/LYBT.UI.WPF/Apis/RegistrationApiModels.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace LYBT.UI.WPF.Apis {
+    public class AddRegistrationResponse {
+        public bool Success { get; set; }
+        public Guid Id { get; set; }
+    }
+}

--- a/LYBT.UI.WPF/Interfaces/IRegistrationService.cs
+++ b/LYBT.UI.WPF/Interfaces/IRegistrationService.cs
@@ -7,8 +7,9 @@ namespace LYBT.UI.WPF.Interfaces {
     public interface IRegistrationService {
         Task<IList<RegistrationDto>> GetListAsync();
         Task<RegistrationDetailDto?> GetByIdAsync(Guid id);
-        Task<bool> AddAsync(RegistrationCreateDto dto);
+        Task<Guid?> AddAsync(RegistrationCreateDto dto);
         Task<bool> UpdateAsync(RegistrationEditDto dto);
         Task<bool> DeleteAsync(Guid id);
+        Task<bool> CancelAsync(Guid id);
     }
 }

--- a/LYBT.UI.WPF/Services/RegistrationService.cs
+++ b/LYBT.UI.WPF/Services/RegistrationService.cs
@@ -33,9 +33,9 @@ namespace LYBT.UI.WPF.Services {
         /// <summary>
         /// 方法 AddAsync 的说明
         /// </summary>
-        public async Task<bool> AddAsync(RegistrationCreateDto dto) {
+        public async Task<Guid?> AddAsync(RegistrationCreateDto dto) {
             var resp = await _api.AddAsync(dto);
-            return resp.Success;
+            return resp.Success ? resp.Id : null;
         }
 
         /// <summary>
@@ -51,6 +51,14 @@ namespace LYBT.UI.WPF.Services {
         /// </summary>
         public async Task<bool> DeleteAsync(Guid id) {
             var resp = await _api.DeleteAsync(id);
+            return resp.Success;
+        }
+
+        /// <summary>
+        /// 方法 CancelAsync 的说明
+        /// </summary>
+        public async Task<bool> CancelAsync(Guid id) {
+            var resp = await _api.CancelAsync(id);
             return resp.Success;
         }
     }

--- a/LYBT.UI.WPF/ViewModels/Navigation/RegistrationStaffViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Navigation/RegistrationStaffViewModel.cs
@@ -20,6 +20,12 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
         public ObservableCollection<PatientDetailDto> PatientSearchResults { get; } = new();
         public ObservableCollection<PendingPatientItem> PendingPatients { get; } = new();
 
+        private PendingPatientItem? _selectedPendingPatient;
+        public PendingPatientItem? SelectedPendingPatient {
+            get => _selectedPendingPatient;
+            set => SetProperty(ref _selectedPendingPatient, value);
+        }
+
         private PatientDetailDto? _selectedPatient;
         public PatientDetailDto? SelectedPatient {
             get => _selectedPatient;
@@ -55,8 +61,8 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
             RegisterCommand = new DelegateCommand(async () => await RegisterAsync(), () => SelectedPatient != null)
                 .ObservesProperty(() => SelectedPatient);
             ClearCommand = new DelegateCommand(Clear);
-            CancelCommand = new DelegateCommand(async () => await CancelAsync(), () => SelectedPatient != null)
-                .ObservesProperty(() => SelectedPatient);
+            CancelCommand = new DelegateCommand(async () => await CancelAsync(), () => SelectedPendingPatient != null)
+                .ObservesProperty(() => SelectedPendingPatient);
         }
 
         private async Task SearchAsync() {
@@ -78,9 +84,9 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
                 RegistrationType = "普通"
             };
 
-            var ok = await _registrationService.AddAsync(dto);
-            if (ok) {
-                PendingPatients.Add(new PendingPatientItem { QueueNumber = PendingPatients.Count + 1, Name = SelectedPatient.Name });
+            var regId = await _registrationService.AddAsync(dto);
+            if (regId != null) {
+                PendingPatients.Add(new PendingPatientItem { QueueNumber = PendingPatients.Count + 1, Name = SelectedPatient.Name, RegistrationId = regId.Value });
                 PendingPatientsInfo = string.Empty;
                 SelectedPatient = null;
             } else {
@@ -94,15 +100,23 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
         }
 
         private async Task CancelAsync() {
-            if (SelectedPatient == null)
+            if (SelectedPendingPatient == null)
                 return;
-            await _registrationService.DeleteAsync(SelectedPatient.Id);
-            SelectedPatient = null;
+            bool ok = await _registrationService.CancelAsync(SelectedPendingPatient.RegistrationId);
+            if (ok) {
+                PendingPatients.Remove(SelectedPendingPatient);
+                SelectedPendingPatient = null;
+                if (PendingPatients.Count == 0)
+                    PendingPatientsInfo = "暂无待看诊患者";
+            } else {
+                MessageBox.Show("取消挂号失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         public class PendingPatientItem {
             public int QueueNumber { get; set; }
             public string Name { get; set; } = string.Empty;
+            public Guid RegistrationId { get; set; }
         }
     }
 }

--- a/LYBT.UI.WPF/Views/Navigation/RegistrationStaffView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/RegistrationStaffView.xaml
@@ -114,7 +114,7 @@
 
                 <GroupBox Grid.Row="0" Header="待看诊患者" FontWeight="Bold" Margin="0,0,0,15">
                     <DataGrid x:Name="dgPendingPatients" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True"
-                              ItemsSource="{Binding PendingPatients}">
+                              ItemsSource="{Binding PendingPatients}" SelectedItem="{Binding SelectedPendingPatient, Mode=TwoWay}">
                         <DataGrid.Columns>
                             <DataGridTextColumn Header="看诊号" Binding="{Binding QueueNumber}" Width="50"/>
                             <DataGridTextColumn Header="姓名" Binding="{Binding Name}" Width="*"/>


### PR DESCRIPTION
## Summary
- add CancelAsync to registration API and service interfaces
- update registration service implementation
- track registration IDs in pending list
- support cancellation of pending registrations in the WPF viewmodel and XAML
- test cancellation logic in backend service

## Testing
- `dotnet test LYBT.Tests/LYBT.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6873bb2e07908333b5a3857a38d0fd16