### PR TITLE
Improve error handling in DoctorService

### DIFF
--- a/LYBT.UI.WPF/Services/DoctorService.cs
+++ b/LYBT.UI.WPF/Services/DoctorService.cs
@@ -64,9 +64,7 @@ namespace LYBT.UI.WPF.Services {
                 var msg = "新增医生失败";
                 if (!string.IsNullOrWhiteSpace(ex.Content)) {
                     try {
-                        var apiMsg = JsonSerializer.Deserialize<ApiSuccessResponse>(ex.Content);
-                        if (!string.IsNullOrWhiteSpace(apiMsg?.Message))
-                            msg = apiMsg.Message;
+                        msg = JsonSerializer.Deserialize<ApiSuccessResponse>(ex.Content)?.Message ?? msg;
                     } catch { }
                 }
                 MessageBox.Show(msg, "错误", MessageBoxButton.OK, MessageBoxImage.Error);
@@ -87,9 +85,7 @@ namespace LYBT.UI.WPF.Services {
                 var msg = "保存医生失败";
                 if (!string.IsNullOrWhiteSpace(ex.Content)) {
                     try {
-                        var apiMsg = JsonSerializer.Deserialize<ApiSuccessResponse>(ex.Content);
-                        if (!string.IsNullOrWhiteSpace(apiMsg?.Message))
-                            msg = apiMsg.Message;
+                        msg = JsonSerializer.Deserialize<ApiSuccessResponse>(ex.Content)?.Message ?? msg;
                     } catch { }
                 }
                 MessageBox.Show(msg, "错误", MessageBoxButton.OK, MessageBoxImage.Error);


### PR DESCRIPTION
## Summary
- handle `_doctorApi.AddAsync` and `UpdateAsync` failures with nicer message parsing

## Testing
- `dotnet test -v minimal` *(fails: missing .NET 8.0 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687460292e4483338ca373306ab9d63b