### PR TITLE
Show model identifiers in admin lists

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -25,6 +25,7 @@
                 </StackPanel>
             </controls:CommonListView.ActionContent>
             <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="160"/>
                 <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
             </controls:CommonListView.Columns>
         </controls:CommonListView>

--- a/LYBT.UI.WPF/Views/Admin/PrescriptionManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/PrescriptionManagementView.xaml
@@ -23,6 +23,7 @@
                 </StackPanel>
             </controls:CommonListView.ActionContent>
             <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="160"/>
                 <DataGridTextColumn Header="创建时间" Binding="{Binding CreateTime}" Width="150"/>
                 <DataGridTextColumn Header="状态" Binding="{Binding Status}" Width="100"/>
                 <DataGridTextColumn Header="患者" Binding="{Binding PatientId}" Width="*"/>

--- a/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/RecordManagementView.xaml
@@ -24,6 +24,7 @@
                 </StackPanel>
             </controls:CommonListView.ActionContent>
             <controls:CommonListView.Columns>
+                <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="160"/>
                 <DataGridTextColumn Header="患者" Binding="{Binding PatientName}" Width="*"/>
                 <DataGridTextColumn Header="诊断" Binding="{Binding Diagnosis}" Width="*"/>
                 <DataGridTextColumn Header="时间" Binding="{Binding RecordTime, StringFormat=yyyy-MM-dd HH:mm}" Width="150"/>


### PR DESCRIPTION
## Summary
- show IDs for formulas, prescriptions and records in their admin lists

## Testing
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877ce8c7b1083339408ba3e78c94453