### PR TITLE
Fix patient profile cancel navigation

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
@@ -9,6 +9,7 @@ using Prism.Mvvm;
 using System;
 using System.Threading.Tasks;
 using System.Windows;
+using LYBT.UI.WPF.ViewModels.Main;
 
 namespace LYBT.UI.WPF.ViewModels.Profile {
     public class PatientProfileViewModel : BindableBase {
@@ -78,7 +79,14 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         }
 
         private void Cancel() {
-            CancelAction?.Invoke();
+            if (CancelAction != null) {
+                CancelAction.Invoke();
+                return;
+            }
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                main.IsMainVisible = true;
+                main.IsFunctionVisible = false;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- restore the main screen when patient profile is cancelled
- keep patient profile navigation registered and accessible from registration view

## Testing
- `dotnet test LYBT.Tests/LYBT.Tests.csproj -v normal` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6873c448609483339d013834d48d9007