### PR TITLE
Add base view models and refactor doctors/patients

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/DoctorManagementViewModel.cs
@@ -5,7 +5,7 @@ using LYBT.UI.WPF.Services;
 using LYBT.UI.WPF.ViewModels.Profile;
 using LYBT.Common.Enums;
 using Prism.Commands;
-using Prism.Mvvm;
+using LYBT.UI.WPF.ViewModels.Base;
 using Refit;
 using System;
 using System.Collections.ObjectModel;
@@ -18,8 +18,8 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
     /// <summary>
     /// 医生管理视图模型
     /// </summary>
-    public class DoctorManagementViewModel : BindableBase {
-        public ObservableCollection<DoctorDto> Doctors { get; } = new();
+    public class DoctorManagementViewModel : BaseListViewModel<DoctorDto> {
+        public ObservableCollection<DoctorDto> Doctors => Items;
 
         private DoctorDto? _selectedDoctor;
         /// <summary>列表中选中的医生</summary>
@@ -61,8 +61,8 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             EditDoctorCommand = new DelegateCommand(EditDoctor, () => SelectedDoctor != null).ObservesProperty(() => SelectedDoctor);
             SaveDoctorCommand = new DelegateCommand(async () => await SaveDoctor(), () => IsEditable).ObservesProperty(() => IsEditable);
             CancelCommand = new DelegateCommand(CancelEdit);
-            SearchCommand = new DelegateCommand(async () => await LoadDoctors());
-            _ = LoadDoctors();
+            SearchCommand = new DelegateCommand(async () => await LoadPageAsync());
+            _ = LoadPageAsync();
         }
 
         /// <summary>
@@ -78,11 +78,11 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             }
         }
 
-        private async Task LoadDoctors() {
+        public override async Task LoadPageAsync() {
             var list = await _doctorService.SearchAsync(SearchKeyword);
-            Doctors.Clear();
+            Items.Clear();
             foreach (var d in list)
-                Doctors.Add(d);
+                Items.Add(d);
         }
 
 
@@ -130,7 +130,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 MessageBox.Show($"操作失败：{msg}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
-            await LoadDoctors();
+            await LoadPageAsync();
             DoctorProfileViewModel.Mode = ProfileMode.View;
             DoctorProfileViewModel.IsEditable = false;
             DoctorProfileViewModel.EditModeTitle = "医生详情";

--- a/LYBT.UI.WPF/ViewModels/Admin/PatientManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/PatientManagementViewModel.cs
@@ -1,7 +1,7 @@
 using LYBT.Module.Patients.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using Prism.Commands;
-using Prism.Mvvm;
+using LYBT.UI.WPF.ViewModels.Base;
 using System;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -9,9 +9,9 @@ using LYBT.UI.WPF.ViewModels.Profile;
 using LYBT.Common.Enums;
 
 namespace LYBT.UI.WPF.ViewModels.Admin {
-    public class PatientManagementViewModel : BindableBase {
+    public class PatientManagementViewModel : BaseListViewModel<PatientDetailDto> {
         private readonly IPatientService _patientService;
-        public ObservableCollection<PatientDetailDto> Patients { get; } = new();
+        public ObservableCollection<PatientDetailDto> Patients => Items;
 
         private PatientDetailDto? _selectedPatient;
         public PatientDetailDto? SelectedPatient {
@@ -37,17 +37,17 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         public PatientManagementViewModel(IPatientService patientService, PatientProfileViewModel profileViewModel) {
             _patientService = patientService;
             PatientProfileViewModel = profileViewModel;
-            SearchCommand = new DelegateCommand(async () => await LoadPatients());
-            _ = LoadPatients();
+            SearchCommand = new DelegateCommand(async () => await LoadPageAsync());
+            _ = LoadPageAsync();
         }
 
-        private async Task LoadPatients() {
+        public override async Task LoadPageAsync() {
             var list = string.IsNullOrWhiteSpace(SearchKeyword)
                 ? await _patientService.GetAllAsync()
                 : await _patientService.SearchAsync(SearchKeyword);
-            Patients.Clear();
+            Items.Clear();
             foreach (var p in list)
-                Patients.Add(p);
+                Items.Add(p);
         }
 
         private async Task LoadProfileAsync(Guid id) {

--- a/LYBT.UI.WPF/ViewModels/Base/BaseListViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Base/BaseListViewModel.cs
@@ -1,0 +1,49 @@
+using Prism.Mvvm;
+using Prism.Commands;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+namespace LYBT.UI.WPF.ViewModels.Base {
+    /// <summary>
+    /// Provides a paged list view model base.
+    /// </summary>
+    /// <typeparam name="TDto">Dto type displayed in the list.</typeparam>
+    public abstract class BaseListViewModel<TDto> : BindableBase {
+        /// <summary>Collection of items for current page.</summary>
+        public ObservableCollection<TDto> Items { get; } = new();
+
+        private int _pageIndex = 1;
+        /// <summary>Current page index (1-based).</summary>
+        public int PageIndex {
+            get => _pageIndex;
+            set => SetProperty(ref _pageIndex, value);
+        }
+
+        private int _pageSize = 20;
+        /// <summary>Number of items per page.</summary>
+        public int PageSize {
+            get => _pageSize;
+            set => SetProperty(ref _pageSize, value);
+        }
+
+        private int _totalCount;
+        /// <summary>Total item count.</summary>
+        public int TotalCount {
+            get => _totalCount;
+            set => SetProperty(ref _totalCount, value);
+        }
+
+        /// <summary>Command loading the current page.</summary>
+        public DelegateCommand LoadPageCommand { get; }
+
+        protected BaseListViewModel() {
+            LoadPageCommand = new DelegateCommand(async () => await LoadPageAsync());
+        }
+
+        /// <summary>
+        /// Loads items for the current page. Derived classes should override to
+        /// provide data retrieval logic.
+        /// </summary>
+        public virtual Task LoadPageAsync() => Task.CompletedTask;
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Base/BaseProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Base/BaseProfileViewModel.cs
@@ -1,0 +1,29 @@
+using Prism.Commands;
+using Prism.Mvvm;
+using LYBT.Common.Enums;
+
+namespace LYBT.UI.WPF.ViewModels.Base {
+    /// <summary>
+    /// Provides common properties for profile view models.
+    /// </summary>
+    public abstract class BaseProfileViewModel : BindableBase {
+        private ProfileMode _mode;
+        /// <summary>Current profile mode.</summary>
+        public ProfileMode Mode {
+            get => _mode;
+            set => SetProperty(ref _mode, value);
+        }
+
+        private bool _isEditable;
+        /// <summary>Indicates whether the profile can be edited.</summary>
+        public bool IsEditable {
+            get => _isEditable;
+            set => SetProperty(ref _isEditable, value);
+        }
+
+        /// <summary>Command for persisting changes.</summary>
+        public DelegateCommand? SaveCommand { get; protected set; }
+        /// <summary>Command for canceling editing.</summary>
+        public DelegateCommand? CancelCommand { get; protected set; }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -4,6 +4,7 @@ using LYBT.Module.Users.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.Services;
 using LYBT.UI.WPF.ViewModels.Main;
+using LYBT.UI.WPF.ViewModels.Base;
 using LYBT.Common.Helpers;
 using LYBT.Common.Models;
 using System.Collections.ObjectModel;
@@ -11,7 +12,7 @@ using System.Linq;
 using System.Windows;
 
 namespace LYBT.UI.WPF.ViewModels.Profile {
-    public class DoctorProfileViewModel : BindableBase, INavigationAware {
+    public class DoctorProfileViewModel : BaseProfileViewModel, INavigationAware {
         private readonly IDoctorService _doctorService;
         private readonly IAuthService _authService;
         private readonly IUserService _userService;
@@ -31,23 +32,6 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
         public string? ContactNumber { get => Doctor.ContactNumber; set { Doctor.ContactNumber = value; RaisePropertyChanged(); } }
 
-        private bool _isEditable;
-        public bool IsEditable {
-            get => _isEditable;
-            set => SetProperty(ref _isEditable, value);
-        }
-
-        private ProfileMode _mode;
-        /// <summary>
-        /// 当前视图模式
-        /// </summary>
-        public ProfileMode Mode {
-            get => _mode;
-            set => SetProperty(ref _mode, value);
-        }
-
-        public DelegateCommand SaveCommand { get; }
-        public DelegateCommand CancelCommand { get; }
 
         /// <summary>
         /// Optional action invoked when canceling editing. If not set,

--- a/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
@@ -5,14 +5,14 @@ using LYBT.Common.Helpers;
 using LYBT.Common.Models;
 using System.Collections.ObjectModel;
 using Prism.Commands;
-using Prism.Mvvm;
+using LYBT.UI.WPF.ViewModels.Base;
 using System;
 using System.Threading.Tasks;
 using System.Windows;
 using LYBT.UI.WPF.ViewModels.Main;
 
 namespace LYBT.UI.WPF.ViewModels.Profile {
-    public class PatientProfileViewModel : BindableBase {
+    public class PatientProfileViewModel : BaseProfileViewModel {
         private readonly IPatientService _patientService;
 
         private PatientDetailDto _patient = new();
@@ -28,24 +28,6 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             get => _editModeTitle;
             set => SetProperty(ref _editModeTitle, value);
         }
-
-        private bool _isEditable;
-        public bool IsEditable {
-            get => _isEditable;
-            set => SetProperty(ref _isEditable, value);
-        }
-
-        private ProfileMode _mode;
-        /// <summary>
-        /// 当前视图模式
-        /// </summary>
-        public ProfileMode Mode {
-            get => _mode;
-            set => SetProperty(ref _mode, value);
-        }
-
-        public DelegateCommand SaveCommand { get; }
-        public DelegateCommand CancelCommand { get; }
 
         public Action? CancelAction { get; set; }
 


### PR DESCRIPTION
## Summary
- add `BaseProfileViewModel` and `BaseListViewModel` for common behaviors
- use the base classes in doctor/patient profile and management view models
- adjust management logic to call `LoadPageAsync`

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6875e5c4ec9c8333a122b5affdb319f8