### PR TITLE
Refactor profile views to use CommonProfileView

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/DoctorProfileViewModel.cs
@@ -27,7 +27,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         private UserDto? _user;
         public UserDto? User { get => _user; set => SetProperty(ref _user, value); }
 
-        private string _editModeTitle = "新增医生档案";
+        private string _editModeTitle = "医生详细信息";
         public string EditModeTitle { get => _editModeTitle; set => SetProperty(ref _editModeTitle, value); }
 
         public string? ContactNumber { get => Doctor.ContactNumber; set { Doctor.ContactNumber = value; RaisePropertyChanged(); } }
@@ -73,15 +73,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
             switch (mode) {
                 case ProfileMode.Create:
-                    EditModeTitle = "新增医生档案";
+                    EditModeTitle = "新建医生信息";
                     IsEditable = true;
                     break;
                 case ProfileMode.Edit:
-                    EditModeTitle = "编辑医生档案";
+                    EditModeTitle = "编辑医生信息";
                     IsEditable = true;
                     break;
                 default:
-                    EditModeTitle = "医生详情";
+                    EditModeTitle = "医生详细信息";
                     IsEditable = false;
                     break;
             }
@@ -135,7 +135,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             }
             Mode = ProfileMode.View;
             IsEditable = false;
-            EditModeTitle = "医生详情";
+            EditModeTitle = "医生详细信息";
         }
 
         private void Cancel() {
@@ -154,7 +154,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             }
             Mode = ProfileMode.View;
             IsEditable = false;
-            EditModeTitle = "医生详情";
+            EditModeTitle = "医生详细信息";
         }
 
         public async void OnNavigatedTo(NavigationContext navigationContext) {

--- a/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
@@ -31,7 +31,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             set => SetProperty(ref _selectedHerb, value);
         }
 
-        private string _editModeTitle = "新增模板";
+        private string _editModeTitle = "模板详细信息";
         public string EditModeTitle {
             get => _editModeTitle;
             set => SetProperty(ref _editModeTitle, value);
@@ -87,15 +87,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
             switch (mode) {
                 case ProfileMode.Create:
-                    EditModeTitle = "新增模板";
+                    EditModeTitle = "新建模板信息";
                     IsEditable = true;
                     break;
                 case ProfileMode.Edit:
-                    EditModeTitle = "编辑模板";
+                    EditModeTitle = "编辑模板信息";
                     IsEditable = true;
                     break;
                 default:
-                    EditModeTitle = "模板详情";
+                    EditModeTitle = "模板详细信息";
                     IsEditable = false;
                     break;
             }
@@ -123,7 +123,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             else {
                 Mode = ProfileMode.View;
                 IsEditable = false;
-                EditModeTitle = "模板详情";
+                EditModeTitle = "模板详细信息";
                 CancelAction?.Invoke();
             }
         }
@@ -131,7 +131,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         private void Cancel() {
             Mode = ProfileMode.View;
             IsEditable = false;
-            EditModeTitle = "模板详情";
+            EditModeTitle = "模板详细信息";
             CancelAction?.Invoke();
         }
     }

--- a/LYBT.UI.WPF/ViewModels/Profile/HerbProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/HerbProfileViewModel.cs
@@ -14,7 +14,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         private HerbDetailDto _herb = new();
         public HerbDetailDto Herb { get => _herb; set => SetProperty(ref _herb, value); }
 
-        private string _editModeTitle = "新增药材";
+        private string _editModeTitle = "药材详细信息";
         public string EditModeTitle { get => _editModeTitle; set => SetProperty(ref _editModeTitle, value); }
 
         private bool _isEditable;
@@ -54,15 +54,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
             switch (mode) {
                 case ProfileMode.Create:
-                    EditModeTitle = "新增药材";
+                    EditModeTitle = "新建药材信息";
                     IsEditable = true;
                     break;
                 case ProfileMode.Edit:
-                    EditModeTitle = "编辑药材";
+                    EditModeTitle = "编辑药材信息";
                     IsEditable = true;
                     break;
                 default:
-                    EditModeTitle = "药材详情";
+                    EditModeTitle = "药材详细信息";
                     IsEditable = false;
                     break;
             }
@@ -81,7 +81,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 else {
                     Mode = ProfileMode.View;
                     IsEditable = false;
-                    EditModeTitle = "药材详情";
+                    EditModeTitle = "药材详细信息";
                     CancelAction?.Invoke();
                 }
             } catch (Exception ex) {
@@ -92,7 +92,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         private void Cancel() {
             Mode = ProfileMode.View;
             IsEditable = false;
-            EditModeTitle = "药材详情";
+            EditModeTitle = "药材详细信息";
             CancelAction?.Invoke();
         }
     }

--- a/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PatientProfileViewModel.cs
@@ -23,7 +23,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
         public ObservableCollection<EnumItem<Gender>> GenderList { get; } = EnumHelper.BuildComboBoxSource<Gender>();
 
-        private string _editModeTitle = "新增患者档案";
+        private string _editModeTitle = "患者详细信息";
         public string EditModeTitle {
             get => _editModeTitle;
             set => SetProperty(ref _editModeTitle, value);
@@ -48,15 +48,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
             switch (mode) {
                 case ProfileMode.Create:
-                    EditModeTitle = "新增患者档案";
+                    EditModeTitle = "新建患者信息";
                     IsEditable = true;
                     break;
                 case ProfileMode.Edit:
-                    EditModeTitle = "编辑患者档案";
+                    EditModeTitle = "编辑患者信息";
                     IsEditable = true;
                     break;
                 default:
-                    EditModeTitle = "患者详情";
+                    EditModeTitle = "患者详细信息";
                     IsEditable = false;
                     break;
             }
@@ -73,7 +73,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 MessageBox.Show("已保存", "提示", MessageBoxButton.OK, MessageBoxImage.Information);
                 Mode = ProfileMode.View;
                 IsEditable = false;
-                EditModeTitle = "患者详情";
+                EditModeTitle = "患者详细信息";
             } else {
                 MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -90,7 +90,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             }
             Mode = ProfileMode.View;
             IsEditable = false;
-            EditModeTitle = "患者详情";
+            EditModeTitle = "患者详细信息";
         }
     }
 }

--- a/LYBT.UI.WPF/ViewModels/Profile/PrescriptionProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/PrescriptionProfileViewModel.cs
@@ -30,7 +30,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             set => SetProperty(ref _selectedItem, value);
         }
 
-        private string _editModeTitle = "新增处方";
+        private string _editModeTitle = "处方详细信息";
         public string EditModeTitle {
             get => _editModeTitle;
             set => SetProperty(ref _editModeTitle, value);
@@ -86,15 +86,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
             switch (mode) {
                 case ProfileMode.Create:
-                    EditModeTitle = "新增处方";
+                    EditModeTitle = "新建处方信息";
                     IsEditable = true;
                     break;
                 case ProfileMode.Edit:
-                    EditModeTitle = "编辑处方";
+                    EditModeTitle = "编辑处方信息";
                     IsEditable = true;
                     break;
                 default:
-                    EditModeTitle = "处方详情";
+                    EditModeTitle = "处方详细信息";
                     IsEditable = false;
                     break;
             }
@@ -122,7 +122,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             else {
                 Mode = ProfileMode.View;
                 IsEditable = false;
-                EditModeTitle = "处方详情";
+                EditModeTitle = "处方详细信息";
                 CancelAction?.Invoke();
             }
         }
@@ -130,7 +130,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         private void Cancel() {
             Mode = ProfileMode.View;
             IsEditable = false;
-            EditModeTitle = "处方详情";
+            EditModeTitle = "处方详细信息";
             CancelAction?.Invoke();
         }
     }

--- a/LYBT.UI.WPF/Views/Profile/DoctorProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/DoctorProfileView.xaml
@@ -2,9 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-            xmlns:common="clr-namespace:LYBT.Common.Models;assembly=LYBT.Common"
-            xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
-            prism:ViewModelLocator.AutoWireViewModel="True">
+             xmlns:common="clr-namespace:LYBT.Common.Models;assembly=LYBT.Common"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
+             xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
+             prism:ViewModelLocator.AutoWireViewModel="True">
     <UserControl.Resources>
     </UserControl.Resources>
     <Grid>
@@ -14,48 +15,45 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
                 </Border.Effect>
-                <StackPanel>
-                    <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel>
-                            <TextBlock Text="账号" />
-                            <TextBox Text="{Binding Doctor.UserName, Mode=OneWay}" IsReadOnly="True" Margin="0,0,0,8"/>
-                            <TextBlock Text="姓名" />
-                            <TextBox Text="{Binding Doctor.RealName, Mode=OneWay}" IsReadOnly="True" Margin="0,0,0,8"/>
-                            <TextBlock Text="联系号码" />
-                            <TextBox Text="{Binding Doctor.ContactNumber}" Margin="0,0,0,8"
-                                     IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="性别" />
-                            <ComboBox ItemsSource="{Binding GenderList}" SelectedValuePath="Value" DisplayMemberPath="Text"
-                                      SelectedValue="{Binding Doctor.Gender}" Margin="0,0,0,8"
-                                      IsEnabled="{Binding IsEditable}"/>
-                            <TextBlock Text="出生日期" />
-                            <DatePicker SelectedDate="{Binding Doctor.Birthday}" Margin="0,0,0,8"
-                                        IsEnabled="{Binding IsEditable}"/>
-                            <TextBlock Text="拼音码" />
-                            <TextBox Text="{Binding Doctor.PinyinCode}" Margin="0,0,0,8"
-                                     IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="执业证号" />
-                            <TextBox Text="{Binding Doctor.LicenseNumber}" Margin="0,0,0,8"
-                                     IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="职称" />
-                            <ComboBox ItemsSource="{Binding TitleList}" SelectedValuePath="Value" DisplayMemberPath="Text"
-                                      SelectedValue="{Binding Doctor.Title}" Margin="0,0,0,8"
-                                      IsEnabled="{Binding IsEditable}"/>
-                            <TextBlock Text="状态" />
-                            <ComboBox ItemsSource="{Binding StatusList}" SelectedValuePath="Value" DisplayMemberPath="Text"
-                                      SelectedValue="{Binding Doctor.Status}" Margin="0,0,0,8"
-                                      IsEnabled="{Binding IsEditable}"/>
-                            <TextBlock Text="备注" />
-                            <TextBox Text="{Binding Doctor.Remark}" Margin="0,0,0,8"
-                                     IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        </StackPanel>
-                    </ScrollViewer>
-                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0"
-                            Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0"
-                            Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                </StackPanel>
+                <controls:CommonProfileView Title="{Binding EditModeTitle}" SaveCommand="{Binding SaveCommand}" CancelCommand="{Binding CancelCommand}" IsEditable="{Binding IsEditable}">
+                    <controls:CommonProfileView.ProfileContent>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <TextBlock Text="账号" />
+                                <TextBox Text="{Binding Doctor.UserName, Mode=OneWay}" IsReadOnly="True" Margin="0,0,0,8"/>
+                                <TextBlock Text="姓名" />
+                                <TextBox Text="{Binding Doctor.RealName, Mode=OneWay}" IsReadOnly="True" Margin="0,0,0,8"/>
+                                <TextBlock Text="联系号码" />
+                                <TextBox Text="{Binding Doctor.ContactNumber}" Margin="0,0,0,8"
+                                         IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="性别" />
+                                <ComboBox ItemsSource="{Binding GenderList}" SelectedValuePath="Value" DisplayMemberPath="Text"
+                                          SelectedValue="{Binding Doctor.Gender}" Margin="0,0,0,8"
+                                          IsEnabled="{Binding IsEditable}"/>
+                                <TextBlock Text="出生日期" />
+                                <DatePicker SelectedDate="{Binding Doctor.Birthday}" Margin="0,0,0,8"
+                                            IsEnabled="{Binding IsEditable}"/>
+                                <TextBlock Text="拼音码" />
+                                <TextBox Text="{Binding Doctor.PinyinCode}" Margin="0,0,0,8"
+                                         IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="执业证号" />
+                                <TextBox Text="{Binding Doctor.LicenseNumber}" Margin="0,0,0,8"
+                                         IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="职称" />
+                                <ComboBox ItemsSource="{Binding TitleList}" SelectedValuePath="Value" DisplayMemberPath="Text"
+                                          SelectedValue="{Binding Doctor.Title}" Margin="0,0,0,8"
+                                          IsEnabled="{Binding IsEditable}"/>
+                                <TextBlock Text="状态" />
+                                <ComboBox ItemsSource="{Binding StatusList}" SelectedValuePath="Value" DisplayMemberPath="Text"
+                                          SelectedValue="{Binding Doctor.Status}" Margin="0,0,0,8"
+                                          IsEnabled="{Binding IsEditable}"/>
+                                <TextBlock Text="备注" />
+                                <TextBox Text="{Binding Doctor.Remark}" Margin="0,0,0,8"
+                                         IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </controls:CommonProfileView.ProfileContent>
+                </controls:CommonProfileView>
             </Border>
         </Grid>
     </Grid>

--- a/LYBT.UI.WPF/Views/Profile/FormulaTemplatesProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/FormulaTemplatesProfileView.xaml
@@ -2,31 +2,31 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
+             xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Border Padding="20" MinWidth="420" Background="#FAFAFA" CornerRadius="8" BorderBrush="#DDD" BorderThickness="1">
-            <StackPanel>
-                <TextBlock Text="{Binding EditModeTitle}" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="名称" Width="60"/>
-                    <TextBox Text="{Binding Template.Name}" Width="300"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <Button Content="添加药材" Command="{Binding AddHerbCommand}" Margin="0,0,5,0"/>
-                    <Button Content="删除药材" Command="{Binding RemoveHerbCommand}" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
-                </StackPanel>
-                <DataGrid ItemsSource="{Binding Herbs}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHerb}" Height="200" Margin="0,0,0,10">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="药材" Binding="{Binding Name}" Width="*"/>
-                    </DataGrid.Columns>
-                </DataGrid>
-                <TextBlock Text="备注"/>
-                <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,10"/>
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,0,10,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                </StackPanel>
-            </StackPanel>
+            <controls:CommonProfileView Title="{Binding EditModeTitle}" SaveCommand="{Binding SaveCommand}" CancelCommand="{Binding CancelCommand}" IsEditable="{Binding IsEditable}">
+                <controls:CommonProfileView.ProfileContent>
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                            <TextBlock Text="名称" Width="60"/>
+                            <TextBox Text="{Binding Template.Name}" Width="300"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                            <Button Content="添加药材" Command="{Binding AddHerbCommand}" Margin="0,0,5,0"/>
+                            <Button Content="删除药材" Command="{Binding RemoveHerbCommand}" IsEnabled="{Binding SelectedHerb, Converter={StaticResource NullToBoolConverter}}"/>
+                        </StackPanel>
+                        <DataGrid ItemsSource="{Binding Herbs}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedHerb}" Height="200" Margin="0,0,0,10">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="药材" Binding="{Binding Name}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <TextBlock Text="备注"/>
+                        <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,10"/>
+                    </StackPanel>
+                </controls:CommonProfileView.ProfileContent>
+            </controls:CommonProfileView>
         </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Profile/HerbProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/HerbProfileView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
+             xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
@@ -10,29 +11,28 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
                 </Border.Effect>
-                <StackPanel>
-                    <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
-                    <StackPanel>
-                        <TextBlock Text="名称" />
-                        <TextBox Text="{Binding Herb.Name}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="拼音码" />
-                        <TextBox Text="{Binding Herb.Pinyin}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="产地" />
-                        <TextBox Text="{Binding Herb.Origin}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="规格" />
-                        <TextBox Text="{Binding Herb.Spec}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="单位" />
-                        <TextBox Text="{Binding Herb.Unit}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="单价" />
-                        <TextBox Text="{Binding Herb.Price}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="功效" />
-                        <TextBox Text="{Binding Herb.Effect}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="备注" />
-                        <TextBox Text="{Binding Herb.Remark}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                    </StackPanel>
-                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                </StackPanel>
+                <controls:CommonProfileView Title="{Binding EditModeTitle}" SaveCommand="{Binding SaveCommand}" CancelCommand="{Binding CancelCommand}" IsEditable="{Binding IsEditable}">
+                    <controls:CommonProfileView.ProfileContent>
+                        <StackPanel>
+                            <TextBlock Text="名称" />
+                            <TextBox Text="{Binding Herb.Name}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="拼音码" />
+                            <TextBox Text="{Binding Herb.Pinyin}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="产地" />
+                            <TextBox Text="{Binding Herb.Origin}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="规格" />
+                            <TextBox Text="{Binding Herb.Spec}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="单位" />
+                            <TextBox Text="{Binding Herb.Unit}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="单价" />
+                            <TextBox Text="{Binding Herb.Price}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="功效" />
+                            <TextBox Text="{Binding Herb.Effect}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="备注" />
+                            <TextBox Text="{Binding Herb.Remark}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        </StackPanel>
+                    </controls:CommonProfileView.ProfileContent>
+                </controls:CommonProfileView>
             </Border>
         </Grid>
     </Grid>

--- a/LYBT.UI.WPF/Views/Profile/PatientProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/PatientProfileView.xaml
@@ -2,9 +2,10 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
-            xmlns:common="clr-namespace:LYBT.Common.Models;assembly=LYBT.Common"
-            xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
-            prism:ViewModelLocator.AutoWireViewModel="True">
+             xmlns:common="clr-namespace:LYBT.Common.Models;assembly=LYBT.Common"
+             xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
+             xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
+             prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
         <Grid VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
@@ -12,43 +13,42 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
                 </Border.Effect>
-                <StackPanel>
-                    <TextBlock Text="{Binding EditModeTitle}" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center"/>
-                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                        <StackPanel>
-                            <TextBlock Text="姓名" />
-                            <TextBox Text="{Binding Patient.Name}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="性别" />
-                            <ComboBox ItemsSource="{Binding GenderList}" SelectedValuePath="Value" DisplayMemberPath="Text"
-                                      SelectedValue="{Binding Patient.Gender}" Margin="0,0,0,8" IsEnabled="{Binding IsEditable}"/>
-                            <TextBlock Text="年龄" />
-                            <TextBox Text="{Binding Patient.Age}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="过敏史" />
-                            <TextBox Text="{Binding Patient.AllergyHistory}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="民族" />
-                            <TextBox Text="{Binding Patient.Ethnicity}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="联系电话" />
-                            <TextBox Text="{Binding Patient.PhoneNumber}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="地址" />
-                            <TextBox Text="{Binding Patient.Address}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="学历" />
-                            <TextBox Text="{Binding Patient.Education}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="职业" />
-                            <TextBox Text="{Binding Patient.Profession}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="证件类型" />
-                            <TextBox Text="{Binding Patient.IDType}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="证件号" />
-                            <TextBox Text="{Binding Patient.IDNumber}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="婚姻状况" />
-                            <TextBox Text="{Binding Patient.MaritalStatus}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <TextBlock Text="拼音码" />
-                            <TextBox Text="{Binding Patient.PinyinCode}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                            <CheckBox Content="特殊患者" IsChecked="{Binding Patient.IsSpecial}" Margin="0,0,0,8" IsEnabled="{Binding IsEditable}"/>
-                        </StackPanel>
-                    </ScrollViewer>
-                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Margin="0,10,0,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                </StackPanel>
+                <controls:CommonProfileView Title="{Binding EditModeTitle}" SaveCommand="{Binding SaveCommand}" CancelCommand="{Binding CancelCommand}" IsEditable="{Binding IsEditable}">
+                    <controls:CommonProfileView.ProfileContent>
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <StackPanel>
+                                <TextBlock Text="姓名" />
+                                <TextBox Text="{Binding Patient.Name}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="性别" />
+                                <ComboBox ItemsSource="{Binding GenderList}" SelectedValuePath="Value" DisplayMemberPath="Text"
+                                          SelectedValue="{Binding Patient.Gender}" Margin="0,0,0,8" IsEnabled="{Binding IsEditable}"/>
+                                <TextBlock Text="年龄" />
+                                <TextBox Text="{Binding Patient.Age}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="过敏史" />
+                                <TextBox Text="{Binding Patient.AllergyHistory}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="民族" />
+                                <TextBox Text="{Binding Patient.Ethnicity}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="联系电话" />
+                                <TextBox Text="{Binding Patient.PhoneNumber}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="地址" />
+                                <TextBox Text="{Binding Patient.Address}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="学历" />
+                                <TextBox Text="{Binding Patient.Education}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="职业" />
+                                <TextBox Text="{Binding Patient.Profession}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="证件类型" />
+                                <TextBox Text="{Binding Patient.IDType}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="证件号" />
+                                <TextBox Text="{Binding Patient.IDNumber}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="婚姻状况" />
+                                <TextBox Text="{Binding Patient.MaritalStatus}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <TextBlock Text="拼音码" />
+                                <TextBox Text="{Binding Patient.PinyinCode}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                                <CheckBox Content="特殊患者" IsChecked="{Binding Patient.IsSpecial}" Margin="0,0,0,8" IsEnabled="{Binding IsEditable}"/>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </controls:CommonProfileView.ProfileContent>
+                </controls:CommonProfileView>
             </Border>
         </Grid>
     </Grid>

--- a/LYBT.UI.WPF/Views/Profile/PrescriptionProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/PrescriptionProfileView.xaml
@@ -2,48 +2,48 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
+             xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Border Padding="20" MinWidth="420" Background="#FAFAFA" CornerRadius="8" BorderBrush="#DDD" BorderThickness="1">
-            <StackPanel>
-                <TextBlock Text="{Binding EditModeTitle}" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="患者" Width="60"/>
-                    <TextBox Text="{Binding Prescription.PatientId}" Width="300"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <TextBlock Text="医生" Width="60"/>
-                    <TextBox Text="{Binding Prescription.DoctorId}" Width="300"/>
-                </StackPanel>
-                <TextBlock Text="诊断"/>
-                <TextBox Text="{Binding Prescription.Diagnosis}" Margin="0,0,0,5"/>
-                <TextBlock Text="备注"/>
-                <TextBox Text="{Binding Prescription.Remark}" Margin="0,0,0,10"/>
+            <controls:CommonProfileView Title="{Binding EditModeTitle}" SaveCommand="{Binding SaveCommand}" CancelCommand="{Binding CancelCommand}" IsEditable="{Binding IsEditable}">
+                <controls:CommonProfileView.ProfileContent>
+                    <StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                            <TextBlock Text="患者" Width="60"/>
+                            <TextBox Text="{Binding Prescription.PatientId}" Width="300"/>
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                            <TextBlock Text="医生" Width="60"/>
+                            <TextBox Text="{Binding Prescription.DoctorId}" Width="300"/>
+                        </StackPanel>
+                        <TextBlock Text="诊断"/>
+                        <TextBox Text="{Binding Prescription.Diagnosis}" Margin="0,0,0,5"/>
+                        <TextBlock Text="备注"/>
+                        <TextBox Text="{Binding Prescription.Remark}" Margin="0,0,0,10"/>
 
-                <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                    <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
-                </StackPanel>
-                <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}" AutoGenerateColumns="False" Height="200" Margin="0,0,0,10">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
-                        <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>
-                        <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="80"/>
-                        <DataGridTextColumn Header="用法" Binding="{Binding Usage}" Width="100"/>
-                        <DataGridTemplateColumn Width="60">
-                            <DataGridTemplateColumn.CellTemplate>
-                                <DataTemplate>
-                                    <Button Content="删除" Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}"/>
-                                </DataTemplate>
-                            </DataGridTemplateColumn.CellTemplate>
-                        </DataGridTemplateColumn>
-                    </DataGrid.Columns>
-                </DataGrid>
-
-                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
-                    <Button Content="保存" Command="{Binding SaveCommand}" Margin="0,0,10,0" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                    <Button Content="取消" Command="{Binding CancelCommand}" Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                </StackPanel>
-            </StackPanel>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                            <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
+                        </StackPanel>
+                        <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}" AutoGenerateColumns="False" Height="200" Margin="0,0,0,10">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
+                                <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>
+                                <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="80"/>
+                                <DataGridTextColumn Header="用法" Binding="{Binding Usage}" Width="100"/>
+                                <DataGridTemplateColumn Width="60">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button Content="删除" Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </StackPanel>
+                </controls:CommonProfileView.ProfileContent>
+            </controls:CommonProfileView>
+            
         </Border>
     </Grid>
 </UserControl>

--- a/LYBT.UI.WPF/Views/Profile/UserProfileView.xaml
+++ b/LYBT.UI.WPF/Views/Profile/UserProfileView.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:prism="http://prismlibrary.com/"
+             xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
              prism:ViewModelLocator.AutoWireViewModel="True">
     <Grid>
         <Image Source="/Assets/bg.jpg" Stretch="UniformToFill" Opacity="0.6" Panel.ZIndex="0"/>
@@ -10,26 +11,27 @@
                 <Border.Effect>
                     <DropShadowEffect Color="Black" Opacity="0.16" BlurRadius="18" ShadowDepth="5"/>
                 </Border.Effect>
-                <StackPanel>
-                    <TextBlock Text="用户资料" FontSize="20" FontWeight="Bold" Margin="0,0,0,20" HorizontalAlignment="Center" Foreground="#333"/>
-                    <StackPanel>
-                        <TextBlock Text="账号" />
-                        <TextBox Text="{Binding User.UserName}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <TextBlock Text="姓名" />
-                        <TextBox Text="{Binding User.RealName}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <TextBlock Text="角色" />
-                        <TextBox Text="{Binding User.RolesText}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <TextBlock Text="邮箱" />
-                        <TextBox Text="{Binding User.Email}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <TextBlock Text="联系电话" />
-                        <TextBox Text="{Binding User.PhoneNumber}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <TextBlock Text="创建时间" />
-                        <TextBox Text="{Binding User.CreatedTime, StringFormat=yyyy-MM-dd HH:mm}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <TextBlock Text="最近登录" />
-                        <TextBox Text="{Binding User.LastLoginTime, StringFormat=yyyy-MM-dd HH:mm}" IsReadOnly="True" Margin="0,0,0,8"/>
-                        <CheckBox Content="启用" IsChecked="{Binding User.IsActive}" IsEnabled="False"/>
-                    </StackPanel>
-                </StackPanel>
+                <controls:CommonProfileView Title="用户详细信息">
+                    <controls:CommonProfileView.ProfileContent>
+                        <StackPanel>
+                            <TextBlock Text="账号" />
+                            <TextBox Text="{Binding User.UserName}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <TextBlock Text="姓名" />
+                            <TextBox Text="{Binding User.RealName}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <TextBlock Text="角色" />
+                            <TextBox Text="{Binding User.RolesText}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <TextBlock Text="邮箱" />
+                            <TextBox Text="{Binding User.Email}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <TextBlock Text="联系电话" />
+                            <TextBox Text="{Binding User.PhoneNumber}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <TextBlock Text="创建时间" />
+                            <TextBox Text="{Binding User.CreatedTime, StringFormat=yyyy-MM-dd HH:mm}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <TextBlock Text="最近登录" />
+                            <TextBox Text="{Binding User.LastLoginTime, StringFormat=yyyy-MM-dd HH:mm}" IsReadOnly="True" Margin="0,0,0,8"/>
+                            <CheckBox Content="启用" IsChecked="{Binding User.IsActive}" IsEnabled="False"/>
+                        </StackPanel>
+                    </controls:CommonProfileView.ProfileContent>
+                </controls:CommonProfileView>
             </Border>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Summary
- replace profile view xaml with `CommonProfileView`
- adjust view models to provide dynamic titles ("新建/编辑" etc.)

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6877e29965e88333a3c25a8e00ea00a9