### PR TITLE
Fix doctor save error due to missing user

### DIFF
--- a/LYBT.Module.Doctors/Services/DoctorService.cs
+++ b/LYBT.Module.Doctors/Services/DoctorService.cs
@@ -69,6 +69,10 @@ namespace LYBT.Module.Doctors.Services {
 
             var model = _mapper.Map<DoctorModel>(dto);
             model.Id = Guid.NewGuid();
+            // EF Core requires the User navigation property for required relationships
+            // to be non-null when saving entities. Assign the retrieved user to avoid
+            // validation errors when calling SaveChangesAsync.
+            model.User = user;
             try {
                 return await _doctorRepository.AddAsync(model);
             } catch (DbUpdateException ex) {

--- a/LYBT.Tests/Services/DoctorServiceTests.cs
+++ b/LYBT.Tests/Services/DoctorServiceTests.cs
@@ -74,7 +74,8 @@ public class DoctorServiceTests
             .Callback<DoctorModel>(m => savedModel = m)
             .ReturnsAsync(true);
         var userRepo = new Mock<IUserRepository>();
-        userRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new UserModel());
+        var existingUser = new UserModel();
+        userRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(existingUser);
         var mapper = CreateMapper();
         var service = new DoctorService(repo.Object, userRepo.Object, mapper);
 
@@ -97,6 +98,8 @@ public class DoctorServiceTests
 
         Assert.True(result);
         Assert.NotNull(savedModel);
+        // User navigation property should be assigned with the existing user
+        Assert.Same(existingUser, savedModel!.User);
         Assert.Equal(dto.Birthday, savedModel!.Birthday);
         Assert.Equal(dto.Title, savedModel.Title);
         Assert.Equal(dto.LicenseNumber, savedModel.LicenseNumber);


### PR DESCRIPTION
## Summary
- assign the existing user entity when creating doctors
- update tests to ensure user is assigned and unaffected

## Testing
- `dotnet test LYBT.Tests/LYBT.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68750354513c833396173717afdbcadf