### PR TITLE
Add patient profile command and navigation

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -139,6 +139,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterForNavigation<ChangePasswordView>("ChangePasswordView");
             containerRegistry.RegisterForNavigation<ChangeProfileView>("ChangeProfileView");
             containerRegistry.RegisterForNavigation<DoctorProfileView>("DoctorProfileView");
+            containerRegistry.RegisterForNavigation<PatientProfileView>("PatientProfileView");
             containerRegistry.RegisterForNavigation<HerbProfileView>("HerbProfileView");
             containerRegistry.RegisterForNavigation<FormulaTemplatesProfileView>("FormulaTemplatesProfileView");
             containerRegistry.RegisterForNavigation<UserProfileView>("UserProfileView");

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ using System.Windows;
 using System.Threading.Tasks;
 using System;
 using LYBT.UI.WPF.Interfaces;
+using LYBT.UI.WPF.ViewModels.Profile;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
     /// <summary>
@@ -66,6 +67,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         /// </summary>
         public DelegateCommand ShowChangeProfileCommand { get; }
         public DelegateCommand ShowDoctorProfileCommand { get; }
+        public DelegateCommand ShowPatientProfileCommand { get; }
 
 
         private readonly IEventAggregator _eventAggregator;
@@ -88,6 +90,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             ShowChangePasswordCommand = new DelegateCommand(ShowChangePassword);
             ShowChangeProfileCommand = new DelegateCommand(ShowChangeProfile);
             ShowDoctorProfileCommand = new DelegateCommand(ShowDoctorProfile);
+            ShowPatientProfileCommand = new DelegateCommand(ShowPatientProfile);
             
             System.Diagnostics.Debug.WriteLine("MainWindowViewModel constructed");
         }
@@ -130,6 +133,20 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             IsMainVisible = false;
             IsFunctionVisible = true;
             _regionManager.RequestNavigate("FunctionRegion", "DoctorProfileView");
+        }
+
+        private void ShowPatientProfile() {
+            IsMainVisible = false;
+            IsFunctionVisible = true;
+            _regionManager.RequestNavigate("FunctionRegion", "PatientProfileView", result => {
+                var view = _regionManager.Regions["FunctionRegion"].ActiveViews.FirstOrDefault();
+                if (view is FrameworkElement element && element.DataContext is PatientProfileViewModel vm) {
+                    vm.CancelAction = () => {
+                        IsMainVisible = true;
+                        IsFunctionVisible = false;
+                    };
+                }
+            });
         }
 
 

--- a/LYBT.UI.WPF/ViewModels/Navigation/RegistrationStaffViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Navigation/RegistrationStaffViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using LYBT.UI.WPF.ViewModels.Main;
 
 namespace LYBT.UI.WPF.ViewModels.Navigation {
     /// <summary>
@@ -50,7 +51,7 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
             _patientService = patientService;
 
             ReadCardCommand = new DelegateCommand(() => MessageBox.Show("读卡功能待实现", "提示"));
-            NewPatientCommand = new DelegateCommand(() => MessageBox.Show("新建患者功能待实现", "提示"));
+            NewPatientCommand = new DelegateCommand(NewPatient);
             SearchCommand = new DelegateCommand(async () => await SearchAsync());
             RegisterCommand = new DelegateCommand(async () => await RegisterAsync(), () => SelectedPatient != null)
                 .ObservesProperty(() => SelectedPatient);
@@ -85,6 +86,12 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
                 SelectedPatient = null;
             } else {
                 MessageBox.Show("挂号失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
+        private void NewPatient() {
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                main.ShowPatientProfileCommand.Execute();
             }
         }
 


### PR DESCRIPTION
## Summary
- add `ShowPatientProfileCommand` with `ShowPatientProfile` method
- enable navigation to `PatientProfileView`
- allow registration staff to open patient profile

## Testing
- `dotnet build LYBTZYZS.sln -v:q`
- `dotnet test LYBTZYZS.sln --no-build` *(fails: Test Run Aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6873bb2a4da48333b923e2005fe6ca6b