### PR TITLE
Add HerbInputControl in formula template management

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/FormulaTemplatesManagementViewModel.cs
@@ -2,6 +2,8 @@ using LYBT.Module.FormulaTemplates.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.ViewModels.Profile;
 using LYBT.Common.Enums;
+using LYBT.Module.Herbs.Dtos;
+using LYBT.Module.Prescriptions.Dtos;
 using Prism.Commands;
 using Prism.Mvvm;
 using System;
@@ -18,7 +20,11 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
     /// </summary>
     public class FormulaTemplatesManagementViewModel : BindableBase {
         private readonly IFormulaTemplateService _service;
+        private readonly IHerbService _herbService;
+
         public ObservableCollection<FormulaTemplateDto> Templates { get; } = new();
+        public ObservableCollection<PrescriptionItemDto> InputItems { get; } = new();
+        public ObservableCollection<HerbDto> Herbs { get; } = new();
 
         private FormulaTemplateDto? _selectedTemplate;
         public FormulaTemplateDto? SelectedTemplate {
@@ -35,8 +41,9 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         public DelegateCommand ImportCommand { get; }
         public DelegateCommand ExportCommand { get; }
 
-        public FormulaTemplatesManagementViewModel(IFormulaTemplateService service, FormulaTemplatesProfileViewModel profileViewModel) {
+        public FormulaTemplatesManagementViewModel(IFormulaTemplateService service, IHerbService herbService, FormulaTemplatesProfileViewModel profileViewModel) {
             _service = service;
+            _herbService = herbService;
             ProfileViewModel = profileViewModel;
             RefreshCommand = new DelegateCommand(async () => await LoadAsync());
             AddCommand = new DelegateCommand(Add);
@@ -45,6 +52,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             ImportCommand = new DelegateCommand(async () => await ImportAsync());
             ExportCommand = new DelegateCommand(async () => await ExportAsync());
             _ = LoadAsync();
+            _ = LoadHerbsAsync();
         }
 
         private async Task LoadAsync() {
@@ -111,6 +119,13 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
                     MessageBox.Show($"导出失败：{ex.Message}", "错误");
                 }
             }
+        }
+
+        private async Task LoadHerbsAsync() {
+            var list = await _herbService.GetListAsync();
+            Herbs.Clear();
+            foreach (var h in list)
+                Herbs.Add(h);
         }
     }
 }

--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -10,13 +10,21 @@
             <ColumnDefinition Width="2*"/>
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
-        <controls:CommonListView Grid.Column="0" ShowPaging="False"
-                                 ItemsSource="{Binding Templates}"
-                                 SelectedItem="{Binding SelectedTemplate, Mode=TwoWay}"
-                                 SearchCommand="{Binding RefreshCommand}">
-            <controls:CommonListView.ActionContent>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-                    <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
+        <Grid Grid.Column="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <controls:HerbInputControl Grid.Row="0"
+                                      ItemsSource="{Binding InputItems}"
+                                      Herbs="{Binding Herbs}" Margin="0,0,0,8"/>
+            <controls:CommonListView Grid.Row="1" ShowPaging="False"
+                                     ItemsSource="{Binding Templates}"
+                                     SelectedItem="{Binding SelectedTemplate, Mode=TwoWay}"
+                                     SearchCommand="{Binding RefreshCommand}">
+                <controls:CommonListView.ActionContent>
+                    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+                        <Button Content="刷新" Command="{Binding RefreshCommand}" Margin="0,0,8,0"/>
                     <Button Content="新增" Command="{Binding AddCommand}" Margin="0,0,8,0"/>
                     <Button Content="编辑" Command="{Binding EditCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
                     <Button Content="删除" Command="{Binding DeleteCommand}" Margin="0,0,8,0" IsEnabled="{Binding SelectedTemplate, Converter={StaticResource NullToBoolConverter}}"/>
@@ -28,7 +36,8 @@
                 <DataGridTextColumn Header="ID" Binding="{Binding Id}" Width="160"/>
                 <DataGridTextColumn Header="名称" Binding="{Binding Name}" Width="*"/>
             </controls:CommonListView.Columns>
-        </controls:CommonListView>
+            </controls:CommonListView>
+        </Grid>
         <Border Grid.Column="1" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
             <main:FormulaTemplatesProfileView DataContext="{Binding ProfileViewModel}" />
         </Border>

--- a/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
@@ -6,7 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using LYBT.Module.Herbs.Dtos;
-using LYBT.Models.Prescriptions.Dtos;
+using LYBT.Module.Prescriptions.Dtos;
 
 namespace LYBT.WPFControls {
     /// <summary>

--- a/LYBT.WPFControls/LYBT.WPFControls.csproj
+++ b/LYBT.WPFControls/LYBT.WPFControls.csproj
@@ -7,4 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\LYBT.Module.Herbs\LYBT.Module.Herbs.csproj" />
+    <ProjectReference Include="..\LYBT.Models\LYBT.Models.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- integrate `HerbInputControl` inside classical formula management view
- expose herb list and input items via view model
- reference modules in controls project for DTO types

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: requires .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6877d8d75fe08333ba7313662846e95a