### PR TITLE
Handle malformed Excel rows

### DIFF
--- a/LYBT.CommonUtils/CommonUtils.cs
+++ b/LYBT.CommonUtils/CommonUtils.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
@@ -18,24 +19,48 @@ public static class CommonUtils {
         var result = new List<HerbImportDto>();
         IWorkbook wb = new XSSFWorkbook(stream);
         var sheet = wb.GetSheetAt(0);
+
+        var header = sheet.GetRow(0);
+        int start = 0;
+        if (header?.GetCell(0)?.ToString()?.Trim()
+                .Equals("Id", StringComparison.OrdinalIgnoreCase) == true)
+            start = 1;
+
         for (int i = 1; i <= sheet.LastRowNum; i++) {
             var row = sheet.GetRow(i);
             if (row == null) continue;
-            if (row.Cells.All(c => c == null || string.IsNullOrWhiteSpace(c.ToString())))
-                continue;
+
+            bool empty = true;
+            for (int c = start; c < start + 11; c++) {
+                var cell = row.GetCell(c);
+                if (cell != null && !string.IsNullOrWhiteSpace(cell.ToString())) {
+                    empty = false;
+                    break;
+                }
+            }
+            if (empty) continue;
+
             var dto = new HerbImportDto {
-                Name = row.GetCell(0)?.ToString() ?? string.Empty,
-                Pinyin = row.GetCell(1)?.ToString(),
-                Origin = row.GetCell(2)?.ToString(),
-                Spec = row.GetCell(3)?.ToString(),
-                Unit = row.GetCell(4)?.ToString(),
-                Price = (decimal)(row.GetCell(5)?.NumericCellValue ?? 0),
-                Stock = (int)(row.GetCell(6)?.NumericCellValue ?? 0),
-                BatchNo = row.GetCell(7)?.ToString(),
-                ExpireDate = row.GetCell(8)?.DateCellValue,
-                Effect = row.GetCell(9)?.ToString(),
-                Remark = row.GetCell(10)?.ToString()
+                Name = row.GetCell(start)?.ToString() ?? string.Empty,
+                Pinyin = row.GetCell(start + 1)?.ToString(),
+                Origin = row.GetCell(start + 2)?.ToString(),
+                Spec = row.GetCell(start + 3)?.ToString(),
+                Unit = row.GetCell(start + 4)?.ToString()
             };
+
+            decimal.TryParse(row.GetCell(start + 5)?.ToString(), out var price);
+            dto.Price = price;
+            int.TryParse(row.GetCell(start + 6)?.ToString(), out var stock);
+            dto.Stock = stock;
+
+            dto.BatchNo = row.GetCell(start + 7)?.ToString();
+
+            if (DateTime.TryParse(row.GetCell(start + 8)?.ToString(), out var exp))
+                dto.ExpireDate = exp;
+
+            dto.Effect = row.GetCell(start + 9)?.ToString();
+            dto.Remark = row.GetCell(start + 10)?.ToString();
+
             result.Add(dto);
         }
         return result;

--- a/LYBT.Tests/Helpers/CommonUtilsTests.cs
+++ b/LYBT.Tests/Helpers/CommonUtilsTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
 using CommonUtil = LYBT.CommonUtils.CommonUtils;
 using LYBT.Module.Herbs.Dtos;
 using LYBT.Module.FormulaTemplates.Dtos;
@@ -35,5 +37,33 @@ public class CommonUtilsTests {
         Assert.Equal("test", list[0].Name);
         Assert.Single(list[0].Herbs);
         Assert.Equal("黄芩", list[0].Herbs[0].Name);
+    }
+
+    [Fact]
+    public void ReadHerbs_HandlesInvalidValuesAndIdColumn() {
+        IWorkbook wb = new XSSFWorkbook();
+        var sheet = wb.CreateSheet("herbs");
+        var header = sheet.CreateRow(0);
+        string[] heads = {"Id","Name","Pinyin","Origin","Spec","Unit","Price","Stock","BatchNo","ExpireDate","Effect","Remark"};
+        for (int i = 0; i < heads.Length; i++)
+            header.CreateCell(i).SetCellValue(heads[i]);
+        var row = sheet.CreateRow(1);
+        row.CreateCell(0).SetCellValue("1");
+        row.CreateCell(1).SetCellValue("甘草");
+        row.CreateCell(6).SetCellValue("bad");
+        row.CreateCell(7).SetCellValue("nope");
+        row.CreateCell(9).SetCellValue("unknown");
+        using var ms = new MemoryStream();
+        wb.Write(ms, true);
+        ms.Position = 0;
+
+        var list = CommonUtil.ReadHerbs(ms);
+
+        Assert.Single(list);
+        var dto = list[0];
+        Assert.Equal("甘草", dto.Name);
+        Assert.Equal(0, dto.Price);
+        Assert.Equal(0, dto.Stock);
+        Assert.Null(dto.ExpireDate);
     }
 }

--- a/LYBT.Tests/Services/HerbServiceTests.cs
+++ b/LYBT.Tests/Services/HerbServiceTests.cs
@@ -1,6 +1,9 @@
 using System;
 using AutoMapper;
 using System.Threading.Tasks;
+using System.IO;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
 using Moq;
 using Xunit;
 using LYBT.Module.Herbs.Services;
@@ -30,6 +33,36 @@ public class HerbServiceTests
         var result = await service.AddAsync(dto);
 
         Assert.True(result);
+        repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.HerbModel>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ImportFromExcelAsync_HandlesMalformedRows()
+    {
+        IWorkbook wb = new XSSFWorkbook();
+        var sheet = wb.CreateSheet("herbs");
+        var header = sheet.CreateRow(0);
+        string[] heads = {"Id","Name","Pinyin","Origin","Spec","Unit","Price","Stock","BatchNo","ExpireDate","Effect","Remark"};
+        for (int i = 0; i < heads.Length; i++)
+            header.CreateCell(i).SetCellValue(heads[i]);
+        var row = sheet.CreateRow(1);
+        row.CreateCell(0).SetCellValue("3");
+        row.CreateCell(1).SetCellValue("紫苏");
+        row.CreateCell(6).SetCellValue("abc");
+        row.CreateCell(7).SetCellValue("xyz");
+        row.CreateCell(9).SetCellValue("no");
+        using var ms = new MemoryStream();
+        wb.Write(ms, true);
+        ms.Position = 0;
+
+        var repo = new Mock<IHerbRepository>();
+        repo.Setup(r => r.AddAsync(It.IsAny<LYBT.Models.HerbModel>())).ReturnsAsync(true);
+        var mapper = CreateMapper();
+        var service = new HerbService(repo.Object, mapper);
+
+        var count = await service.ImportFromExcelAsync(ms);
+
+        Assert.Equal(1, count);
         repo.Verify(r => r.AddAsync(It.IsAny<LYBT.Models.HerbModel>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- safely parse numeric/date fields in `CommonUtils.ReadHerbs`
- detect optional `Id` column when importing herbs
- add regression tests for herb import parsing

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687710630b308333add6a872184cc41a