### PR TITLE
Add profile mode to profile view models

### DIFF
--- a/LYBT.Common/Enums/ProfileMode.cs
+++ b/LYBT.Common/Enums/ProfileMode.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+
+namespace LYBT.Common.Enums {
+    /// <summary>
+    /// Profile view mode
+    /// </summary>
+    public enum ProfileMode {
+        [Description("查看")]
+        View = 0,
+        [Description("编辑")]
+        Edit = 1,
+        [Description("新增")]
+        Create = 2
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
@@ -3,6 +3,7 @@ using LYBT.Module.Doctors.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.Services;
 using LYBT.UI.WPF.ViewModels.Profile;
+using LYBT.Common.Enums;
 using Prism.Commands;
 using Prism.Mvvm;
 using Refit;
@@ -73,6 +74,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             var detail = await _doctorService.GetByIdAsync(doctorId);
             if (detail != null) {
                 DoctorProfileViewModel.Doctor = detail;
+                DoctorProfileViewModel.Mode = ProfileMode.View;
                 DoctorProfileViewModel.EditModeTitle = "医生详情";
                 DoctorProfileViewModel.IsEditable = false;
             }
@@ -103,6 +105,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 Remark = string.Empty
             };
             DoctorProfileViewModel.Doctor = newDoctor;
+            DoctorProfileViewModel.Mode = ProfileMode.Create;
             DoctorProfileViewModel.EditModeTitle = "新增医生档案";
             DoctorProfileViewModel.IsEditable = true;
             SelectedDoctor = null;
@@ -113,6 +116,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         /// </summary>
         private void EditDoctor() {
             if (SelectedDoctor != null) {
+                DoctorProfileViewModel.Mode = ProfileMode.Edit;
                 DoctorProfileViewModel.IsEditable = true;
                 DoctorProfileViewModel.EditModeTitle = "编辑医生档案";
             }
@@ -154,6 +158,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 return;
             }
             await LoadDoctors();
+            DoctorProfileViewModel.Mode = ProfileMode.View;
             DoctorProfileViewModel.IsEditable = false;
             DoctorProfileViewModel.EditModeTitle = "医生详情";
         }
@@ -166,6 +171,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 _ = UpdateDoctorProfileViewModel(SelectedDoctor.Id);
             else
                 DoctorProfileViewModel.Doctor = new DoctorDetailDto();
+            DoctorProfileViewModel.Mode = ProfileMode.View;
             DoctorProfileViewModel.IsEditable = false;
             DoctorProfileViewModel.EditModeTitle = "医生详情";
         }

--- a/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
@@ -1,6 +1,7 @@
 using LYBT.Module.FormulaTemplates.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.ViewModels.Profile;
+using LYBT.Common.Enums;
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
@@ -47,23 +48,21 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         }
 
         private void Add() {
-            ProfileViewModel.IsEditable = true;
             ProfileViewModel.CancelAction = async () => {
-                ProfileViewModel.IsEditable = false;
                 await LoadAsync();
+                await ProfileViewModel.LoadAsync(SelectedTemplate?.Id, ProfileMode.View);
             };
-            _ = ProfileViewModel.LoadAsync();
+            _ = ProfileViewModel.LoadAsync(null, ProfileMode.Create);
         }
 
         private void Edit() {
             if (SelectedTemplate == null)
                 return;
-            ProfileViewModel.IsEditable = true;
             ProfileViewModel.CancelAction = async () => {
-                ProfileViewModel.IsEditable = false;
                 await LoadAsync();
+                await ProfileViewModel.LoadAsync(SelectedTemplate.Id, ProfileMode.View);
             };
-            _ = ProfileViewModel.LoadAsync(SelectedTemplate.Id);
+            _ = ProfileViewModel.LoadAsync(SelectedTemplate.Id, ProfileMode.Edit);
         }
 
         private async Task DeleteAsync() {

--- a/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
@@ -1,6 +1,7 @@
 using LYBT.Module.Herbs.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.ViewModels.Profile;
+using LYBT.Common.Enums;
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
@@ -22,7 +23,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             set {
                 if (SetProperty(ref _selectedHerb, value)) {
                     if (value != null)
-                        _ = HerbProfileViewModel.LoadAsync(value.Id);
+                        _ = HerbProfileViewModel.LoadAsync(value.Id, ProfileMode.View);
                 }
             }
         }
@@ -64,22 +65,20 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         }
 
         private void Add() {
-            HerbProfileViewModel.IsEditable = true;
             HerbProfileViewModel.CancelAction = async () => {
-                HerbProfileViewModel.IsEditable = false;
                 await LoadAsync();
+                await HerbProfileViewModel.LoadAsync(SelectedHerb?.Id, ProfileMode.View);
             };
-            HerbProfileViewModel.LoadAsync();
+            HerbProfileViewModel.LoadAsync(null, ProfileMode.Create);
         }
 
         private void Edit() {
             if (SelectedHerb != null) {
-                HerbProfileViewModel.IsEditable = true;
                 HerbProfileViewModel.CancelAction = async () => {
-                    HerbProfileViewModel.IsEditable = false;
                     await LoadAsync();
+                    await HerbProfileViewModel.LoadAsync(SelectedHerb.Id, ProfileMode.View);
                 };
-                HerbProfileViewModel.LoadAsync(SelectedHerb.Id);
+                HerbProfileViewModel.LoadAsync(SelectedHerb.Id, ProfileMode.Edit);
             }
         }
 

--- a/LYBT.UI.WPF/ViewModels/Admin/PatientManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/PatientManagementViewModel.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using LYBT.UI.WPF.ViewModels.Profile;
+using LYBT.Common.Enums;
 
 namespace LYBT.UI.WPF.ViewModels.Admin {
     public class PatientManagementViewModel : BindableBase {
@@ -50,8 +51,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         }
 
         private async Task LoadProfileAsync(Guid id) {
-            await PatientProfileViewModel.LoadAsync(id);
-            PatientProfileViewModel.IsEditable = false;
+            await PatientProfileViewModel.LoadAsync(id, ProfileMode.View);
         }
 
     }

--- a/LYBT.UI.WPF/ViewModels/Admin/PrescriptionManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/PrescriptionManagementViewModel.cs
@@ -1,6 +1,7 @@
 using LYBT.Module.Prescriptions.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.ViewModels.Profile;
+using LYBT.Common.Enums;
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
@@ -47,23 +48,21 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         }
 
         private void Add() {
-            ProfileViewModel.IsEditable = true;
             ProfileViewModel.CancelAction = async () => {
-                ProfileViewModel.IsEditable = false;
                 await LoadAsync();
+                await ProfileViewModel.LoadAsync(SelectedPrescription?.Id, ProfileMode.View);
             };
-            _ = ProfileViewModel.LoadAsync();
+            _ = ProfileViewModel.LoadAsync(null, ProfileMode.Create);
         }
 
         private void Edit() {
             if (SelectedPrescription == null)
                 return;
-            ProfileViewModel.IsEditable = true;
             ProfileViewModel.CancelAction = async () => {
-                ProfileViewModel.IsEditable = false;
                 await LoadAsync();
+                await ProfileViewModel.LoadAsync(SelectedPrescription.Id, ProfileMode.View);
             };
-            _ = ProfileViewModel.LoadAsync(SelectedPrescription.Id);
+            _ = ProfileViewModel.LoadAsync(SelectedPrescription.Id, ProfileMode.Edit);
         }
 
         private async Task DeleteAsync() {

--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -36,6 +36,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             set => SetProperty(ref _isEditable, value);
         }
 
+        private ProfileMode _mode;
+        /// <summary>
+        /// 当前视图模式
+        /// </summary>
+        public ProfileMode Mode {
+            get => _mode;
+            set => SetProperty(ref _mode, value);
+        }
+
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
 
@@ -53,13 +62,13 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             CancelCommand = new DelegateCommand(Cancel);
         }
 
-        public async Task LoadAsync() {
+        public async Task LoadAsync(ProfileMode mode = ProfileMode.View) {
+            Mode = mode;
             var info = await _doctorService.GetByUserIdAsync(_authService.UserId);
             var currentUser = await _userService.GetByIdAsync(_authService.UserId);
             User = currentUser;
             if (info != null) {
                 Doctor = info;
-                EditModeTitle = "编辑医生档案";
             } else {
                 Doctor = new DoctorDetailDto {
                     UserId = _authService.UserId,
@@ -72,9 +81,22 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                     Specialty = string.Empty,
                     Remark = string.Empty
                 };
-                EditModeTitle = "新增医生档案";
             }
-            IsEditable = true;
+
+            switch (mode) {
+                case ProfileMode.Create:
+                    EditModeTitle = "新增医生档案";
+                    IsEditable = true;
+                    break;
+                case ProfileMode.Edit:
+                    EditModeTitle = "编辑医生档案";
+                    IsEditable = true;
+                    break;
+                default:
+                    EditModeTitle = "医生详情";
+                    IsEditable = false;
+                    break;
+            }
         }
 
         private async Task SaveAsync() {
@@ -120,6 +142,9 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                     main.HasDoctorProfile = true;
                     await main.CheckDoctorProfileAsync(); // 重新检查状态
                 }
+                Mode = ProfileMode.View;
+                IsEditable = false;
+                EditModeTitle = "医生详情";
             } else {
                 MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -134,11 +159,14 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 main.IsMainVisible = true;
                 main.IsFunctionVisible = false;
             }
+            Mode = ProfileMode.View;
+            IsEditable = false;
+            EditModeTitle = "医生详情";
         }
 
         public async void OnNavigatedTo(NavigationContext navigationContext) {
             try {
-                await LoadAsync();
+                await LoadAsync(ProfileMode.Edit);
             } catch (Exception ex) {
                 MessageBox.Show($"加载医生档案失败：{ex.Message}", "错误",
                     MessageBoxButton.OK, MessageBoxImage.Error);

--- a/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
@@ -5,6 +5,7 @@ using Prism.Commands;
 using Prism.Mvvm;
 using System;
 using System.Collections.ObjectModel;
+using LYBT.Common.Enums;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
@@ -42,6 +43,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             set => SetProperty(ref _isEditable, value);
         }
 
+        private ProfileMode _mode;
+        /// <summary>
+        /// 当前视图模式
+        /// </summary>
+        public ProfileMode Mode {
+            get => _mode;
+            set => SetProperty(ref _mode, value);
+        }
+
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
         public DelegateCommand AddHerbCommand { get; }
@@ -57,7 +67,8 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             RemoveHerbCommand = new DelegateCommand(RemoveHerb, () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
         }
 
-        public async Task LoadAsync(Guid? id = null) {
+        public async Task LoadAsync(Guid? id = null, ProfileMode mode = ProfileMode.View) {
+            Mode = mode;
             if (id.HasValue && id.Value != Guid.Empty) {
                 var detail = await _service.GetByIdAsync(id.Value);
                 if (detail != null) {
@@ -65,12 +76,28 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                     Herbs.Clear();
                     foreach (var h in detail.Herbs)
                         Herbs.Add(h);
-                    EditModeTitle = "编辑模板";
+                } else {
+                    Template = new FormulaTemplateDetailDto();
+                    Herbs.Clear();
                 }
             } else {
                 Template = new FormulaTemplateDetailDto();
                 Herbs.Clear();
-                EditModeTitle = "新增模板";
+            }
+
+            switch (mode) {
+                case ProfileMode.Create:
+                    EditModeTitle = "新增模板";
+                    IsEditable = true;
+                    break;
+                case ProfileMode.Edit:
+                    EditModeTitle = "编辑模板";
+                    IsEditable = true;
+                    break;
+                default:
+                    EditModeTitle = "模板详情";
+                    IsEditable = false;
+                    break;
             }
         }
 
@@ -104,10 +131,19 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             }
             if (!ok)
                 MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
-            else
+            else {
+                Mode = ProfileMode.View;
+                IsEditable = false;
+                EditModeTitle = "模板详情";
                 CancelAction?.Invoke();
+            }
         }
 
-        private void Cancel() => CancelAction?.Invoke();
+        private void Cancel() {
+            Mode = ProfileMode.View;
+            IsEditable = false;
+            EditModeTitle = "模板详情";
+            CancelAction?.Invoke();
+        }
     }
 }

--- a/LYBT.UI.WPF/ViewModels/Profile/HerbProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/HerbProfileViewModel.cs
@@ -5,6 +5,7 @@ using Prism.Mvvm;
 using System;
 using System.Threading.Tasks;
 using System.Windows;
+using LYBT.Common.Enums;
 
 namespace LYBT.UI.WPF.ViewModels.Profile {
     public class HerbProfileViewModel : BindableBase {
@@ -19,6 +20,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         private bool _isEditable;
         public bool IsEditable { get => _isEditable; set => SetProperty(ref _isEditable, value); }
 
+        private ProfileMode _mode;
+        /// <summary>
+        /// 当前视图模式
+        /// </summary>
+        public ProfileMode Mode {
+            get => _mode;
+            set => SetProperty(ref _mode, value);
+        }
+
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
 
@@ -30,16 +40,31 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             CancelCommand = new DelegateCommand(Cancel);
         }
 
-        public async Task LoadAsync(Guid? id = null) {
+        public async Task LoadAsync(Guid? id = null, ProfileMode mode = ProfileMode.View) {
+            Mode = mode;
             if (id.HasValue && id.Value != Guid.Empty) {
                 var info = await _herbService.GetByIdAsync(id.Value);
-                if (info != null) {
+                if (info != null)
                     Herb = info;
-                    EditModeTitle = "编辑药材";
-                }
+                else
+                    Herb = new HerbDetailDto();
             } else {
                 Herb = new HerbDetailDto();
-                EditModeTitle = "新增药材";
+            }
+
+            switch (mode) {
+                case ProfileMode.Create:
+                    EditModeTitle = "新增药材";
+                    IsEditable = true;
+                    break;
+                case ProfileMode.Edit:
+                    EditModeTitle = "编辑药材";
+                    IsEditable = true;
+                    break;
+                default:
+                    EditModeTitle = "药材详情";
+                    IsEditable = false;
+                    break;
             }
         }
 
@@ -72,14 +97,21 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 }
                 if (!success)
                     MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
-                else
+                else {
+                    Mode = ProfileMode.View;
+                    IsEditable = false;
+                    EditModeTitle = "药材详情";
                     CancelAction?.Invoke();
+                }
             } catch (Exception ex) {
                 MessageBox.Show($"保存失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 
         private void Cancel() {
+            Mode = ProfileMode.View;
+            IsEditable = false;
+            EditModeTitle = "药材详情";
             CancelAction?.Invoke();
         }
     }

--- a/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
@@ -35,6 +35,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             set => SetProperty(ref _isEditable, value);
         }
 
+        private ProfileMode _mode;
+        /// <summary>
+        /// 当前视图模式
+        /// </summary>
+        public ProfileMode Mode {
+            get => _mode;
+            set => SetProperty(ref _mode, value);
+        }
+
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
 
@@ -46,21 +55,29 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             CancelCommand = new DelegateCommand(Cancel);
         }
 
-        public async Task LoadAsync(Guid patientId) {
+        public async Task LoadAsync(Guid patientId, ProfileMode mode = ProfileMode.View) {
+            Mode = mode;
             if (patientId != Guid.Empty) {
                 var info = await _patientService.GetByIdAsync(patientId);
-                if (info != null) {
-                    Patient = info;
-                    EditModeTitle = "编辑患者档案";
-                } else {
-                    Patient = new PatientDetailDto();
-                    EditModeTitle = "新增患者档案";
-                }
+                Patient = info ?? new PatientDetailDto();
             } else {
                 Patient = new PatientDetailDto();
-                EditModeTitle = "新增患者档案";
             }
-            IsEditable = true;
+
+            switch (mode) {
+                case ProfileMode.Create:
+                    EditModeTitle = "新增患者档案";
+                    IsEditable = true;
+                    break;
+                case ProfileMode.Edit:
+                    EditModeTitle = "编辑患者档案";
+                    IsEditable = true;
+                    break;
+                default:
+                    EditModeTitle = "患者详情";
+                    IsEditable = false;
+                    break;
+            }
         }
 
         private async Task SaveAsync() {
@@ -72,7 +89,9 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
             if (ok) {
                 MessageBox.Show("已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+                Mode = ProfileMode.View;
                 IsEditable = false;
+                EditModeTitle = "患者详情";
             } else {
                 MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -87,6 +106,9 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 main.IsMainVisible = true;
                 main.IsFunctionVisible = false;
             }
+            Mode = ProfileMode.View;
+            IsEditable = false;
+            EditModeTitle = "患者详情";
         }
     }
 }

--- a/LYBT.UI.WPF/ViewModels/Profile/PrescriptionProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PrescriptionProfileViewModel.cs
@@ -7,6 +7,7 @@ using Prism.Commands;
 using Prism.Mvvm;
 using LYBT.Module.Prescriptions.Dtos;
 using LYBT.UI.WPF.Interfaces;
+using LYBT.Common.Enums;
 
 namespace LYBT.UI.WPF.ViewModels.Profile {
     /// <summary>
@@ -41,6 +42,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             set => SetProperty(ref _isEditable, value);
         }
 
+        private ProfileMode _mode;
+        /// <summary>
+        /// 当前视图模式
+        /// </summary>
+        public ProfileMode Mode {
+            get => _mode;
+            set => SetProperty(ref _mode, value);
+        }
+
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
         public DelegateCommand AddItemCommand { get; }
@@ -56,7 +66,8 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             RemoveItemCommand = new DelegateCommand<object?>(param => RemoveItem(param as PrescriptionItemDto));
         }
 
-        public async Task LoadAsync(Guid? id = null) {
+        public async Task LoadAsync(Guid? id = null, ProfileMode mode = ProfileMode.View) {
+            Mode = mode;
             if (id.HasValue && id.Value != Guid.Empty) {
                 var detail = await _service.GetByIdAsync(id.Value);
                 if (detail != null) {
@@ -64,12 +75,28 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                     Items.Clear();
                     foreach (var it in detail.Items)
                         Items.Add(it);
-                    EditModeTitle = "编辑处方";
+                } else {
+                    Prescription = new PrescriptionDetailDto();
+                    Items.Clear();
                 }
             } else {
                 Prescription = new PrescriptionDetailDto();
                 Items.Clear();
-                EditModeTitle = "新增处方";
+            }
+
+            switch (mode) {
+                case ProfileMode.Create:
+                    EditModeTitle = "新增处方";
+                    IsEditable = true;
+                    break;
+                case ProfileMode.Edit:
+                    EditModeTitle = "编辑处方";
+                    IsEditable = true;
+                    break;
+                default:
+                    EditModeTitle = "处方详情";
+                    IsEditable = false;
+                    break;
             }
         }
 
@@ -121,10 +148,19 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             }
             if (!ok)
                 MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
-            else
+            else {
+                Mode = ProfileMode.View;
+                IsEditable = false;
+                EditModeTitle = "处方详情";
                 CancelAction?.Invoke();
+            }
         }
 
-        private void Cancel() => CancelAction?.Invoke();
+        private void Cancel() {
+            Mode = ProfileMode.View;
+            IsEditable = false;
+            EditModeTitle = "处方详情";
+            CancelAction?.Invoke();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `ProfileMode` enum
- add `Mode` property to profile view models
- load profiles with appropriate mode in management view models
- set `IsEditable` and `EditModeTitle` based on mode

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: required runtime 8.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687447bf3c0483338a84d0eb58f14dd8