### PR TITLE
Remove redundant error messages when saving doctors

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
@@ -114,10 +114,8 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 } else {
                     ok = await _doctorService.UpdateAsync(editing);
                 }
-                if (!ok) {
-                    MessageBox.Show(editing.Id == Guid.Empty ? "新增医生失败" : "保存医生失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+                if (!ok)
                     return;
-                }
             } catch (Exception ex) {
                 var msg = ex.Message;
                 if (ex is ApiException apiEx && !string.IsNullOrEmpty(apiEx.Content)) {

--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -326,10 +326,9 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 MessageBox.Show($"创建医生档案失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
-            if (ok)
-                MessageBox.Show("医生档案创建成功", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
-            else
-                MessageBox.Show("创建医生档案失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            if (!ok)
+                return;
+            MessageBox.Show("医生档案创建成功", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
         }
 
         private void CancelEdit() {

--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -134,20 +134,18 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 ok = await _doctorService.UpdateAsync(dto);
             }
 
-            if (ok) {
-                MessageBox.Show("已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
-                if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
-                    main.IsMainVisible = true;
-                    main.IsFunctionVisible = false;
-                    main.HasDoctorProfile = true;
-                    await main.CheckDoctorProfileAsync(); // 重新检查状态
-                }
-                Mode = ProfileMode.View;
-                IsEditable = false;
-                EditModeTitle = "医生详情";
-            } else {
-                MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
+            if (!ok)
+                return;
+            MessageBox.Show("已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                main.IsMainVisible = true;
+                main.IsFunctionVisible = false;
+                main.HasDoctorProfile = true;
+                await main.CheckDoctorProfileAsync(); // 重新检查状态
             }
+            Mode = ProfileMode.View;
+            IsEditable = false;
+            EditModeTitle = "医生详情";
         }
 
         private void Cancel() {


### PR DESCRIPTION
## Summary
- avoid duplicate failure messages when creating doctor profile
- skip extra alerts when saving doctor records fails
- stop showing an extra failure message from DoctorProfileViewModel

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68746572b2a483339556429a34f15ee1