### PR TITLE
统一管理模块显示并修复搜索功能

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/DoctorManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/DoctorManagementView.xaml
@@ -27,66 +27,56 @@
         </ObjectDataProvider>
     </UserControl.Resources>
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <!-- 操作区 -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="查找" Command="{Binding SearchCommand}" Margin="0,0,8,0"/>
-            <Button Content="修改医生档案" Command="{Binding EditDoctorCommand}" Margin="0,0,8,0"
-                    IsEnabled="{Binding SelectedDoctor, Converter={StaticResource NullToBoolConverter}}"/>
-        </StackPanel>
-        <!-- 内容区 -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.2*"/>
-                <ColumnDefinition Width="1.8*"/>
-            </Grid.ColumnDefinitions>
-            <!-- 左侧列表区 -->
-            <DataGrid Grid.Column="0" ItemsSource="{Binding Doctors}" SelectedItem="{Binding SelectedDoctor, Mode=TwoWay}"
-                      AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="账号" Binding="{Binding UserName}" Width="*"/>
-                    <DataGridTextColumn Header="姓名" Binding="{Binding RealName}" Width="*"/>
-                    <DataGridTextColumn Header="联系号码" Binding="{Binding ContactNumber}" Width="*"/>
-                    <DataGridTemplateColumn Header="性别" Width="80">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Gender, Converter={StaticResource EnumDescriptionConverter}}" VerticalAlignment="Center"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="出生日期" Binding="{Binding Birthday, StringFormat=yyyy-MM-dd}" Width="110"/>
-                    <DataGridTextColumn Header="拼音码" Binding="{Binding PinyinCode}" Width="*"/>
-                    <DataGridTextColumn Header="执业证号" Binding="{Binding LicenseNumber}" Width="*"/>
-                    <DataGridTemplateColumn Header="职称" Width="*">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Title, Converter={StaticResource EnumDescriptionConverter}}" VerticalAlignment="Center"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTemplateColumn Header="状态" Width="80">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding Status, Converter={StaticResource EnumDescriptionConverter}}" VerticalAlignment="Center"/>
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="备注" Binding="{Binding Remark}" Width="*"/>
-                </DataGrid.Columns>
-            </DataGrid>
-            <!-- 右侧档案区 -->
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-                <main:DoctorProfileView DataContext="{Binding DoctorProfileViewModel}" />
-            </Border>
-        </Grid>
-        <controls:PageManagerControl Grid.Row="2" Margin="0,8,0,0"
-                                     PageIndex="{Binding PageIndex}"
-                                     PageSize="{Binding PageSize}"
-                                     TotalCount="{Binding TotalCount}" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2.2*"/>
+            <ColumnDefinition Width="1.8*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0" ShowPaging="True"
+                                 ItemsSource="{Binding Doctors}"
+                                 SelectedItem="{Binding SelectedDoctor, Mode=TwoWay}"
+                                 SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                                 SearchCommand="{Binding SearchCommand}"
+                                 LoadPageCommand="{Binding LoadPageCommand}"
+                                 IsBusy="{Binding IsBusy}">
+            <controls:CommonListView.ActionContent>
+                <StackPanel Orientation="Horizontal">
+                    <Button Content="修改医生档案" Command="{Binding EditDoctorCommand}" Margin="0,0,8,0"
+                            IsEnabled="{Binding SelectedDoctor, Converter={StaticResource NullToBoolConverter}}"/>
+                </StackPanel>
+            </controls:CommonListView.ActionContent>
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="账号" Binding="{Binding UserName}" Width="*"/>
+                <DataGridTextColumn Header="姓名" Binding="{Binding RealName}" Width="*"/>
+                <DataGridTextColumn Header="联系号码" Binding="{Binding ContactNumber}" Width="*"/>
+                <DataGridTemplateColumn Header="性别" Width="80">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Gender, Converter={StaticResource EnumDescriptionConverter}}" VerticalAlignment="Center"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="出生日期" Binding="{Binding Birthday, StringFormat=yyyy-MM-dd}" Width="110"/>
+                <DataGridTextColumn Header="拼音码" Binding="{Binding PinyinCode}" Width="*"/>
+                <DataGridTextColumn Header="执业证号" Binding="{Binding LicenseNumber}" Width="*"/>
+                <DataGridTemplateColumn Header="职称" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Title, Converter={StaticResource EnumDescriptionConverter}}" VerticalAlignment="Center"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="状态" Width="80">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Status, Converter={StaticResource EnumDescriptionConverter}}" VerticalAlignment="Center"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+                <DataGridTextColumn Header="备注" Binding="{Binding Remark}" Width="*"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <main:DoctorProfileView DataContext="{Binding DoctorProfileViewModel}" />
+        </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -6,36 +6,30 @@
              xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
-            <Button Content="新增" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
-            <Button Content="编辑" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="删除" Command="{Binding DeleteCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="批量导入经典方" Command="{Binding ImportCommand}" Margin="0,0,8,0"/>
-            <Button Content="批量导出经典方" Command="{Binding ExportCommand}"/>
-        </StackPanel>
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="2*"/>
-            </Grid.ColumnDefinitions>
-            <DataGrid Grid.Column="0" ItemsSource="{Binding Templates}" SelectedItem="{Binding SelectedTemplate, Mode=TwoWay}" AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
-                </DataGrid.Columns>
-            </DataGrid>
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-                <main:FormulaTemplatesProfileView DataContext="{Binding ProfileViewModel}" />
-            </Border>
-        </Grid>
-        <controls:PageManagerControl Grid.Row="2" Margin="0,8,0,0"
-                                     PageIndex="{Binding PageIndex}"
-                                     PageSize="{Binding PageSize}"
-                                     TotalCount="{Binding TotalCount}" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0" ShowPaging="False"
+                                 ItemsSource="{Binding Templates}"
+                                 SelectedItem="{Binding SelectedTemplate, Mode=TwoWay}"
+                                 SearchCommand="{Binding RefreshCommand}">
+            <controls:CommonListView.ActionContent>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+                    <Button Content="新增" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+                    <Button Content="编辑" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="删除" Command="{Binding DeleteCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="批量导入经典方" Command="{Binding ImportCommand}" Margin="0,0,8,0"/>
+                    <Button Content="批量导出经典方" Command="{Binding ExportCommand}"/>
+                </StackPanel>
+            </controls:CommonListView.ActionContent>
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <main:FormulaTemplatesProfileView DataContext="{Binding ProfileViewModel}" />
+        </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
@@ -15,6 +15,7 @@
                                  SelectedItem="{Binding SelectedHerb, Mode=TwoWay}"
                                  SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
                                  SearchCommand="{Binding SearchCommand}"
+                                 LoadPageCommand="{Binding LoadPageCommand}"
                                  IsBusy="{Binding IsBusy}">
             <controls:CommonListView.ActionContent>
                 <StackPanel Orientation="Horizontal">

--- a/LYBT.UI.WPF/Views/Admin/PatientManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/PatientManagementView.xaml
@@ -9,43 +9,26 @@
               mc:Ignorable="d"
               prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <!-- 操作区 -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <TextBox Width="180" Margin="0,0,8,0" Text="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="查找" Command="{Binding SearchCommand}" Margin="0,0,8,0"/>
-            <!-- 可扩展：新增、编辑、删除等操作按钮 -->
-        </StackPanel>
-        <!-- 内容区 -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2.2*"/>
-                <ColumnDefinition Width="1.8*"/>
-            </Grid.ColumnDefinitions>
-            <!-- 左侧列表区 -->
-            <ListView Grid.Column="0" ItemsSource="{Binding Patients}" SelectedItem="{Binding SelectedPatient, Mode=TwoWay}">
-                <ListView.View>
-                    <GridView>
-                        <GridViewColumn Header="姓名" DisplayMemberBinding="{Binding Name}" Width="100"/>
-                        <GridViewColumn Header="性别" DisplayMemberBinding="{Binding Gender}" Width="60"/>
-                        <GridViewColumn Header="年龄" DisplayMemberBinding="{Binding Age}" Width="60"/>
-                        <GridViewColumn Header="手机号" DisplayMemberBinding="{Binding PhoneNumber}" Width="120"/>
-                        <GridViewColumn Header="地址" DisplayMemberBinding="{Binding Address}" Width="200"/>
-                    </GridView>
-                </ListView.View>
-            </ListView>
-            <!-- 右侧详情区 -->
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-                <main:PatientProfileView DataContext="{Binding PatientProfileViewModel}"/>
-            </Border>
-        </Grid>
-        <controls:PageManagerControl Grid.Row="2" Margin="0,8,0,0"
-                                     PageIndex="{Binding PageIndex}"
-                                     PageSize="{Binding PageSize}"
-                                     TotalCount="{Binding TotalCount}" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2.2*"/>
+            <ColumnDefinition Width="1.8*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0" ShowPaging="True"
+                                 ItemsSource="{Binding Patients}"
+                                 SelectedItem="{Binding SelectedPatient, Mode=TwoWay}"
+                                 SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                                 SearchCommand="{Binding SearchCommand}"
+                                 LoadPageCommand="{Binding LoadPageCommand}">
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="姓名" Binding="{Binding Name}" Width="100"/>
+                <DataGridTextColumn Header="性别" Binding="{Binding Gender}" Width="60"/>
+                <DataGridTextColumn Header="年龄" Binding="{Binding Age}" Width="60"/>
+                <DataGridTextColumn Header="手机号" Binding="{Binding PhoneNumber}" Width="120"/>
+                <DataGridTextColumn Header="地址" Binding="{Binding Address}" Width="200"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <main:PatientProfileView DataContext="{Binding PatientProfileViewModel}"/>
+        </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Admin/PrescriptionManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/PrescriptionManagementView.xaml
@@ -6,37 +6,31 @@
              xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
-            <Button Content="新增" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
-            <Button Content="编辑" Command="{Binding EditCommand}" IsEnabled="{Binding SelectedPrescription, Converter={StaticResource NullToBoolConverter}}" Margin="0,0,8,0"/>
-            <Button Content="删除" Command="{Binding DeleteCommand}" IsEnabled="{Binding SelectedPrescription, Converter={StaticResource NullToBoolConverter}}"/>
-        </StackPanel>
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="2*"/>
-            </Grid.ColumnDefinitions>
-            <DataGrid Grid.Column="0" ItemsSource="{Binding Prescriptions}" SelectedItem="{Binding SelectedPrescription, Mode=TwoWay}" AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="创建时间" Binding="{Binding CreateTime}" Width="150"/>
-                    <DataGridTextColumn Header="状态" Binding="{Binding Status}" Width="100"/>
-                    <DataGridTextColumn Header="患者" Binding="{Binding PatientId}" Width="*"/>
-                    <DataGridTextColumn Header="医生" Binding="{Binding DoctorId}" Width="*"/>
-                </DataGrid.Columns>
-            </DataGrid>
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-                <main:PrescriptionProfileView DataContext="{Binding ProfileViewModel}" />
-            </Border>
-        </Grid>
-        <controls:PageManagerControl Grid.Row="2" Margin="0,8,0,0"
-                                     PageIndex="{Binding PageIndex}"
-                                     PageSize="{Binding PageSize}"
-                                     TotalCount="{Binding TotalCount}" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0" ShowPaging="False"
+                                 ItemsSource="{Binding Prescriptions}"
+                                 SelectedItem="{Binding SelectedPrescription, Mode=TwoWay}"
+                                 SearchCommand="{Binding RefreshCommand}">
+            <controls:CommonListView.ActionContent>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+                    <Button Content="新增" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+                    <Button Content="编辑" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedPrescription, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="删除" Command="{Binding DeleteCommand}" IsEnabled="{Binding SelectedPrescription, Converter={StaticResource NullToBoolConverter}}"/>
+                </StackPanel>
+            </controls:CommonListView.ActionContent>
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="创建时间" Binding="{Binding CreateTime}" Width="150"/>
+                <DataGridTextColumn Header="状态" Binding="{Binding Status}" Width="100"/>
+                <DataGridTextColumn Header="患者" Binding="{Binding PatientId}" Width="*"/>
+                <DataGridTextColumn Header="医生" Binding="{Binding DoctorId}" Width="*"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <main:PrescriptionProfileView DataContext="{Binding ProfileViewModel}" />
+        </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml
@@ -5,61 +5,46 @@
              xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
-        </Grid.RowDefinitions>
-        <!-- 操作区 -->
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-            <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
-            <Button Content="新增病历" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
-            <Button Content="编辑病历" Command="{Binding EditCommand}" Margin="0,0,8,0"
-                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="删除病历" Command="{Binding DeleteCommand}" Margin="0,0,8,0"
-                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="共享" Command="{Binding ShareCommand}" Margin="0,0,8,0"
-                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
-            <Button Content="取消共享" Command="{Binding RevokeShareCommand}"
-                    IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
-        </StackPanel>
-        <!-- 内容区 -->
-        <Grid Grid.Row="1">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="2*"/>
-                <ColumnDefinition Width="2*"/>
-            </Grid.ColumnDefinitions>
-            <!-- 左侧列表 -->
-            <DataGrid Grid.Column="0" ItemsSource="{Binding Records}" SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
-                      AutoGenerateColumns="False" Margin="0,0,8,0" IsReadOnly="True">
-                <DataGrid.Columns>
-                    <DataGridTextColumn Header="患者" Binding="{Binding PatientName}" Width="*"/>
-                    <DataGridTextColumn Header="诊断" Binding="{Binding Diagnosis}" Width="*"/>
-                    <DataGridTextColumn Header="时间" Binding="{Binding RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Width="150"/>
-                    <DataGridCheckBoxColumn Header="共享" Binding="{Binding IsShared}" Width="70"/>
-                </DataGrid.Columns>
-            </DataGrid>
-            <!-- 右侧详情区 -->
-            <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-                <StackPanel>
-                    <TextBlock Text="{Binding EditModeTitle}" FontWeight="Bold" FontSize="17" Margin="0,0,0,16"/>
-                    <TextBlock Text="患者姓名" />
-                    <TextBox Text="{Binding EditingRecord.PatientName}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                    <TextBlock Text="诊断" />
-                    <TextBox Text="{Binding EditingRecord.Diagnosis}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                    <TextBlock Text="记录时间" />
-                    <TextBox Text="{Binding EditingRecord.RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Margin="0,0,0,8"/>
-                    <CheckBox Content="共享" IsChecked="{Binding EditingRecord.IsShared}" Margin="0,0,0,8"/>
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}" Margin="0,10,0,0">
-                        <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,0,8,0"/>
-                        <Button Content="取消" Command="{Binding CancelCommand}"/>
-                    </StackPanel>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="2*"/>
+        </Grid.ColumnDefinitions>
+        <controls:CommonListView Grid.Column="0" ShowPaging="False"
+                                 ItemsSource="{Binding Records}"
+                                 SelectedItem="{Binding SelectedRecord, Mode=TwoWay}"
+                                 SearchCommand="{Binding RefreshCommand}">
+            <controls:CommonListView.ActionContent>
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                    <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+                    <Button Content="新增病历" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
+                    <Button Content="编辑病历" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="删除病历" Command="{Binding DeleteCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="共享" Command="{Binding ShareCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
+                    <Button Content="取消共享" Command="{Binding RevokeShareCommand}" IsEnabled="{Binding SelectedRecord, Converter={StaticResource NullToBoolConverter}}"/>
                 </StackPanel>
-            </Border>
-        </Grid>
-        <controls:PageManagerControl Grid.Row="2" Margin="0,8,0,0"
-                                     PageIndex="{Binding PageIndex}"
-                                     PageSize="{Binding PageSize}"
-                                     TotalCount="{Binding TotalCount}" />
+            </controls:CommonListView.ActionContent>
+            <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="患者" Binding="{Binding PatientName}" Width="*"/>
+                <DataGridTextColumn Header="诊断" Binding="{Binding Diagnosis}" Width="*"/>
+                <DataGridTextColumn Header="时间" Binding="{Binding RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Width="150"/>
+                <DataGridCheckBoxColumn Header="共享" Binding="{Binding IsShared}" Width="70"/>
+            </controls:CommonListView.Columns>
+        </controls:CommonListView>
+        <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <StackPanel>
+                <TextBlock Text="{Binding EditModeTitle}" FontWeight="Bold" FontSize="17" Margin="0,0,0,16"/>
+                <TextBlock Text="患者姓名" />
+                <TextBox Text="{Binding EditingRecord.PatientName}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                <TextBlock Text="诊断" />
+                <TextBox Text="{Binding EditingRecord.Diagnosis}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                <TextBlock Text="记录时间" />
+                <TextBox Text="{Binding EditingRecord.RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Margin="0,0,0,8"/>
+                <CheckBox Content="共享" IsChecked="{Binding EditingRecord.IsShared}" Margin="0,0,0,8"/>
+                <StackPanel Orientation="Horizontal" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}" Margin="0,10,0,0">
+                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,0,8,0"/>
+                    <Button Content="取消" Command="{Binding CancelCommand}"/>
+                </StackPanel>
+            </StackPanel>
+        </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -16,6 +16,7 @@
                                  SelectedItem="{Binding SelectedUser, Mode=TwoWay}"
                                  SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
                                  SearchCommand="{Binding SearchCommand}"
+                                 LoadPageCommand="{Binding LoadPageCommand}"
                                  IsBusy="{Binding IsBusy}">
             <controls:CommonListView.ActionContent>
                 <StackPanel Orientation="Horizontal">

--- a/LYBT.WPFControls/Controls/CommonListView.xaml
+++ b/LYBT.WPFControls/Controls/CommonListView.xaml
@@ -29,7 +29,7 @@
                 <ProgressBar IsIndeterminate="True" Width="120" Height="4" />
             </StackPanel>
         </Border>
-        <controls:PageManagerControl Grid.Row="2" Margin="0,8,0,0"
+        <controls:PageManagerControl x:Name="PART_Pager" Grid.Row="2" Margin="0,8,0,0"
             Visibility="{Binding ShowPaging, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource BoolToVisibilityConverter}}"
             PageIndex="{Binding PageIndex}"
             PageSize="{Binding PageSize}"

--- a/LYBT.WPFControls/Controls/CommonListView.xaml.cs
+++ b/LYBT.WPFControls/Controls/CommonListView.xaml.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Windows.Input;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Markup;
@@ -14,6 +15,7 @@ namespace LYBT.WPFControls {
             Columns = new ObservableCollection<DataGridColumn>();
             InitializeComponent();
             Loaded += (_, __) => ApplyColumns();
+            PART_Pager.PagingChanged += (_, __) => ExecuteLoadPageCommand();
         }
 
         private void ApplyColumns() {
@@ -55,7 +57,9 @@ namespace LYBT.WPFControls {
         }
 
         public static readonly DependencyProperty SearchKeywordProperty =
-            DependencyProperty.Register(nameof(SearchKeyword), typeof(string), typeof(CommonListView));
+            DependencyProperty.Register(
+                nameof(SearchKeyword), typeof(string), typeof(CommonListView),
+                new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSearchKeywordChanged));
 
         public System.Windows.Input.ICommand? SearchCommand {
             get => (System.Windows.Input.ICommand?)GetValue(SearchCommandProperty);
@@ -64,6 +68,14 @@ namespace LYBT.WPFControls {
 
         public static readonly DependencyProperty SearchCommandProperty =
             DependencyProperty.Register(nameof(SearchCommand), typeof(System.Windows.Input.ICommand), typeof(CommonListView));
+
+        public ICommand? LoadPageCommand {
+            get => (ICommand?)GetValue(LoadPageCommandProperty);
+            set => SetValue(LoadPageCommandProperty, value);
+        }
+
+        public static readonly DependencyProperty LoadPageCommandProperty =
+            DependencyProperty.Register(nameof(LoadPageCommand), typeof(ICommand), typeof(CommonListView));
 
         public bool IsBusy {
             get => (bool)GetValue(IsBusyProperty);
@@ -80,5 +92,20 @@ namespace LYBT.WPFControls {
 
         public static readonly DependencyProperty ShowPagingProperty =
             DependencyProperty.Register(nameof(ShowPaging), typeof(bool), typeof(CommonListView), new PropertyMetadata(true));
+
+        private static void OnSearchKeywordChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
+            if (d is CommonListView view)
+                view.ExecuteSearchCommand();
+        }
+
+        private void ExecuteSearchCommand() {
+            if (SearchCommand?.CanExecute(null) == true)
+                SearchCommand.Execute(null);
+        }
+
+        private void ExecuteLoadPageCommand() {
+            if (LoadPageCommand?.CanExecute(null) == true)
+                LoadPageCommand.Execute(null);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- show all admin lists with `CommonListView`
- add paging hooks and two‑way binding for search keyword
- automatically refresh list when search keyword or page changes

## Testing
- `dotnet test LYBTZYZS.sln --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877ca56c1908333aa7004f7b4a6ba94