### PR TITLE
Fix WPF theme dictionary path

### DIFF
--- a/LYBT.UI.WPF/App.xaml
+++ b/LYBT.UI.WPF/App.xaml
@@ -3,17 +3,16 @@
                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:prism="http://prismlibrary.com/"
-                xmlns:local="clr-namespace:LYBT.UI.WPF.Converters">
+                xmlns:local="clr-namespace:LYBT.UI.WPF.Converters"
+                xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
     <!-- 注意：移除了 StartupUri，以避免启动两个窗口 -->
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <!-- MaterialDesign resource dictionaries -->
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
                 <!-- Updated for MaterialDesignThemes v5 -->
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
-                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <!-- 添加 BoolToVisibilityConverter 资源 -->


### PR DESCRIPTION
## Summary
- update `App.xaml` to use BundledTheme instead of missing accent dictionary

## Testing
- `dotnet build LYBTZYZS.sln -c Release` *(fails: The type or namespace name 'IAuthService' could not be found)*
- `dotnet test LYBTZYZS.sln` *(fails: .NET 8 runtime is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68772d83d8e083339fbf228f3d6c464d