### PR TITLE
Align doctor profile creation view

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/UserManagementViewModel.cs
@@ -8,6 +8,8 @@ using System.Text.Json;
 using System.Linq;
 
 using LYBT.Module.Doctors.Dtos;
+using LYBT.UI.WPF.ViewModels.Main;
+using LYBT.Common.Enums;
 using LYBT.UI.WPF.Interfaces;
 
 
@@ -315,20 +317,9 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 return;
             }
 
-            // 创建档案编辑窗口并预填用户信息
-            var vm = new DoctorProfileViewModel(_doctorService, null, null) {
-                Doctor = new DoctorDetailDto {
-                    UserId = SelectedUser.Id,
-                    UserName = SelectedUser.UserName,
-                    RealName = SelectedUser.RealName
-                },
-                Mode = ProfileMode.Create,
-                IsEditable = true,
-                EditModeTitle = "新增医生档案"
-            };
-            var win = new DoctorProfileWindow { DataContext = vm };
-            vm.CancelAction = () => win.Close();
-            win.ShowDialog();
+            if (Application.Current.MainWindow.DataContext is MainWindowViewModel main) {
+                main.NavigateDoctorProfile(SelectedUser.Id, ProfileMode.Create);
+            }
         }
 
         private void CancelEdit() {

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using LYBT.UI.WPF.Services;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Mvvm;
+using Prism.Regions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
@@ -12,6 +13,7 @@ using System.Threading.Tasks;
 using System;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.ViewModels.Profile;
+using LYBT.Common.Enums;
 
 namespace LYBT.UI.WPF.ViewModels.Main {
     /// <summary>
@@ -130,9 +132,25 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         }
 
         private void ShowDoctorProfile() {
+            NavigateDoctorProfile();
+        }
+
+        public void NavigateDoctorProfile(Guid? userId = null, ProfileMode? mode = null) {
             IsMainVisible = false;
             IsFunctionVisible = true;
-            _regionManager.RequestNavigate("FunctionRegion", "DoctorProfileView");
+            var actualMode = mode ?? (HasDoctorProfile ? ProfileMode.Edit : ProfileMode.Create);
+            var parameters = new NavigationParameters { { "Mode", actualMode } };
+            if (userId != null)
+                parameters.Add("UserId", userId.Value);
+            _regionManager.RequestNavigate("FunctionRegion", "DoctorProfileView", result => {
+                var view = _regionManager.Regions["FunctionRegion"].ActiveViews.FirstOrDefault();
+                if (view is FrameworkElement element && element.DataContext is DoctorProfileViewModel vm) {
+                    vm.CancelAction = () => {
+                        IsMainVisible = true;
+                        IsFunctionVisible = false;
+                    };
+                }
+            }, parameters);
         }
 
         private void ShowPatientProfile() {

--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -62,16 +62,19 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             CancelCommand = new DelegateCommand(Cancel);
         }
 
-        public async Task LoadAsync(ProfileMode mode = ProfileMode.View) {
+        public async Task LoadAsync(Guid? userId = null, ProfileMode mode = ProfileMode.View) {
             Mode = mode;
-            var info = await _doctorService.GetByUserIdAsync(_authService.UserId);
-            var currentUser = await _userService.GetByIdAsync(_authService.UserId);
+            var uid = userId ?? _authService.UserId;
+            var info = await _doctorService.GetByUserIdAsync(uid);
+            var currentUser = await _userService.GetByIdAsync(uid);
             User = currentUser;
             if (info != null) {
                 Doctor = info;
             } else {
                 Doctor = new DoctorDetailDto {
-                    UserId = _authService.UserId,
+                    UserId = uid,
+                    UserName = currentUser?.UserName,
+                    RealName = currentUser?.RealName,
                     Birthday = DateTime.Now.AddYears(-30),
                     Title = DoctorTitle.Junior,
                     Status = DoctorStatus.Active,
@@ -166,7 +169,17 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
         public async void OnNavigatedTo(NavigationContext navigationContext) {
             try {
-                await LoadAsync(ProfileMode.Edit);
+                var mode = ProfileMode.Edit;
+                if (navigationContext.Parameters.TryGetValue("Mode", out var m)) {
+                    if (m is ProfileMode pm)
+                        mode = pm;
+                    else if (m is string s && Enum.TryParse<ProfileMode>(s, out var parsed))
+                        mode = parsed;
+                }
+                Guid? userId = null;
+                if (navigationContext.Parameters.TryGetValue("UserId", out var u) && u is Guid guid)
+                    userId = guid;
+                await LoadAsync(userId, mode);
             } catch (Exception ex) {
                 MessageBox.Show($"加载医生档案失败：{ex.Message}", "错误",
                     MessageBoxButton.OK, MessageBoxImage.Error);


### PR DESCRIPTION
## Summary
- route doctor profile creation through MainWindow navigation
- expose a method to open doctor profile with parameters
- adjust DoctorProfileViewModel to accept user id and mode on navigation

## Testing
- `dotnet restore`
- `dotnet build --no-restore` *(fails: Microsoft.PackageDependencyResolution.targets NETSDK1004; WPF project requires Windows)*
- `dotnet test LYBT.Tests/LYBT.Tests.csproj -v normal` *(fails: requires framework Microsoft.NETCore.App 8.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_687516609d6083339ecff2dc258cca91