### PR TITLE
Fix admin tab underline

### DIFF
--- a/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
@@ -8,7 +8,8 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <TabControl SelectedIndex="{Binding SelectedTabIndex}">
         <TabControl.Resources>
-            <Style TargetType="TabItem">
+            <!-- Preserve MaterialDesign underline styling for selected tab -->
+            <Style TargetType="TabItem" BasedOn="{StaticResource MaterialDesignTabItem}">
                 <Setter Property="Padding" Value="12,8" />
             </Style>
         </TabControl.Resources>


### PR DESCRIPTION
## Summary
- restore MaterialDesign underline style for admin tabs

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d834067c83338f1707438443031f