### PR TITLE
Add WPF PageManagerControl

### DIFF
--- a/LYBT.WPFControls/Controls/PageManagerControl.xaml
+++ b/LYBT.WPFControls/Controls/PageManagerControl.xaml
@@ -1,0 +1,22 @@
+<UserControl x:Class="LYBT.WPFControls.PageManagerControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="root">
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
+        <Button Content="首页" Command="{Binding FirstPageCommand, ElementName=root}" Margin="0,0,4,0" />
+        <Button Content="上一页" Command="{Binding PrevPageCommand, ElementName=root}" Margin="0,0,4,0" />
+        <Button Content="下一页" Command="{Binding NextPageCommand, ElementName=root}" Margin="0,0,4,0" />
+        <Button Content="末页" Command="{Binding LastPageCommand, ElementName=root}" Margin="0,0,8,0" />
+        <TextBlock Text="页码:" VerticalAlignment="Center" />
+        <TextBox x:Name="PART_PageBox" Width="40" Margin="2,0" VerticalAlignment="Center"
+                 Text="{Binding PageIndex, ElementName=root, Mode=TwoWay, UpdateSourceTrigger=Explicit}"
+                 KeyDown="PageBox_KeyDown" />
+        <TextBlock Text="/" VerticalAlignment="Center" />
+        <TextBlock Text="{Binding TotalPages, ElementName=root}" Margin="2,0,8,0" VerticalAlignment="Center" />
+        <TextBlock Text="每页:" VerticalAlignment="Center" />
+        <ComboBox Width="60" Margin="2,0,8,0"
+                  ItemsSource="{Binding PageSizeOptions, ElementName=root}"
+                  SelectedItem="{Binding PageSize, ElementName=root, Mode=TwoWay}" />
+        <TextBlock Text="{Binding RangeText, ElementName=root}" VerticalAlignment="Center" />
+    </StackPanel>
+</UserControl>

--- a/LYBT.WPFControls/Controls/PageManagerControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/PageManagerControl.xaml.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace LYBT.WPFControls {
+    /// <summary>
+    /// Paging control supporting MVVM binding.
+    /// </summary>
+    public partial class PageManagerControl : UserControl {
+        public PageManagerControl() {
+            InitializeComponent();
+            FirstPageCommand = new SimpleCommand(() => PageIndex = 1, () => PageIndex > 1);
+            PrevPageCommand = new SimpleCommand(() => PageIndex -= 1, () => PageIndex > 1);
+            NextPageCommand = new SimpleCommand(() => PageIndex += 1, () => PageIndex < TotalPages);
+            LastPageCommand = new SimpleCommand(() => PageIndex = TotalPages, () => PageIndex < TotalPages);
+        }
+
+        public event EventHandler? PagingChanged;
+
+        public ICommand FirstPageCommand { get; }
+        public ICommand PrevPageCommand { get; }
+        public ICommand NextPageCommand { get; }
+        public ICommand LastPageCommand { get; }
+
+        public IEnumerable<int> PageSizeOptions { get; } = new[] { 5, 10, 20, 50, 100 };
+
+        public int PageIndex {
+            get => (int)GetValue(PageIndexProperty);
+            set => SetValue(PageIndexProperty, value);
+        }
+
+        public static readonly DependencyProperty PageIndexProperty =
+            DependencyProperty.Register(
+                nameof(PageIndex), typeof(int), typeof(PageManagerControl),
+                new FrameworkPropertyMetadata(1, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPagingPropertyChanged));
+
+        public int PageSize {
+            get => (int)GetValue(PageSizeProperty);
+            set => SetValue(PageSizeProperty, value);
+        }
+
+        public static readonly DependencyProperty PageSizeProperty =
+            DependencyProperty.Register(
+                nameof(PageSize), typeof(int), typeof(PageManagerControl),
+                new FrameworkPropertyMetadata(10, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPagingPropertyChanged));
+
+        public int TotalCount {
+            get => (int)GetValue(TotalCountProperty);
+            set => SetValue(TotalCountProperty, value);
+        }
+
+        public static readonly DependencyProperty TotalCountProperty =
+            DependencyProperty.Register(
+                nameof(TotalCount), typeof(int), typeof(PageManagerControl),
+                new FrameworkPropertyMetadata(0, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnPagingPropertyChanged));
+
+        public int TotalPages => PageSize <= 0 ? 0 : (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+        public string RangeText {
+            get {
+                if (TotalCount == 0) return "第 0-0 条，共 0 条";
+                var start = (PageIndex - 1) * PageSize + 1;
+                var end = Math.Min(PageIndex * PageSize, TotalCount);
+                return $"第 {start}-{end} 条，共 {TotalCount} 条";
+            }
+        }
+
+        private static void OnPagingPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is PageManagerControl c) {
+                c.CommandManagerInvalidate();
+                c.PagingChanged?.Invoke(c, EventArgs.Empty);
+            }
+        }
+
+        private void CommandManagerInvalidate() => CommandManager.InvalidateRequerySuggested();
+
+        private void PageBox_KeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Enter) {
+                var expr = ((TextBox)sender).GetBindingExpression(TextBox.TextProperty);
+                expr?.UpdateSource();
+            }
+        }
+
+        private class SimpleCommand : ICommand {
+            private readonly Action _execute;
+            private readonly Func<bool> _can;
+            public SimpleCommand(Action execute, Func<bool> can) { _execute = execute; _can = can; }
+            public bool CanExecute(object? parameter) => _can();
+            public void Execute(object? parameter) => _execute();
+            public event EventHandler? CanExecuteChanged {
+                add => CommandManager.RequerySuggested += value;
+                remove => CommandManager.RequerySuggested -= value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add PageManagerControl WPF UserControl with page navigation commands
- expose PageIndex, PageSize and TotalCount via dependency properties
- notify external viewmodels through PagingChanged event

## Testing
- `dotnet build LYBT.WPFControls/LYBT.WPFControls.csproj -c Release -v minimal`
- `dotnet test -v minimal` *(fails: Microsoft.NETCore.App version 8.0.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877c3178fe48333834b3dfbb00b0afd