### PR TITLE
Align search and action buttons to right

### DIFF
--- a/LYBT.WPFControls/Controls/CommonListView.xaml
+++ b/LYBT.WPFControls/Controls/CommonListView.xaml
@@ -11,13 +11,19 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+        <Grid Margin="0,0,0,8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
             <TextBox Width="180" Margin="0,0,8,0"
                      Text="{Binding SearchKeyword, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=PropertyChanged}"/>
-            <Button Content="查找" Margin="0,0,8,0"
-                    Command="{Binding SearchCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-            <ContentPresenter Content="{Binding ActionContent, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-        </StackPanel>
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+                <Button Content="查找" Margin="0,0,8,0"
+                        Command="{Binding SearchCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+                <ContentPresenter Content="{Binding ActionContent, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+            </StackPanel>
+        </Grid>
         <DataGrid x:Name="PART_DataGrid" Grid.Row="1" Margin="0,0,8,0" IsReadOnly="True"
                   ItemsSource="{Binding ItemsSource, RelativeSource={RelativeSource AncestorType=UserControl}}"
                   SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay}"


### PR DESCRIPTION
## Summary
- adjust `CommonListView` layout so search and action buttons align right

## Testing
- `dotnet test -v minimal LYBT.Tests/LYBT.Tests.csproj` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6877d297e9fc8333958d740095eb8904