### PR TITLE
Handle binary export with HttpContent

### DIFF
--- a/LYBT.UI.WPF/Apis/IFormulaTemplateApi.cs
+++ b/LYBT.UI.WPF/Apis/IFormulaTemplateApi.cs
@@ -4,6 +4,7 @@ using Refit;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace LYBT.UI.WPF.Apis {
@@ -34,6 +35,6 @@ namespace LYBT.UI.WPF.Apis {
         Task<ImportCountResponse> ImportExcelAsync([AliasAs("file")] StreamPart file);
 
         [Get("/api/FormulaTemplate/exportExcel")]
-        Task<byte[]> ExportExcelAsync();
+        Task<HttpContent> ExportExcelAsync();
     }
 }

--- a/LYBT.UI.WPF/Apis/IHerbApi.cs
+++ b/LYBT.UI.WPF/Apis/IHerbApi.cs
@@ -4,6 +4,7 @@ using Refit;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace LYBT.UI.WPF.Apis {
@@ -34,6 +35,6 @@ namespace LYBT.UI.WPF.Apis {
         Task<ImportCountResponse> ImportExcelAsync([AliasAs("file")] StreamPart file);
 
         [Get("/api/Herb/exportExcel")]
-        Task<byte[]> ExportExcelAsync();
+        Task<HttpContent> ExportExcelAsync();
     }
 }

--- a/LYBT.UI.WPF/Services/FormulaTemplateService.cs
+++ b/LYBT.UI.WPF/Services/FormulaTemplateService.cs
@@ -84,8 +84,10 @@ namespace LYBT.UI.WPF.Services {
         }
 
         public async Task<int> ExportToExcelAsync(string path) {
-            var bytes = await _api.ExportExcelAsync();
-            await File.WriteAllBytesAsync(path, bytes);
+            var content = await _api.ExportExcelAsync();
+            await using (var fs = File.Create(path)) {
+                await content.CopyToAsync(fs);
+            }
             var list = await _api.GetListAsync();
             return list.Count;
         }

--- a/LYBT.UI.WPF/Services/HerbService.cs
+++ b/LYBT.UI.WPF/Services/HerbService.cs
@@ -116,8 +116,10 @@ namespace LYBT.UI.WPF.Services {
         }
 
         public async Task<int> ExportToExcelAsync(string path) {
-            var bytes = await _api.ExportExcelAsync();
-            await File.WriteAllBytesAsync(path, bytes);
+            var content = await _api.ExportExcelAsync();
+            await using (var fs = File.Create(path)) {
+                await content.CopyToAsync(fs);
+            }
             var list = await _api.GetListAsync();
             return list.Count;
         }


### PR DESCRIPTION
## Summary
- update Refit APIs to return `HttpContent` for Excel exports
- copy response streams directly to the local file when exporting herbs and formula templates

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874996e89b08333969bf507265e66a4