### PR TITLE
Ensure Doctor fields map correctly

### DIFF
--- a/LYBT.Module.Doctors/Mapping/DoctorMappingProfile.cs
+++ b/LYBT.Module.Doctors/Mapping/DoctorMappingProfile.cs
@@ -26,7 +26,15 @@ namespace LYBT.Module.Doctors.Mapping {
                 .ForMember(d => d.User, o => o.Ignore())
                 .ForMember(d => d.UserId, o => o.MapFrom(s => s.UserId))
                 .ForMember(d => d.ContactNumber, o => o.MapFrom(s => s.ContactNumber))
-                .ForMember(d => d.Gender, o => o.MapFrom(s => s.Gender));
+                .ForMember(d => d.Gender, o => o.MapFrom(s => s.Gender))
+                .ForMember(d => d.Birthday, o => o.MapFrom(s => s.Birthday))
+                .ForMember(d => d.Title, o => o.MapFrom(s => s.Title))
+                .ForMember(d => d.LicenseNumber, o => o.MapFrom(s => s.LicenseNumber))
+                .ForMember(d => d.Specialty, o => o.MapFrom(s => s.Specialty))
+                .ForMember(d => d.Status, o => o.MapFrom(s => s.Status))
+                .ForMember(d => d.WorkStatus, o => o.MapFrom(s => s.WorkStatus))
+                .ForMember(d => d.PinyinCode, o => o.MapFrom(s => s.PinyinCode))
+                .ForMember(d => d.Remark, o => o.MapFrom(s => s.Remark));
         }
     }
 }

--- a/LYBT.Tests/Services/DoctorServiceTests.cs
+++ b/LYBT.Tests/Services/DoctorServiceTests.cs
@@ -9,6 +9,8 @@ using LYBT.Module.Doctors.Dtos;
 using LYBT.Module.Doctors.Mapping;
 using LYBT.Module.Users.Interfaces;
 using LYBT.Module.Users.Models;
+using LYBT.Models.Doctors;
+using LYBT.Common.Enums;
 
 namespace LYBT.Tests.Services;
 
@@ -60,5 +62,96 @@ public class DoctorServiceTests
         var service = new DoctorService(repo.Object, userRepo.Object, mapper);
 
         await Assert.ThrowsAsync<Exception>(() => service.AddAsync(new DoctorDetailDto { UserId = Guid.NewGuid() }));
+    }
+
+    [Fact]
+    public async Task AddAsync_MapsAllFields()
+    {
+        DoctorModel? savedModel = null;
+        var repo = new Mock<IDoctorRepository>();
+        repo.Setup(r => r.GetByUserIdAsync(It.IsAny<Guid>())).ReturnsAsync((DoctorModel?)null);
+        repo.Setup(r => r.AddAsync(It.IsAny<DoctorModel>()))
+            .Callback<DoctorModel>(m => savedModel = m)
+            .ReturnsAsync(true);
+        var userRepo = new Mock<IUserRepository>();
+        userRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new UserModel());
+        var mapper = CreateMapper();
+        var service = new DoctorService(repo.Object, userRepo.Object, mapper);
+
+        var dto = new DoctorDetailDto
+        {
+            UserId = Guid.NewGuid(),
+            Gender = Gender.Female,
+            Birthday = new DateTime(1980, 1, 1),
+            Title = DoctorTitle.Senior,
+            LicenseNumber = "LN",
+            Specialty = "Spec",
+            Status = DoctorStatus.Active,
+            WorkStatus = DoctorWorkStatus.Clinic,
+            PinyinCode = "ABC",
+            Remark = "note",
+            ContactNumber = "123"
+        };
+
+        var result = await service.AddAsync(dto);
+
+        Assert.True(result);
+        Assert.NotNull(savedModel);
+        Assert.Equal(dto.Birthday, savedModel!.Birthday);
+        Assert.Equal(dto.Title, savedModel.Title);
+        Assert.Equal(dto.LicenseNumber, savedModel.LicenseNumber);
+        Assert.Equal(dto.Specialty, savedModel.Specialty);
+        Assert.Equal(dto.Status, savedModel.Status);
+        Assert.Equal(dto.WorkStatus, savedModel.WorkStatus);
+        Assert.Equal(dto.PinyinCode, savedModel.PinyinCode);
+        Assert.Equal(dto.Remark, savedModel.Remark);
+        Assert.Equal(dto.ContactNumber, savedModel.ContactNumber);
+        Assert.Equal(dto.Gender, savedModel.Gender);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_MapsAllFields()
+    {
+        var model = new DoctorModel
+        {
+            Id = Guid.NewGuid(),
+            UserId = Guid.NewGuid(),
+            User = new UserModel()
+        };
+        var repo = new Mock<IDoctorRepository>();
+        repo.Setup(r => r.GetByIdAsync(model.Id)).ReturnsAsync(model);
+        repo.Setup(r => r.UpdateAsync(It.IsAny<DoctorModel>())).ReturnsAsync(true);
+        var userRepo = new Mock<IUserRepository>();
+        var mapper = CreateMapper();
+        var service = new DoctorService(repo.Object, userRepo.Object, mapper);
+
+        var dto = new DoctorDetailDto
+        {
+            Id = model.Id,
+            Gender = Gender.Male,
+            Birthday = new DateTime(1990, 2, 2),
+            Title = DoctorTitle.Intermediate,
+            LicenseNumber = "XYZ",
+            Specialty = "S1",
+            Status = DoctorStatus.Inactive,
+            WorkStatus = DoctorWorkStatus.VisitOutside,
+            PinyinCode = "py",
+            Remark = "r",
+            ContactNumber = "c"
+        };
+
+        var result = await service.UpdateAsync(dto);
+
+        Assert.True(result);
+        Assert.Equal(dto.Birthday, model.Birthday);
+        Assert.Equal(dto.Title, model.Title);
+        Assert.Equal(dto.LicenseNumber, model.LicenseNumber);
+        Assert.Equal(dto.Specialty, model.Specialty);
+        Assert.Equal(dto.Status, model.Status);
+        Assert.Equal(dto.WorkStatus, model.WorkStatus);
+        Assert.Equal(dto.PinyinCode, model.PinyinCode);
+        Assert.Equal(dto.Remark, model.Remark);
+        Assert.Equal(dto.ContactNumber, model.ContactNumber);
+        Assert.Equal(dto.Gender, model.Gender);
     }
 }


### PR DESCRIPTION
## Summary
- map full doctor info from `DoctorDetailDto` to `DoctorModel`
- verify that all doctor fields persist on add and update

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6874ffc517208333ad185a7dbfd210dc