### PR TITLE
Update PinYin library

### DIFF
--- a/LYBT.CommonUtils/LYBT.CommonUtils.csproj
+++ b/LYBT.CommonUtils/LYBT.CommonUtils.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.International.Converters.PinYinConverter" Version="1.0.0" />
+    <PackageReference Include="PinYinConverterCore" Version="1.0.2" />
     <PackageReference Include="NPOI" Version="2.7.4" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- use `PinYinConverterCore` v1.0.2 instead of the old Pinyin converter

## Testing
- `dotnet restore LYBTZYZS.sln`
- `dotnet build LYBTZYZS.sln -c Release` *(fails: missing namespaces in WebAPI)*
- `dotnet test LYBT.Tests/LYBT.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6878aa1869d883338a3a0e525bc41434