### PR TITLE
Add hold and complete queue update methods

### DIFF
--- a/LYBT.Common/Enums/QueueStatus.cs
+++ b/LYBT.Common/Enums/QueueStatus.cs
@@ -17,6 +17,9 @@ namespace LYBT.Common.Enums {
         Finished = 2,
 
         [Description("已取消")]
-        Cancelled = 3
+        Cancelled = 3,
+
+        [Description("已挂起")]
+        OnHold = 4
     }
 }

--- a/LYBT.Module.Queueing/Interfaces/IQueueRepository.cs
+++ b/LYBT.Module.Queueing/Interfaces/IQueueRepository.cs
@@ -36,5 +36,15 @@ namespace LYBT.Module.Queueing.Interfaces {
         /// 将排队信息标记为已取消
         /// </summary>
         Task<bool> CancelAsync(Guid id);
+
+        /// <summary>
+        /// 将排队信息标记为已完成
+        /// </summary>
+        Task<bool> CompleteAsync(Guid id);
+
+        /// <summary>
+        /// 将排队信息标记为挂起
+        /// </summary>
+        Task<bool> HoldAsync(Guid id);
     }
 }

--- a/LYBT.Module.Queueing/Interfaces/IQueueService.cs
+++ b/LYBT.Module.Queueing/Interfaces/IQueueService.cs
@@ -36,5 +36,15 @@ namespace LYBT.Module.Queueing.Interfaces {
         /// 取消排队
         /// </summary>
         Task<bool> CancelAsync(Guid id);
+
+        /// <summary>
+        /// 完成排队
+        /// </summary>
+        Task<bool> CompleteAsync(Guid id);
+
+        /// <summary>
+        /// 挂起排队
+        /// </summary>
+        Task<bool> HoldAsync(Guid id);
     }
 }

--- a/LYBT.Module.Queueing/Repositories/QueueRepository.cs
+++ b/LYBT.Module.Queueing/Repositories/QueueRepository.cs
@@ -69,5 +69,23 @@ namespace LYBT.Module.Queueing.Repositories {
             _appDbContext.Queueings.Update(model);
             return await _appDbContext.SaveChangesAsync() > 0;
         }
+
+        public async Task<bool> CompleteAsync(Guid id) {
+            var model = await _appDbContext.Queueings.FindAsync(id);
+            if (model == null)
+                return false;
+            model.Status = LYBT.Common.Enums.QueueStatus.Finished;
+            _appDbContext.Queueings.Update(model);
+            return await _appDbContext.SaveChangesAsync() > 0;
+        }
+
+        public async Task<bool> HoldAsync(Guid id) {
+            var model = await _appDbContext.Queueings.FindAsync(id);
+            if (model == null)
+                return false;
+            model.Status = LYBT.Common.Enums.QueueStatus.OnHold;
+            _appDbContext.Queueings.Update(model);
+            return await _appDbContext.SaveChangesAsync() > 0;
+        }
     }
 }

--- a/LYBT.Module.Queueing/Services/QueueService.cs
+++ b/LYBT.Module.Queueing/Services/QueueService.cs
@@ -73,5 +73,13 @@ namespace LYBT.Module.Queueing.Services {
         public async Task<bool> CancelAsync(Guid id) {
             return await _repository.CancelAsync(id);
         }
+
+        public async Task<bool> CompleteAsync(Guid id) {
+            return await _repository.CompleteAsync(id);
+        }
+
+        public async Task<bool> HoldAsync(Guid id) {
+            return await _repository.HoldAsync(id);
+        }
     }
 }

--- a/LYBT.Tests/Services/QueueingServiceTests.cs
+++ b/LYBT.Tests/Services/QueueingServiceTests.cs
@@ -32,4 +32,34 @@ public class QueueingServiceTests
         Assert.True(result);
         repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.Queueing.QueueingModel>()), Times.Once);
     }
+
+    [Fact]
+    public async Task CompleteAsync_CallsRepository()
+    {
+        var repo = new Mock<IQueueingRepository>();
+        repo.Setup(r => r.CompleteAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new QueueingService(repo.Object, mapper);
+
+        var id = Guid.NewGuid();
+        var result = await service.CompleteAsync(id);
+
+        Assert.True(result);
+        repo.Verify(r => r.CompleteAsync(id), Times.Once);
+    }
+
+    [Fact]
+    public async Task HoldAsync_CallsRepository()
+    {
+        var repo = new Mock<IQueueingRepository>();
+        repo.Setup(r => r.HoldAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new QueueingService(repo.Object, mapper);
+
+        var id = Guid.NewGuid();
+        var result = await service.HoldAsync(id);
+
+        Assert.True(result);
+        repo.Verify(r => r.HoldAsync(id), Times.Once);
+    }
 }

--- a/LYBT.UI.WPF/Apis/IQueueingApi.cs
+++ b/LYBT.UI.WPF/Apis/IQueueingApi.cs
@@ -21,5 +21,11 @@ namespace LYBT.UI.WPF.Apis {
 
         [Delete("/api/Queueing/{id}")]
         Task<ApiSuccessResponse> DeleteAsync(Guid id);
+
+        [Post("/api/Queueing/complete/{id}")]
+        Task<ApiSuccessResponse> CompleteAsync(Guid id);
+
+        [Post("/api/Queueing/hold/{id}")]
+        Task<ApiSuccessResponse> HoldAsync(Guid id);
     }
 }

--- a/LYBT.UI.WPF/Interfaces/IQueueingService.cs
+++ b/LYBT.UI.WPF/Interfaces/IQueueingService.cs
@@ -10,5 +10,7 @@ namespace LYBT.UI.WPF.Interfaces {
         Task<bool> AddAsync(QueueingCreateDto dto);
         Task<bool> UpdateAsync(QueueingEditDto dto);
         Task<bool> DeleteAsync(Guid id);
+        Task<bool> CompleteAsync(Guid id);
+        Task<bool> HoldAsync(Guid id);
     }
 }

--- a/LYBT.UI.WPF/Services/QueueingService.cs
+++ b/LYBT.UI.WPF/Services/QueueingService.cs
@@ -53,5 +53,15 @@ namespace LYBT.UI.WPF.Services {
             var resp = await _api.DeleteAsync(id);
             return resp.Success;
         }
+
+        public async Task<bool> CompleteAsync(Guid id) {
+            var resp = await _api.CompleteAsync(id);
+            return resp.Success;
+        }
+
+        public async Task<bool> HoldAsync(Guid id) {
+            var resp = await _api.HoldAsync(id);
+            return resp.Success;
+        }
     }
 }

--- a/LYBT.UI.WPF/ViewModels/Navigation/DiagnosingDoctorViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Navigation/DiagnosingDoctorViewModel.cs
@@ -105,14 +105,14 @@ namespace LYBT.UI.WPF.ViewModels.Navigation {
 
         private async Task HoldAsync() {
             if (SelectedPatient != null) {
-                await _queueingService.DeleteAsync(SelectedPatient.Id);
+                await _queueingService.HoldAsync(SelectedPatient.Id);
                 await LoadQueueAsync();
             }
         }
 
         private async Task CompleteAsync() {
             if (SelectedPatient != null) {
-                await _queueingService.DeleteAsync(SelectedPatient.Id);
+                await _queueingService.CompleteAsync(SelectedPatient.Id);
                 await LoadQueueAsync();
                 SelectedPatient = null;
                 CurrentPatientName = string.Empty;

--- a/LYBT.WebAPI/Controllers/QueueingController.cs
+++ b/LYBT.WebAPI/Controllers/QueueingController.cs
@@ -86,5 +86,21 @@ namespace LYBT.Module.Queueing.Controllers {
                 return NotFound();
             return Ok();
         }
+
+        [HttpPost("complete/{id}")]
+        public async Task<ActionResult> Complete(Guid id) {
+            var result = await _queueingService.CompleteAsync(id);
+            if (!result)
+                return NotFound();
+            return Ok();
+        }
+
+        [HttpPost("hold/{id}")]
+        public async Task<ActionResult> Hold(Guid id) {
+            var result = await _queueingService.HoldAsync(id);
+            if (!result)
+                return NotFound();
+            return Ok();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend `QueueStatus` with `OnHold`
- add `CompleteAsync` and `HoldAsync` methods to queue service & repo
- expose new endpoints in API and WPF layer
- update doctor view model to use the new methods
- cover new service methods with unit tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6873c44ac87c8333b7b0833af002953b