### PR TITLE
Fix doctor profile creation flow

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -314,21 +314,21 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 MessageBox.Show("该用户已有医生档案", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
                 return;
             }
-            var dto = new DoctorDetailDto {
-                UserId = SelectedUser.Id,
-                UserName = SelectedUser.UserName,
-                RealName = SelectedUser.RealName
+
+            // 创建档案编辑窗口并预填用户信息
+            var vm = new DoctorProfileViewModel(_doctorService, null, null) {
+                Doctor = new DoctorDetailDto {
+                    UserId = SelectedUser.Id,
+                    UserName = SelectedUser.UserName,
+                    RealName = SelectedUser.RealName
+                },
+                Mode = ProfileMode.Create,
+                IsEditable = true,
+                EditModeTitle = "新增医生档案"
             };
-            bool ok;
-            try {
-                ok = await _doctorService.AddAsync(dto);
-            } catch (Exception ex) {
-                MessageBox.Show($"创建医生档案失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
-                return;
-            }
-            if (!ok)
-                return;
-            MessageBox.Show("医生档案创建成功", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
+            var win = new DoctorProfileWindow { DataContext = vm };
+            vm.CancelAction = () => win.Close();
+            win.ShowDialog();
         }
 
         private void CancelEdit() {

--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -137,7 +137,9 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             if (!ok)
                 return;
             MessageBox.Show("已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
-            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+            if (CancelAction != null) {
+                CancelAction.Invoke();
+            } else if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
                 main.IsMainVisible = true;
                 main.IsFunctionVisible = false;
                 main.HasDoctorProfile = true;

--- a/LYBT.UI.WPF/Views/DoctorProfileWindow.xaml
+++ b/LYBT.UI.WPF/Views/DoctorProfileWindow.xaml
@@ -1,0 +1,7 @@
+<Window x:Class="LYBT.UI.WPF.Views.DoctorProfileWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:main="clr-namespace:LYBT.UI.WPF.Views.Main"
+        Title="医生档案" Height="720" Width="600">
+    <main:DoctorProfileView />
+</Window>

--- a/LYBT.UI.WPF/Views/DoctorProfileWindow.xaml.cs
+++ b/LYBT.UI.WPF/Views/DoctorProfileWindow.xaml.cs
@@ -1,0 +1,9 @@
+using System.Windows;
+
+namespace LYBT.UI.WPF.Views {
+    public partial class DoctorProfileWindow : Window {
+        public DoctorProfileWindow() {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show DoctorProfileView window when creating a new doctor profile
- let DoctorProfileViewModel close the window when a CancelAction is provided

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750f509f588333bde1013f27a8e111