### PR TITLE
Update herbs routes

### DIFF
--- a/LYBT.UI.WPF/Apis/IHerbApi.cs
+++ b/LYBT.UI.WPF/Apis/IHerbApi.cs
@@ -9,32 +9,32 @@ using System.Threading.Tasks;
 
 namespace LYBT.UI.WPF.Apis {
     public interface IHerbApi {
-        [Get("/api/Herb")]
+        [Get("/api/herbs")]
         Task<List<HerbDto>> GetListAsync();
 
-        [Get("/api/Herb/{id}")]
+        [Get("/api/herbs/{id}")]
         Task<HerbDetailDto> GetByIdAsync(Guid id);
 
-        [Post("/api/Herb")]
+        [Post("/api/herbs")]
         Task<ApiSuccessResponse> AddAsync([Body] HerbCreateDto dto);
 
-        [Put("/api/Herb")]
+        [Put("/api/herbs")]
         Task<ApiSuccessResponse> UpdateAsync([Body] HerbEditDto dto);
 
-        [Delete("/api/Herb/{id}")]
+        [Delete("/api/herbs/{id}")]
         Task<ApiSuccessResponse> DeleteAsync(Guid id);
 
-        [Post("/api/Herb/import")]
+        [Post("/api/herbs/import")]
         Task<ApiSuccessResponse> ImportAsync([Body] List<HerbImportDto> dtos);
 
-        [Post("/api/Herb/export")]
+        [Post("/api/herbs/export")]
         Task<List<HerbDetailDto>> ExportAsync();
 
         [Multipart]
-        [Post("/api/Herb/importExcel")]
+        [Post("/api/herbs/importExcel")]
         Task<ImportCountResponse> ImportExcelAsync([AliasAs("file")] StreamPart file);
 
-        [Get("/api/Herb/exportExcel")]
+        [Get("/api/herbs/exportExcel")]
         Task<HttpContent> ExportExcelAsync();
     }
 }

--- a/LYBT.WebAPI/Controllers/HerbsController.cs
+++ b/LYBT.WebAPI/Controllers/HerbsController.cs
@@ -9,14 +9,14 @@ namespace LYBT.Module.Herbs.Controllers {
     /// 药材管理 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class HerbController : ControllerBase {
+    [Route("api/herbs")]
+    public class HerbsController : ControllerBase {
         private readonly IHerbService _herbService;
 
         /// <summary>
         /// 构造方法，注入药材服务
         /// </summary>
-        public HerbController(IHerbService herbService) {
+        public HerbsController(IHerbService herbService) {
             _herbService = herbService;
         }
 


### PR DESCRIPTION
## Summary
- rename HerbController to HerbsController
- use `/api/herbs` route for herbs API endpoints
- update Refit interface with plural routes

## Testing
- `dotnet test LYBTZYZS.sln`

------
https://chatgpt.com/codex/tasks/task_e_68771061a20883338e862bd3fe104ecd