### PR TITLE
Add reusable list control

### DIFF
--- a/LYBT.UI.WPF/Controls/CommonListView.xaml
+++ b/LYBT.UI.WPF/Controls/CommonListView.xaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="LYBT.UI.WPF.Controls.CommonListView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:controls="clr-namespace:LYBT.UI.WPF.Controls">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <TextBox Width="180" Margin="0,0,8,0"
+                     Text="{Binding SearchKeyword, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=PropertyChanged}"/>
+            <Button Content="查找" Margin="0,0,8,0"
+                    Command="{Binding SearchCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+            <ContentPresenter Content="{Binding ActionContent, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+        </StackPanel>
+        <DataGrid x:Name="PART_DataGrid" Grid.Row="1" Margin="0,0,8,0" IsReadOnly="True"
+                  ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                  SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"
+                  AutoGenerateColumns="False">
+        </DataGrid>
+        <Border Grid.Row="1" Background="#80000000"
+                Visibility="{Binding IsBusy, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="120" Height="4" />
+            </StackPanel>
+        </Border>
+        <controls:PagingBar Grid.Row="2" Margin="0,8,0,0"
+            Visibility="{Binding ShowPaging, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource BoolToVisibilityConverter}}"/>
+    </Grid>
+</UserControl>

--- a/LYBT.UI.WPF/Controls/CommonListView.xaml.cs
+++ b/LYBT.UI.WPF/Controls/CommonListView.xaml.cs
@@ -1,0 +1,84 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+
+namespace LYBT.UI.WPF.Controls {
+    /// <summary>
+    /// 通用列表控件，包含查询、数据表格与分页条。
+    /// </summary>
+    [ContentProperty(nameof(Columns))]
+    public partial class CommonListView : UserControl {
+        public CommonListView() {
+            Columns = new ObservableCollection<DataGridColumn>();
+            InitializeComponent();
+            Loaded += (_, __) => ApplyColumns();
+        }
+
+        private void ApplyColumns() {
+            PART_DataGrid.Columns.Clear();
+            foreach (var c in Columns)
+                PART_DataGrid.Columns.Add(c);
+        }
+
+        public ObservableCollection<DataGridColumn> Columns { get; }
+
+        public object? ActionContent {
+            get => GetValue(ActionContentProperty);
+            set => SetValue(ActionContentProperty, value);
+        }
+
+        public static readonly DependencyProperty ActionContentProperty =
+            DependencyProperty.Register(nameof(ActionContent), typeof(object), typeof(CommonListView));
+
+        public object? ItemsSource {
+            get => GetValue(ItemsSourceProperty);
+            set => SetValue(ItemsSourceProperty, value);
+        }
+
+        public static readonly DependencyProperty ItemsSourceProperty =
+            DependencyProperty.Register(nameof(ItemsSource), typeof(object), typeof(CommonListView));
+
+        public object? SelectedItem {
+            get => GetValue(SelectedItemProperty);
+            set => SetValue(SelectedItemProperty, value);
+        }
+
+        public static readonly DependencyProperty SelectedItemProperty =
+            DependencyProperty.Register(nameof(SelectedItem), typeof(object), typeof(CommonListView),
+                new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public string? SearchKeyword {
+            get => (string?)GetValue(SearchKeywordProperty);
+            set => SetValue(SearchKeywordProperty, value);
+        }
+
+        public static readonly DependencyProperty SearchKeywordProperty =
+            DependencyProperty.Register(nameof(SearchKeyword), typeof(string), typeof(CommonListView));
+
+        public System.Windows.Input.ICommand? SearchCommand {
+            get => (System.Windows.Input.ICommand?)GetValue(SearchCommandProperty);
+            set => SetValue(SearchCommandProperty, value);
+        }
+
+        public static readonly DependencyProperty SearchCommandProperty =
+            DependencyProperty.Register(nameof(SearchCommand), typeof(System.Windows.Input.ICommand), typeof(CommonListView));
+
+        public bool IsBusy {
+            get => (bool)GetValue(IsBusyProperty);
+            set => SetValue(IsBusyProperty, value);
+        }
+
+        public static readonly DependencyProperty IsBusyProperty =
+            DependencyProperty.Register(nameof(IsBusy), typeof(bool), typeof(CommonListView));
+
+        public bool ShowPaging {
+            get => (bool)GetValue(ShowPagingProperty);
+            set => SetValue(ShowPagingProperty, value);
+        }
+
+        public static readonly DependencyProperty ShowPagingProperty =
+            DependencyProperty.Register(nameof(ShowPaging), typeof(bool), typeof(CommonListView), new PropertyMetadata(true));
+    }
+}

--- a/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
@@ -2,51 +2,42 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-               xmlns:main="clr-namespace:LYBT.UI.WPF.Views.Profile"
-               prism:ViewModelLocator.AutoWireViewModel="True">
+             xmlns:main="clr-namespace:LYBT.UI.WPF.Views.Profile"
+             xmlns:controls="clr-namespace:LYBT.UI.WPF.Controls"
+             prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-        <!-- 操作区 -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="查找" Command="{Binding SearchCommand}" Margin="0,0,8,0"/>
-            <Button Content="新增药材" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
-            <Button Content="编辑药材" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="删除药材" Command="{Binding DeleteCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="批量导入药材" Command="{Binding ImportCommand}" Margin="0,0,8,0"/>
-            <Button Content="批量导出药材" Command="{Binding ExportCommand}"/>
-        </StackPanel>
-        <!-- 内容区 -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.2*"/>
-                <ColumnDefinition Width="1.8*"/>
-            </Grid.ColumnDefinitions>
-            <!-- 左侧列表 -->
-            <Grid Grid.Column="0">
-                <DataGrid ItemsSource="{Binding Herbs}" SelectedItem="{Binding SelectedHerb, Mode=TwoWay}" AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
-                        <DataGridTextColumn Header="拼音码" Binding="{Binding Pinyin}" Width="*"/>
-                        <DataGridTextColumn Header="产地" Binding="{Binding Origin}" Width="*"/>
-                        <DataGridTextColumn Header="规格" Binding="{Binding Spec}" Width="*"/>
-                        <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="*"/>
-                        <DataGridTextColumn Header="单价" Binding="{Binding Price}" Width="*"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <Border Background="#80000000" Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
-                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <ProgressBar IsIndeterminate="True" Width="120" Height="4" />
-                    </StackPanel>
-                </Border>
-            </Grid>
-            <!-- 右侧详情区 -->
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-                <main:HerbProfileView DataContext="{Binding HerbProfileViewModel}" />
-            </Border>
-        </Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2.2*"/>
+            <ColumnDefinition Width="1.8*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0" ShowPaging="False"
+                                 ItemsSource="{Binding Herbs}"
+                                 SelectedItem="{Binding SelectedHerb, Mode=TwoWay}"
+                                 SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                                 SearchCommand="{Binding SearchCommand}"
+                                 IsBusy="{Binding IsBusy}">
+            <controls:CommonListView.ActionContent>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="新增药材" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+                    <Button Content="编辑药材" Command="{Binding EditCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="删除药材" Command="{Binding DeleteCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="批量导入药材" Command="{Binding ImportCommand}" Margin="0,0,8,0"/>
+                    <Button Content="批量导出药材" Command="{Binding ExportCommand}"/>
+                </StackPanel>
+            </controls:CommonListView.ActionContent>
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="拼音码" Binding="{Binding Pinyin}" Width="*"/>
+                <DataGridTextColumn Header="产地" Binding="{Binding Origin}" Width="*"/>
+                <DataGridTextColumn Header="规格" Binding="{Binding Spec}" Width="*"/>
+                <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="*"/>
+                <DataGridTextColumn Header="单价" Binding="{Binding Price}" Width="*"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <main:HerbProfileView DataContext="{Binding HerbProfileViewModel}" />
+        </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -1,95 +1,75 @@
-﻿<UserControl x:Class="LYBT.UI.WPF.Views.Admin.UserManagementView"
+<UserControl x:Class="LYBT.UI.WPF.Views.Admin.UserManagementView"
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
               xmlns:prism="http://prismlibrary.com/"
-              xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
               xmlns:helpers="clr-namespace:LYBT.UI.WPF.Helpers"
-               xmlns:controls="clr-namespace:LYBT.UI.WPF.Controls"
-               prism:ViewModelLocator.AutoWireViewModel="True">
+              xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
+              xmlns:controls="clr-namespace:LYBT.UI.WPF.Controls"
+              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <!-- 操作区 -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="查找" Command="{Binding SearchCommand}" Margin="0,0,8,0"/>
-            <Button Content="新增用户" Command="{Binding AddUserCommand}" Margin="0,0,8,0"/>
-            <Button Content="编辑用户" Command="{Binding EditUserCommand}" Margin="0,0,8,0"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="禁用用户" Command="{Binding DisableUserCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
-                    Margin="0,0,8,0"/>
-            <Button Content="启用用户" Command="{Binding EnableUserCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
-                    Margin="0,0,8,0"/>
-            <Button Content="重置密码" Command="{Binding ResetPasswordCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="创建医生档案"
-                    Command="{Binding CreateDoctorProfileCommand}"
-                    IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"
-                    Margin="0,0,8,0"/>
-        </StackPanel>
-        <!-- 内容区 -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.2*"/>
-                <ColumnDefinition Width="1.8*"/>
-            </Grid.ColumnDefinitions>
-            <!-- 左侧列表区 -->
-            <Grid Grid.Column="0">
-                <DataGrid ItemsSource="{Binding Users}" SelectedItem="{Binding SelectedUser, Mode=TwoWay}"
-                          AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="账号" Binding="{Binding UserName}" Width="*"/>
-                        <DataGridTextColumn Header="姓名" Binding="{Binding RealName}" Width="*"/>
-                        <DataGridTextColumn Header="角色" Binding="{Binding RolesText}" Width="*"/>
-                        <DataGridCheckBoxColumn Header="启用" Binding="{Binding IsActive}" Width="60"/>
-                        <DataGridTextColumn Header="最近登录" Binding="{Binding LastLoginTime}" Width="130"/>
-                        <DataGridTextColumn Header="邮箱" Binding="{Binding Email}" Width="110"/>
-                        <DataGridTextColumn Header="手机号" Binding="{Binding PhoneNumber}" Width="90"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <Border Background="#80000000"
-                        Visibility="{Binding IsBusy, Converter={StaticResource BoolToVisibilityConverter}}">
-                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                        <ProgressBar IsIndeterminate="True" Width="120" Height="4" />
-                    </StackPanel>
-                </Border>
-            </Grid>
-            <!-- 右侧详情区 -->
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1" IsEnabled="{Binding IsEditable}">
-                <StackPanel>
-                    <TextBlock Text="{Binding EditModeTitle}" FontWeight="Bold" FontSize="17" Margin="0,0,0,16"/>
-                    <TextBlock Text="账号" />
-                    <TextBox Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
-                    <TextBlock Text="姓名" />
-                    <TextBox Text="{Binding EditingUser.RealName}" Margin="0,0,0,8"/>
-                    <TextBlock Text="角色" />
-                    <ListBox x:Name="RolesListBox"
-                             ItemsSource="{Binding RoleList}"
-                             SelectionMode="Multiple"
-                             Margin="0,0,0,8"
-                             helpers:ListBoxExtensions.BindableSelectedItems="{Binding EditingUser.Roles}">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <CheckBox Content="{Binding Converter={StaticResource EnumDescriptionConverter}}"
-                                          IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                    <TextBlock Text="邮箱" />
-                    <TextBox Text="{Binding EditingUser.Email}" Margin="0,0,0,8"/>
-                    <TextBlock Text="手机号" />
-                    <TextBox Text="{Binding EditingUser.PhoneNumber}" Margin="0,0,0,8"/>
-                    <CheckBox Content="启用" IsChecked="{Binding EditingUser.IsActive}" Margin="0,0,0,10"/>
-                    <Button Content="保存" Command="{Binding SaveUserCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2.2*"/>
+            <ColumnDefinition Width="1.8*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0"
+                                 ItemsSource="{Binding Users}"
+                                 SelectedItem="{Binding SelectedUser, Mode=TwoWay}"
+                                 SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                                 SearchCommand="{Binding SearchCommand}"
+                                 IsBusy="{Binding IsBusy}">
+            <controls:CommonListView.ActionContent>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="新增用户" Command="{Binding AddUserCommand}" Margin="0,0,8,0"/>
+                    <Button Content="编辑用户" Command="{Binding EditUserCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="禁用用户" Command="{Binding DisableUserCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="启用用户" Command="{Binding EnableUserCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="重置密码" Command="{Binding ResetPasswordCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="创建医生档案" Command="{Binding CreateDoctorProfileCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedUser, Converter={StaticResource NullToBoolConverter}}"/>
                 </StackPanel>
-            </Border>
-        </Grid>
-        <controls:PagingBar Grid.Row="2" Margin="0,8,0,0" />
+            </controls:CommonListView.ActionContent>
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="账号" Binding="{Binding UserName}" Width="*"/>
+                <DataGridTextColumn Header="姓名" Binding="{Binding RealName}" Width="*"/>
+                <DataGridTextColumn Header="角色" Binding="{Binding RolesText}" Width="*"/>
+                <DataGridCheckBoxColumn Header="启用" Binding="{Binding IsActive}" Width="60"/>
+                <DataGridTextColumn Header="最近登录" Binding="{Binding LastLoginTime}" Width="130"/>
+                <DataGridTextColumn Header="邮箱" Binding="{Binding Email}" Width="110"/>
+                <DataGridTextColumn Header="手机号" Binding="{Binding PhoneNumber}" Width="90"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1" IsEnabled="{Binding IsEditable}">
+            <StackPanel>
+                <TextBlock Text="{Binding EditModeTitle}" FontWeight="Bold" FontSize="17" Margin="0,0,0,16"/>
+                <TextBlock Text="账号" />
+                <TextBox Text="{Binding EditingUser.UserName, UpdateSourceTrigger=PropertyChanged}" Margin="0,0,0,8"/>
+                <TextBlock Text="姓名" />
+                <TextBox Text="{Binding EditingUser.RealName}" Margin="0,0,0,8"/>
+                <TextBlock Text="角色" />
+                <ListBox x:Name="RolesListBox"
+                         ItemsSource="{Binding RoleList}"
+                         SelectionMode="Multiple"
+                         Margin="0,0,0,8"
+                         helpers:ListBoxExtensions.BindableSelectedItems="{Binding EditingUser.Roles}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Content="{Binding Converter={StaticResource EnumDescriptionConverter}}"
+                                      IsChecked="{Binding RelativeSource={RelativeSource AncestorType=ListBoxItem}, Path=IsSelected, Mode=TwoWay}"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <TextBlock Text="邮箱" />
+                <TextBox Text="{Binding EditingUser.Email}" Margin="0,0,0,8"/>
+                <TextBlock Text="手机号" />
+                <TextBox Text="{Binding EditingUser.PhoneNumber}" Margin="0,0,0,8"/>
+                <CheckBox Content="启用" IsChecked="{Binding EditingUser.IsActive}" Margin="0,0,0,10"/>
+                <Button Content="保存" Command="{Binding SaveUserCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- create `CommonListView` user control for searching, displaying and paging lists
- integrate `CommonListView` into user management and herb management views

## Testing
- `dotnet restore LYBT.UI.WPF/LYBT.UI.WPF.csproj`
- `dotnet build --no-restore LYBT.UI.WPF/LYBT.UI.WPF.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68773ef796908333a75e7eec34667978