### PR TITLE
Enable herb list pagination and fix cancel issue

### DIFF
--- a/LYBT.Models/Herbs/Dtos/HerbPagedQueryDto.cs
+++ b/LYBT.Models/Herbs/Dtos/HerbPagedQueryDto.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+
+namespace LYBT.Module.Herbs.Dtos {
+    /// <summary>
+    /// 药材分页查询参数
+    /// </summary>
+    public class HerbPagedQueryDto {
+        /// <summary>关键词（名称或拼音）</summary>
+        [DisplayName("关键词")]
+        public string Keyword { get; set; } = string.Empty;
+
+        /// <summary>页码（从1开始）</summary>
+        [DisplayName("页码")]
+        public int Page { get; set; } = 1;
+
+        /// <summary>每页数量</summary>
+        [DisplayName("每页数量")]
+        public int PageSize { get; set; } = 20;
+    }
+}

--- a/LYBT.Module.Herbs/Interfaces/IHerbRepository.cs
+++ b/LYBT.Module.Herbs/Interfaces/IHerbRepository.cs
@@ -36,5 +36,10 @@ namespace LYBT.Module.Herbs.Interfaces {
         /// 批量新增药材
         /// </summary>
         Task<bool> AddRangeAsync(List<HerbModel> herbs);
+
+        /// <summary>
+        /// 分页查询药材
+        /// </summary>
+        Task<(List<HerbModel> list, int total)> GetPagedAsync(string? keyword, int page, int pageSize);
     }
 }

--- a/LYBT.Module.Herbs/Interfaces/IHerbService.cs
+++ b/LYBT.Module.Herbs/Interfaces/IHerbService.cs
@@ -1,5 +1,6 @@
 using System.IO;
-﻿using LYBT.Module.Herbs.Dtos;
+using LYBT.Module.Herbs.Dtos;
+using LYBT.Common.Models;
 
 namespace LYBT.Module.Herbs.Interfaces {
 
@@ -17,6 +18,11 @@ namespace LYBT.Module.Herbs.Interfaces {
         /// 获取药材列表
         /// </summary>
         Task<List<HerbDto>> GetListAsync();
+
+        /// <summary>
+        /// 分页查询药材
+        /// </summary>
+        Task<PagedResultDto<HerbDto>> GetPagedAsync(HerbPagedQueryDto query);
 
         /// <summary>
         /// 新增药材

--- a/LYBT.Module.Herbs/Repositories/HerbRepository.cs
+++ b/LYBT.Module.Herbs/Repositories/HerbRepository.cs
@@ -1,6 +1,8 @@
 ﻿using LYBT.Infrastructure;
 using LYBT.Models;
 using LYBT.Module.Herbs.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace LYBT.Module.Herbs.Repositories {
 
@@ -61,6 +63,19 @@ namespace LYBT.Module.Herbs.Repositories {
         public async Task<bool> AddRangeAsync(List<HerbModel> herbs) {
             await _appDbContext.Herbs.AddRangeAsync(herbs);
             return await _appDbContext.SaveChangesAsync() > 0;
+        }
+
+        public async Task<(List<HerbModel> list, int total)> GetPagedAsync(string? keyword, int page, int pageSize) {
+            var query = _appDbContext.Herbs.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(keyword)) {
+                query = query.Where(h => h.Name.Contains(keyword) || (h.Pinyin != null && h.Pinyin.Contains(keyword)));
+            }
+            int total = await query.CountAsync();
+            var list = await query.OrderByDescending(h => h.Name)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+            return (list, total);
         }
     }
 }

--- a/LYBT.Module.Herbs/Services/HerbService.cs
+++ b/LYBT.Module.Herbs/Services/HerbService.cs
@@ -3,6 +3,7 @@ using CommonUtil = LYBT.CommonUtils.CommonUtils;
 using LYBT.Models;
 using LYBT.Module.Herbs.Dtos;
 using LYBT.Module.Herbs.Interfaces;
+using LYBT.Common.Models;
 
 namespace LYBT.Module.Herbs.Services {
 
@@ -35,6 +36,14 @@ namespace LYBT.Module.Herbs.Services {
         public async Task<List<HerbDto>> GetListAsync() {
             var list = await _repository.GetListAsync();
             return _mapper.Map<List<HerbDto>>(list);
+        }
+
+        public async Task<PagedResultDto<HerbDto>> GetPagedAsync(HerbPagedQueryDto query) {
+            var (models, total) = await _repository.GetPagedAsync(query.Keyword, query.Page, query.PageSize);
+            return new PagedResultDto<HerbDto> {
+                TotalCount = total,
+                Items = _mapper.Map<List<HerbDto>>(models)
+            };
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/Apis/IHerbApi.cs
+++ b/LYBT.UI.WPF/Apis/IHerbApi.cs
@@ -12,6 +12,9 @@ namespace LYBT.UI.WPF.Apis {
         [Get("/api/herbs")]
         Task<List<HerbDto>> GetListAsync();
 
+        [Post("/api/herbs/paged")]
+        Task<PagedResultDto<HerbDto>> GetPagedAsync([Body] HerbPagedQueryDto query);
+
         [Get("/api/herbs/{id}")]
         Task<HerbDetailDto> GetByIdAsync(Guid id);
 

--- a/LYBT.UI.WPF/Interfaces/IHerbService.cs
+++ b/LYBT.UI.WPF/Interfaces/IHerbService.cs
@@ -1,4 +1,5 @@
 using LYBT.Module.Herbs.Dtos;
+using LYBT.Common.Models;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 namespace LYBT.UI.WPF.Interfaces {
     public interface IHerbService {
         Task<IList<HerbDto>> GetListAsync();
+        Task<PagedResultDto<HerbDto>> GetPagedAsync(HerbPagedQueryDto query);
         Task<HerbDetailDto?> GetByIdAsync(Guid id);
         Task<bool> AddAsync(HerbDetailDto dto);
         Task<bool> UpdateAsync(HerbDetailDto dto);

--- a/LYBT.UI.WPF/Services/HerbService.cs
+++ b/LYBT.UI.WPF/Services/HerbService.cs
@@ -1,6 +1,7 @@
 using LYBT.Module.Herbs.Dtos;
 using LYBT.UI.WPF.Apis;
 using LYBT.UI.WPF.Interfaces;
+using LYBT.Common.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,6 +24,10 @@ namespace LYBT.UI.WPF.Services {
         /// </summary>
         public async Task<IList<HerbDto>> GetListAsync() {
             return await _api.GetListAsync();
+        }
+
+        public async Task<PagedResultDto<HerbDto>> GetPagedAsync(HerbPagedQueryDto query) {
+            return await _api.GetPagedAsync(query);
         }
 
         /// <summary>

--- a/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
@@ -1,30 +1,23 @@
+using LYBT.Common.Enums;
+using LYBT.Common.Models;
 using LYBT.Module.Herbs.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.ViewModels.Profile;
-using LYBT.Common.Enums;
+using LYBT.UI.WPF.ViewModels.Base;
 using Prism.Commands;
-using Prism.Mvvm;
 using System;
 using System.Collections.ObjectModel;
-using System.Collections.Generic;
-using System.Linq;
-using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.Win32;
 
 namespace LYBT.UI.WPF.ViewModels.Admin {
-    public class HerbManagementViewModel : BindableBase {
+    /// <summary>
+    /// 药材管理视图模型，支持分页
+    /// </summary>
+    public class HerbManagementViewModel : BaseListViewModel<HerbDto> {
         private readonly IHerbService _herbService;
-        private IList<HerbDto> _allHerbs = new List<HerbDto>();
-        public ObservableCollection<HerbDto> Herbs { get; } = new();
 
-        private bool _isBusy;
-        public bool IsBusy
-        {
-            get => _isBusy;
-            set => SetProperty(ref _isBusy, value);
-        }
+        public ObservableCollection<HerbDto> Herbs => Items;
 
         private HerbDto? _selectedHerb;
         public HerbDto? SelectedHerb {
@@ -52,40 +45,23 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         public HerbManagementViewModel(IHerbService herbService, HerbProfileViewModel profileViewModel) {
             _herbService = herbService;
             HerbProfileViewModel = profileViewModel;
-            SearchCommand = new DelegateCommand(Search);
+            SearchCommand = new DelegateCommand(async () => await LoadPageAsync(1));
             AddCommand = new DelegateCommand(Add);
             EditCommand = new DelegateCommand(Edit, () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
             DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
             ImportCommand = new DelegateCommand(async () => await ImportAsync());
             ExportCommand = new DelegateCommand(async () => await ExportAsync());
-            _ = LoadAsync();
+            _ = LoadPageAsync();
         }
 
-        private async Task LoadAsync() {
-            IsBusy = true;
-            try {
-                var list = await _herbService.GetListAsync();
-                _allHerbs = list;
-                ApplyFilter();
-            }
-            finally {
-                IsBusy = false;
-            }
-        }
-
-        private void Search() => ApplyFilter();
-
-        private void ApplyFilter() {
-            Herbs.Clear();
-            foreach (var item in _allHerbs.Where(h => string.IsNullOrWhiteSpace(SearchKeyword)
-                || (h.Name?.Contains(SearchKeyword, StringComparison.OrdinalIgnoreCase) ?? false)
-                || (h.Pinyin?.Contains(SearchKeyword, StringComparison.OrdinalIgnoreCase) ?? false)))
-                Herbs.Add(item);
+        protected override async Task<PagedResultDto<HerbDto>> GetPagedAsync(int page, int pageSize) {
+            var query = new HerbPagedQueryDto { Keyword = SearchKeyword, Page = page, PageSize = pageSize };
+            return await _herbService.GetPagedAsync(query);
         }
 
         private void Add() {
             HerbProfileViewModel.CancelAction = async () => {
-                await LoadAsync();
+                await LoadPageAsync(CurrentPage);
                 await HerbProfileViewModel.LoadAsync(SelectedHerb?.Id, ProfileMode.View);
             };
             HerbProfileViewModel.LoadAsync(null, ProfileMode.Create);
@@ -93,11 +69,12 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
 
         private void Edit() {
             if (SelectedHerb != null) {
+                var id = SelectedHerb.Id;
                 HerbProfileViewModel.CancelAction = async () => {
-                    await LoadAsync();
-                    await HerbProfileViewModel.LoadAsync(SelectedHerb.Id, ProfileMode.View);
+                    await LoadPageAsync(CurrentPage);
+                    await HerbProfileViewModel.LoadAsync(id, ProfileMode.View);
                 };
-                HerbProfileViewModel.LoadAsync(SelectedHerb.Id, ProfileMode.Edit);
+                HerbProfileViewModel.LoadAsync(id, ProfileMode.Edit);
             }
         }
 
@@ -108,7 +85,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 var success = await _herbService.DeleteAsync(SelectedHerb.Id);
                 if (!success)
                     MessageBox.Show("删除失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
-                await LoadAsync();
+                await LoadPageAsync(CurrentPage);
             }
         }
 
@@ -120,7 +97,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                 try {
                     var count = await _herbService.ImportFromExcelAsync(dlg.FileName);
                     MessageBox.Show($"成功导入 {count} 条记录", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
-                    await LoadAsync();
+                    await LoadPageAsync(CurrentPage);
                 } catch (Exception ex) {
                     MessageBox.Show($"导入失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
                 }

--- a/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
@@ -10,7 +10,7 @@
             <ColumnDefinition Width="2.2*"/>
             <ColumnDefinition Width="1.8*"/>
         </Grid.ColumnDefinitions>
-        <controls:CommonListView Grid.Column="0" ShowPaging="False"
+        <controls:CommonListView Grid.Column="0" ShowPaging="True"
                                  ItemsSource="{Binding Herbs}"
                                  SelectedItem="{Binding SelectedHerb, Mode=TwoWay}"
                                  SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"

--- a/LYBT.WebAPI/Controllers/HerbsController.cs
+++ b/LYBT.WebAPI/Controllers/HerbsController.cs
@@ -2,6 +2,7 @@
 using LYBT.Module.Herbs.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using LYBT.Common.Models;
 
 namespace LYBT.Module.Herbs.Controllers {
 
@@ -27,6 +28,12 @@ namespace LYBT.Module.Herbs.Controllers {
         public async Task<ActionResult<List<HerbDto>>> GetList() {
             var list = await _herbService.GetListAsync();
             return Ok(list);
+        }
+
+        [HttpPost("paged")]
+        public async Task<ActionResult<PagedResultDto<HerbDto>>> GetPaged([FromBody] HerbPagedQueryDto query) {
+            var result = await _herbService.GetPagedAsync(query);
+            return Ok(result);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add `HerbPagedQueryDto` for herb paging queries
- implement paging methods in herb repository, service and API
- update WPF services and view model to support pagination
- fix cancel edit null reference in `HerbManagementViewModel`
- show paging bar on herb list

## Testing
- `dotnet test` *(fails: Microsoft.NETCore.App 8.0.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877bd59b7a483339208382d232581e5