### PR TITLE
Fix pager update and add load command

### DIFF
--- a/LYBT.UI.WPF/ViewModels/BaseListViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/BaseListViewModel.cs
@@ -11,6 +11,7 @@ namespace LYBT.UI.WPF.ViewModels {
     /// </summary>
     public abstract class BaseListViewModel<T> : BindableBase {
         protected BaseListViewModel() {
+            LoadPageCommand = new DelegateCommand(async () => await LoadPageAsync(PageIndex));
             NextPageCommand = new DelegateCommand(async () => await LoadPageAsync(CurrentPage + 1),
                 () => CurrentPage < TotalPages).ObservesProperty(() => CurrentPage).ObservesProperty(() => TotalPages);
             PrevPageCommand = new DelegateCommand(async () => await LoadPageAsync(CurrentPage - 1),
@@ -73,6 +74,7 @@ namespace LYBT.UI.WPF.ViewModels {
 
         public int PageSize { get; set; } = 20;
 
+        public DelegateCommand LoadPageCommand { get; }
         public DelegateCommand NextPageCommand { get; }
         public DelegateCommand PrevPageCommand { get; }
 

--- a/LYBT.WPFControls/Controls/PageManagerControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/PageManagerControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Data;
 
 namespace LYBT.WPFControls {
     /// <summary>
@@ -69,6 +70,7 @@ namespace LYBT.WPFControls {
 
         private static void OnPagingPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
             if (d is PageManagerControl c) {
+                BindingOperations.GetBindingExpression(c, e.Property)?.UpdateSource();
                 c.CommandManagerInvalidate();
                 c.PagingChanged?.Invoke(c, EventArgs.Empty);
             }


### PR DESCRIPTION
## Summary
- update `PageManagerControl` to push DP value to source before raising events
- expose `LoadPageCommand` in `BaseListViewModel` so `CommonListView` can refresh pages

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877cda030308333aa0ea7540d0869ab