### PR TITLE
Add status-based queries

### DIFF
--- a/LYBT.Module.Billing/Interfaces/IBillingRepository.cs
+++ b/LYBT.Module.Billing/Interfaces/IBillingRepository.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Models.Billing;
+using LYBT.Common.Enums;
 
 namespace LYBT.Module.Billing.Interfaces {
 
@@ -41,5 +42,10 @@ namespace LYBT.Module.Billing.Interfaces {
         /// 搜索账单
         /// </summary>
         Task<List<BillingModel>> SearchAsync(string keyword);
+
+        /// <summary>
+        /// 根据状态获取账单列表
+        /// </summary>
+        Task<List<BillingModel>> GetByStatusAsync(BillingStatus status);
     }
 }

--- a/LYBT.Module.Billing/Interfaces/IBillingService.cs
+++ b/LYBT.Module.Billing/Interfaces/IBillingService.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Module.Billing.Dtos;
+using LYBT.Common.Enums;
 
 namespace LYBT.Module.Billing.Interfaces {
 
@@ -76,5 +77,10 @@ namespace LYBT.Module.Billing.Interfaces {
         /// 可退款账单
         /// </summary>
         Task<List<BillingDto>> GetRefundableBillsAsync();
+
+        /// <summary>
+        /// 根据状态获取账单
+        /// </summary>
+        Task<List<BillingDto>> GetByStatusAsync(BillingStatus status);
     }
 }

--- a/LYBT.Module.Billing/Repositories/BillingRepository.cs
+++ b/LYBT.Module.Billing/Repositories/BillingRepository.cs
@@ -1,5 +1,6 @@
 ﻿using LYBT.Infrastructure;
 using LYBT.Models.Billing;
+using LYBT.Common.Enums;
 using LYBT.Module.Billing.Interfaces;
 
 namespace LYBT.Module.Billing.Repositories {
@@ -72,6 +73,13 @@ namespace LYBT.Module.Billing.Repositories {
         public async Task<List<BillingModel>> SearchAsync(string keyword) {
             var list = _appDbContext.Billings
                 .Where(b => (b.BillingId.Contains(keyword) || b.Remark!.Contains(keyword)) && !b.IsDeleted)
+                .ToList();
+            return await Task.FromResult(list);
+        }
+
+        public async Task<List<BillingModel>> GetByStatusAsync(BillingStatus status) {
+            var list = _appDbContext.Billings
+                .Where(b => b.Status == status && !b.IsDeleted)
                 .ToList();
             return await Task.FromResult(list);
         }

--- a/LYBT.Module.Billing/Services/BillingService.cs
+++ b/LYBT.Module.Billing/Services/BillingService.cs
@@ -138,5 +138,10 @@ namespace LYBT.Module.Billing.Services {
             var refundable = list.Where(b => b.Status == BillingStatus.Paid).ToList();
             return _mapper.Map<List<BillingDto>>(refundable);
         }
+
+        public async Task<List<BillingDto>> GetByStatusAsync(BillingStatus status) {
+            var list = await _billingRepository.GetByStatusAsync(status);
+            return _mapper.Map<List<BillingDto>>(list);
+        }
     }
 }

--- a/LYBT.Module.TreatmentRoom/Interfaces/ITreatmentRoomRepository.cs
+++ b/LYBT.Module.TreatmentRoom/Interfaces/ITreatmentRoomRepository.cs
@@ -31,5 +31,10 @@ namespace LYBT.Module.TreatmentRoom.Interfaces {
         /// 删除治疗室记录
         /// </summary>
         Task<bool> DeleteAsync(Guid id);
+
+        /// <summary>
+        /// 根据状态获取治疗室记录
+        /// </summary>
+        Task<List<TreatmentRoomModel>> GetByStatusAsync(string status);
     }
 }

--- a/LYBT.Module.TreatmentRoom/Interfaces/ITreatmentRoomService.cs
+++ b/LYBT.Module.TreatmentRoom/Interfaces/ITreatmentRoomService.cs
@@ -31,5 +31,10 @@ namespace LYBT.Module.TreatmentRoom.Interfaces {
         /// 删除治疗室单
         /// </summary>
         Task<bool> DeleteAsync(Guid id);
+
+        /// <summary>
+        /// 根据状态获取治疗室单
+        /// </summary>
+        Task<List<TreatmentRoomDto>> GetByStatusAsync(string status);
     }
 }

--- a/LYBT.Module.TreatmentRoom/Repositories/TreatmentRoomRepository.cs
+++ b/LYBT.Module.TreatmentRoom/Repositories/TreatmentRoomRepository.cs
@@ -57,5 +57,12 @@ namespace LYBT.Module.TreatmentRoom.Repositories {
             _appDbContext.TreatmentRooms.Remove(model);
             return await _appDbContext.SaveChangesAsync() > 0;
         }
+
+        public async Task<List<TreatmentRoomModel>> GetByStatusAsync(string status) {
+            var list = _appDbContext.TreatmentRooms
+                .Where(t => t.Status == status)
+                .ToList();
+            return await Task.FromResult(list);
+        }
     }
 }

--- a/LYBT.Module.TreatmentRoom/Services/TreatmentService.cs
+++ b/LYBT.Module.TreatmentRoom/Services/TreatmentService.cs
@@ -67,5 +67,10 @@ namespace LYBT.Module.TreatmentRoom.Services {
         public async Task<bool> DeleteAsync(Guid id) {
             return await _treatmentRoomRepository.DeleteAsync(id);
         }
+
+        public async Task<List<TreatmentRoomDto>> GetByStatusAsync(string status) {
+            var list = await _treatmentRoomRepository.GetByStatusAsync(status);
+            return _mapper.Map<List<TreatmentRoomDto>>(list);
+        }
     }
 }

--- a/LYBT.UI.WPF/Apis/IBillingApi.cs
+++ b/LYBT.UI.WPF/Apis/IBillingApi.cs
@@ -48,5 +48,8 @@ namespace LYBT.UI.WPF.Apis {
 
         [Get("/api/Billing/refundable")]
         Task<List<BillingDto>> GetRefundableBillsAsync();
+
+        [Get("/api/Billing/status/{status}")]
+        Task<List<BillingDto>> GetByStatusAsync(int status);
     }
 }

--- a/LYBT.UI.WPF/Apis/ITreatmentRoomApi.cs
+++ b/LYBT.UI.WPF/Apis/ITreatmentRoomApi.cs
@@ -21,5 +21,8 @@ namespace LYBT.UI.WPF.Apis {
 
         [Delete("/api/TreatmentRoom/{id}")]
         Task<ApiSuccessResponse> DeleteAsync(Guid id);
+
+        [Get("/api/TreatmentRoom/status/{status}")]
+        Task<List<TreatmentRoomDto>> GetByStatusAsync(string status);
     }
 }

--- a/LYBT.UI.WPF/Interfaces/IBillingService.cs
+++ b/LYBT.UI.WPF/Interfaces/IBillingService.cs
@@ -19,5 +19,6 @@ namespace LYBT.UI.WPF.Interfaces {
         Task<IList<BillingDto>> GetByPatientIdAsync(Guid patientId);
         Task<IList<BillingDto>> SearchAsync(string keyword);
         Task<IList<BillingDto>> GetRefundableBillsAsync();
+        Task<IList<BillingDto>> GetByStatusAsync(int status);
     }
 }

--- a/LYBT.UI.WPF/Interfaces/ITreatmentRoomService.cs
+++ b/LYBT.UI.WPF/Interfaces/ITreatmentRoomService.cs
@@ -10,5 +10,6 @@ namespace LYBT.UI.WPF.Interfaces {
         Task<bool> AddAsync(TreatmentRoomCreateDto dto);
         Task<bool> UpdateAsync(TreatmentRoomEditDto dto);
         Task<bool> DeleteAsync(Guid id);
+        Task<IList<TreatmentRoomDto>> GetByStatusAsync(string status);
     }
 }

--- a/LYBT.UI.WPF/Services/BillingService.cs
+++ b/LYBT.UI.WPF/Services/BillingService.cs
@@ -107,5 +107,9 @@ namespace LYBT.UI.WPF.Services {
         public async Task<IList<BillingDto>> GetRefundableBillsAsync() {
             return await _billingApi.GetRefundableBillsAsync();
         }
+
+        public async Task<IList<BillingDto>> GetByStatusAsync(int status) {
+            return await _billingApi.GetByStatusAsync(status);
+        }
     }
 }

--- a/LYBT.UI.WPF/Services/TreatmentRoomService.cs
+++ b/LYBT.UI.WPF/Services/TreatmentRoomService.cs
@@ -53,5 +53,9 @@ namespace LYBT.UI.WPF.Services {
             var resp = await _api.DeleteAsync(id);
             return resp.Success;
         }
+
+        public async Task<IList<TreatmentRoomDto>> GetByStatusAsync(string status) {
+            return await _api.GetByStatusAsync(status);
+        }
     }
 }

--- a/LYBT.WebAPI/Controllers/BillingController.cs
+++ b/LYBT.WebAPI/Controllers/BillingController.cs
@@ -1,5 +1,6 @@
 ﻿using LYBT.Module.Billing.Dtos;
 using LYBT.Module.Billing.Interfaces;
+using LYBT.Common.Enums;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LYBT.Module.Billing.Controllers {
@@ -143,6 +144,12 @@ namespace LYBT.Module.Billing.Controllers {
         [HttpGet("refundable")]
         public async Task<ActionResult<List<BillingDto>>> GetRefundableBills() {
             var list = await _billingService.GetRefundableBillsAsync();
+            return Ok(list);
+        }
+
+        [HttpGet("status/{status}")]
+        public async Task<ActionResult<List<BillingDto>>> GetByStatus(BillingStatus status) {
+            var list = await _billingService.GetByStatusAsync(status);
             return Ok(list);
         }
     }

--- a/LYBT.WebAPI/Controllers/TreatmentRoomController.cs
+++ b/LYBT.WebAPI/Controllers/TreatmentRoomController.cs
@@ -79,5 +79,11 @@ namespace LYBT.Module.TreatmentRoom.Controllers {
                 return NotFound();
             return Ok("删除治疗室单成功");
         }
+
+        [HttpGet("status/{status}")]
+        public async Task<ActionResult<List<TreatmentRoomDto>>> GetByStatus(string status) {
+            var list = await _treatmentRoomService.GetByStatusAsync(status);
+            return Ok(list);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support querying billings and treatment rooms by status
- expose new `/api/.../status/{status}` endpoints
- update WPF APIs and service wrappers for status queries

## Testing
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6873c44b164c833384849d5925f20473