### PR TITLE
Add CommonProfileView control

### DIFF
--- a/LYBT.WPFControls/Controls/CommonProfileView.xaml
+++ b/LYBT.WPFControls/Controls/CommonProfileView.xaml
@@ -1,0 +1,32 @@
+<UserControl x:Class="LYBT.WPFControls.CommonProfileView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Name="root">
+    <UserControl.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock Grid.Row="0" Text="{Binding Title, ElementName=root}" 
+                   FontSize="18" FontWeight="Bold" Margin="0,0,0,10" />
+        <ContentPresenter Grid.Row="1" Content="{Binding ProfileContent, ElementName=root}" />
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">
+            <Button Content="保存" Margin="0,0,8,0"
+                    Command="{Binding SaveCommand, ElementName=root}"
+                    Visibility="{Binding IsEditable, ElementName=root, Converter={StaticResource BoolToVisibilityConverter}}" />
+            <Button Content="取消" 
+                    Command="{Binding CancelCommand, ElementName=root}"
+                    Visibility="{Binding IsEditable, ElementName=root, Converter={StaticResource BoolToVisibilityConverter}}" />
+        </StackPanel>
+        <Border Grid.RowSpan="3" Background="#80000000"
+                Visibility="{Binding IsBusy, ElementName=root, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                <ProgressBar IsIndeterminate="True" Width="120" Height="4" />
+            </StackPanel>
+        </Border>
+    </Grid>
+</UserControl>

--- a/LYBT.WPFControls/Controls/CommonProfileView.xaml.cs
+++ b/LYBT.WPFControls/Controls/CommonProfileView.xaml.cs
@@ -1,0 +1,64 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Markup;
+using System.Windows.Input;
+
+namespace LYBT.WPFControls {
+    /// <summary>
+    /// 通用档案编辑视图控件，提供标题、内容呈现以及保存/取消按钮。
+    /// </summary>
+    [ContentProperty(nameof(ProfileContent))]
+    public partial class CommonProfileView : UserControl {
+        public CommonProfileView() {
+            InitializeComponent();
+        }
+
+        public object? ProfileContent {
+            get => GetValue(ProfileContentProperty);
+            set => SetValue(ProfileContentProperty, value);
+        }
+
+        public static readonly DependencyProperty ProfileContentProperty =
+            DependencyProperty.Register(nameof(ProfileContent), typeof(object), typeof(CommonProfileView));
+
+        public string? Title {
+            get => (string?)GetValue(TitleProperty);
+            set => SetValue(TitleProperty, value);
+        }
+
+        public static readonly DependencyProperty TitleProperty =
+            DependencyProperty.Register(nameof(Title), typeof(string), typeof(CommonProfileView));
+
+        public ICommand? SaveCommand {
+            get => (ICommand?)GetValue(SaveCommandProperty);
+            set => SetValue(SaveCommandProperty, value);
+        }
+
+        public static readonly DependencyProperty SaveCommandProperty =
+            DependencyProperty.Register(nameof(SaveCommand), typeof(ICommand), typeof(CommonProfileView));
+
+        public ICommand? CancelCommand {
+            get => (ICommand?)GetValue(CancelCommandProperty);
+            set => SetValue(CancelCommandProperty, value);
+        }
+
+        public static readonly DependencyProperty CancelCommandProperty =
+            DependencyProperty.Register(nameof(CancelCommand), typeof(ICommand), typeof(CommonProfileView));
+
+        public bool IsEditable {
+            get => (bool)GetValue(IsEditableProperty);
+            set => SetValue(IsEditableProperty, value);
+        }
+
+        public static readonly DependencyProperty IsEditableProperty =
+            DependencyProperty.Register(nameof(IsEditable), typeof(bool), typeof(CommonProfileView), new PropertyMetadata(false));
+
+        public bool IsBusy {
+            get => (bool)GetValue(IsBusyProperty);
+            set => SetValue(IsBusyProperty, value);
+        }
+
+        public static readonly DependencyProperty IsBusyProperty =
+            DependencyProperty.Register(nameof(IsBusy), typeof(bool), typeof(CommonProfileView));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `CommonProfileView` WPF control for profile editing
- expose dependency properties for title, content, commands, and busy state
- include save/cancel buttons and busy overlay

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6877d99a46d88333940c86b068a435cb