### PR TITLE
Use display name fields in Excel templates

### DIFF
--- a/LYBT.CommonUtils/CommonUtils.cs
+++ b/LYBT.CommonUtils/CommonUtils.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Net.NetworkInformation;
 using System.Text.RegularExpressions;
 using System.Text.Json;
+using System.Reflection;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
 using LYBT.Module.Herbs.Dtos;
@@ -15,6 +16,11 @@ namespace LYBT.CommonUtils;
 /// </summary>
 [Description("通用工具类")]
 public static class CommonUtils {
+    private static string GetDisplayName(Type type, string property) {
+        var prop = type.GetProperty(property);
+        var attr = prop?.GetCustomAttribute<DisplayNameAttribute>();
+        return attr?.DisplayName ?? property;
+    }
     public static List<HerbImportDto> ReadHerbs(Stream stream) {
         var result = new List<HerbImportDto>();
         IWorkbook wb = new XSSFWorkbook(stream);
@@ -22,8 +28,10 @@ public static class CommonUtils {
 
         var header = sheet.GetRow(0);
         int start = 0;
-        if (header?.GetCell(0)?.ToString()?.Trim()
-                .Equals("Id", StringComparison.OrdinalIgnoreCase) == true)
+        var first = header?.GetCell(0)?.ToString()?.Trim();
+        if (!string.IsNullOrEmpty(first) &&
+            (first.Equals("Id", StringComparison.OrdinalIgnoreCase) ||
+             first.Equals(GetDisplayName(typeof(HerbDetailDto), "Id"), StringComparison.OrdinalIgnoreCase)))
             start = 1;
 
         for (int i = 1; i <= sheet.LastRowNum; i++) {
@@ -70,9 +78,9 @@ public static class CommonUtils {
         IWorkbook wb = new XSSFWorkbook();
         var sheet = wb.CreateSheet("Herbs");
         var header = sheet.CreateRow(0);
-        string[] heads = {"Name","Pinyin","Origin","Spec","Unit","Price","Stock","BatchNo","ExpireDate","Effect","Remark"};
-        for (int i = 0; i < heads.Length; i++)
-            header.CreateCell(i).SetCellValue(heads[i]);
+        string[] props = {"Name","Pinyin","Origin","Spec","Unit","Price","Stock","BatchNo","ExpireDate","Effect","Remark"};
+        for (int i = 0; i < props.Length; i++)
+            header.CreateCell(i).SetCellValue(GetDisplayName(typeof(HerbDetailDto), props[i]));
         int r = 1;
         foreach (var h in data) {
             var row = sheet.CreateRow(r++);
@@ -119,9 +127,9 @@ public static class CommonUtils {
         IWorkbook wb = new XSSFWorkbook();
         var sheet = wb.CreateSheet("Templates");
         var header = sheet.CreateRow(0);
-        string[] heads = {"Name","Herbs","Remark"};
-        for(int i=0;i<heads.Length;i++)
-            header.CreateCell(i).SetCellValue(heads[i]);
+        string[] props = {"Name","Herbs","Remark"};
+        for(int i=0;i<props.Length;i++)
+            header.CreateCell(i).SetCellValue(GetDisplayName(typeof(FormulaTemplateDetailDto), props[i]));
         int r=1;
         foreach(var t in data) {
             var row = sheet.CreateRow(r++);

--- a/LYBT.Tests/Helpers/CommonUtilsTests.cs
+++ b/LYBT.Tests/Helpers/CommonUtilsTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.ComponentModel;
+using System.Reflection;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.UserModel;
 using CommonUtil = LYBT.CommonUtils.CommonUtils;
@@ -11,6 +13,11 @@ using Xunit;
 namespace LYBT.Tests.Helpers;
 
 public class CommonUtilsTests {
+    private static string GetDisplayName(Type type, string property) {
+        var prop = type.GetProperty(property);
+        var attr = prop?.GetCustomAttribute<DisplayNameAttribute>();
+        return attr?.DisplayName ?? property;
+    }
     [Fact]
     public void HerbRoundTrip() {
         var data = new List<HerbDetailDto> {
@@ -44,7 +51,20 @@ public class CommonUtilsTests {
         IWorkbook wb = new XSSFWorkbook();
         var sheet = wb.CreateSheet("herbs");
         var header = sheet.CreateRow(0);
-        string[] heads = {"Id","Name","Pinyin","Origin","Spec","Unit","Price","Stock","BatchNo","ExpireDate","Effect","Remark"};
+        string[] heads = {
+            "Id",
+            GetDisplayName(typeof(HerbDetailDto), "Name"),
+            GetDisplayName(typeof(HerbDetailDto), "Pinyin"),
+            GetDisplayName(typeof(HerbDetailDto), "Origin"),
+            GetDisplayName(typeof(HerbDetailDto), "Spec"),
+            GetDisplayName(typeof(HerbDetailDto), "Unit"),
+            GetDisplayName(typeof(HerbDetailDto), "Price"),
+            GetDisplayName(typeof(HerbDetailDto), "Stock"),
+            GetDisplayName(typeof(HerbDetailDto), "BatchNo"),
+            GetDisplayName(typeof(HerbDetailDto), "ExpireDate"),
+            GetDisplayName(typeof(HerbDetailDto), "Effect"),
+            GetDisplayName(typeof(HerbDetailDto), "Remark")
+        };
         for (int i = 0; i < heads.Length; i++)
             header.CreateCell(i).SetCellValue(heads[i]);
         var row = sheet.CreateRow(1);

--- a/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
@@ -101,7 +101,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         private async Task ExportAsync() {
             var dlg = new Microsoft.Win32.SaveFileDialog {
                 Filter = "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*",
-                FileName = "templates.xlsx"
+                FileName = "经典方.xlsx"
             };
             if (dlg.ShowDialog() == true) {
                 try {

--- a/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
@@ -130,7 +130,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         private async Task ExportAsync() {
             var dlg = new Microsoft.Win32.SaveFileDialog {
                 Filter = "Excel Files (*.xlsx)|*.xlsx|All Files (*.*)|*.*",
-                FileName = "herbs.xlsx"
+                FileName = "药材.xlsx"
             };
             if (dlg.ShowDialog() == true) {
                 try {

--- a/LYBT.WebAPI/Controllers/FormulaTemplatesController.cs
+++ b/LYBT.WebAPI/Controllers/FormulaTemplatesController.cs
@@ -100,7 +100,7 @@ namespace LYBT.Module.FormulaTemplates.Controllers {
         [HttpGet("exportExcel")]
         public async Task<FileContentResult> ExportExcel() {
             var bytes = await _service.ExportToExcelAsync();
-            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "templates.xlsx");
+            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "经典方.xlsx");
         }
     }
 }

--- a/LYBT.WebAPI/Controllers/HerbsController.cs
+++ b/LYBT.WebAPI/Controllers/HerbsController.cs
@@ -100,7 +100,7 @@ namespace LYBT.Module.Herbs.Controllers {
         [HttpGet("exportExcel")]
         public async Task<FileContentResult> ExportExcel() {
             var bytes = await _herbService.ExportToExcelAsync();
-            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "herbs.xlsx");
+            return File(bytes, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "药材.xlsx");
         }
     }
 }


### PR DESCRIPTION
## Summary
- derive Excel header names from `DisplayName` attributes
- use display name for exported Excel file names
- adjust tests for new headers

## Testing
- `DOTNET_ROLL_FORWARD=LatestMajor dotnet test LYBT.Tests/LYBT.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6877166cfb5c83339d84643396ff2df2