### PR TITLE
Fix XAML name conflict

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -57,7 +57,7 @@
                         <TextBox Text="{Binding EditingUser.RealName}" Margin="0,0,0,8"
                                  IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
                         <TextBlock Text="角色" />
-                        <ListBox x:Name="RolesListBox"
+                        <ListBox
                                  ItemsSource="{Binding RoleList}"
                                  SelectionMode="Multiple"
                                  Margin="0,0,0,8"


### PR DESCRIPTION
## Summary
- remove RolesListBox `x:Name` to avoid duplicate name errors during XAML parsing

## Testing
- `dotnet build LYBTZYZS.sln`

------
https://chatgpt.com/codex/tasks/task_e_68783d5e26388333a0ff83ef8b67ce5e