### PR TITLE
Fix MaterialDesignThemes path

### DIFF
--- a/LYBT.UI.WPF/App.xaml
+++ b/LYBT.UI.WPF/App.xaml
@@ -10,7 +10,8 @@
             <ResourceDictionary.MergedDictionaries>
                 <!-- MaterialDesign resource dictionaries -->
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <!-- Updated for MaterialDesignThemes v5 -->
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
             </ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
## Summary
- fix the `App.xaml` theme path to MaterialDesign2.Defaults

## Testing
- `dotnet test` *(fails: Microsoft.NETCore.App 8.0 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877257a60ac8333bda03a3c6beb1535