### PR TITLE
Fix generic type inference in DoctorProfileViewModel

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -170,14 +170,14 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         public async void OnNavigatedTo(NavigationContext navigationContext) {
             try {
                 var mode = ProfileMode.Edit;
-                if (navigationContext.Parameters.TryGetValue("Mode", out var m)) {
+                if (navigationContext.Parameters.TryGetValue<object>("Mode", out var m)) {
                     if (m is ProfileMode pm)
                         mode = pm;
                     else if (m is string s && Enum.TryParse<ProfileMode>(s, out var parsed))
                         mode = parsed;
                 }
                 Guid? userId = null;
-                if (navigationContext.Parameters.TryGetValue("UserId", out var u) && u is Guid guid)
+                if (navigationContext.Parameters.TryGetValue<object>("UserId", out var u) && u is Guid guid)
                     userId = guid;
                 await LoadAsync(userId, mode);
             } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- specify generic type arguments when retrieving NavigationContext parameters to avoid compile error

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68751c6160dc8333a3496f21ebf39d34