### PR TITLE
Use user's pinyin code for doctor entity

### DIFF
--- a/LYBT.Module.Doctors/Services/DoctorService.cs
+++ b/LYBT.Module.Doctors/Services/DoctorService.cs
@@ -74,7 +74,7 @@ namespace LYBT.Module.Doctors.Services {
             // to be non-null when saving entities. Assign the retrieved user to avoid
             // validation errors when calling SaveChangesAsync.
             model.User = user;
-            model.PinyinCode = CommonUtil.GetPinyinCode(user.RealName);
+            model.PinyinCode = user.PinyinCode;
             try {
                 return await _doctorRepository.AddAsync(model);
             } catch (DbUpdateException ex) {
@@ -94,7 +94,7 @@ namespace LYBT.Module.Doctors.Services {
             model.Specialty = dto.Specialty;
             model.Status = dto.Status;
             model.WorkStatus = dto.WorkStatus;
-            model.PinyinCode = CommonUtil.GetPinyinCode(model.User.RealName);
+            model.PinyinCode = model.User.PinyinCode;
             model.Remark = dto.Remark;
             model.ContactNumber = dto.ContactNumber;
             // 不更新UserId、User

--- a/LYBT.Tests/Services/DoctorServiceTests.cs
+++ b/LYBT.Tests/Services/DoctorServiceTests.cs
@@ -75,7 +75,11 @@ public class DoctorServiceTests
             .Callback<DoctorModel>(m => savedModel = m)
             .ReturnsAsync(true);
         var userRepo = new Mock<IUserRepository>();
-        var existingUser = new UserModel { RealName = "Test" };
+        var existingUser = new UserModel
+        {
+            RealName = "Test",
+            PinyinCode = CommonUtil.GetPinyinCode("Test")
+        };
         userRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(existingUser);
         var mapper = CreateMapper();
         var service = new DoctorService(repo.Object, userRepo.Object, mapper);
@@ -107,7 +111,7 @@ public class DoctorServiceTests
         Assert.Equal(dto.Specialty, savedModel.Specialty);
         Assert.Equal(dto.Status, savedModel.Status);
         Assert.Equal(dto.WorkStatus, savedModel.WorkStatus);
-        var expectedCode = CommonUtil.GetPinyinCode(existingUser.RealName);
+        var expectedCode = existingUser.PinyinCode;
         Assert.Equal(expectedCode, savedModel.PinyinCode);
         Assert.Equal(dto.Remark, savedModel.Remark);
         Assert.Equal(dto.ContactNumber, savedModel.ContactNumber);
@@ -121,7 +125,11 @@ public class DoctorServiceTests
         {
             Id = Guid.NewGuid(),
             UserId = Guid.NewGuid(),
-            User = new UserModel { RealName = "Old" }
+            User = new UserModel
+            {
+                RealName = "Old",
+                PinyinCode = CommonUtil.GetPinyinCode("Old")
+            }
         };
         var repo = new Mock<IDoctorRepository>();
         repo.Setup(r => r.GetByIdAsync(model.Id)).ReturnsAsync(model);
@@ -154,7 +162,7 @@ public class DoctorServiceTests
         Assert.Equal(dto.Specialty, model.Specialty);
         Assert.Equal(dto.Status, model.Status);
         Assert.Equal(dto.WorkStatus, model.WorkStatus);
-        var expectedCode2 = CommonUtil.GetPinyinCode(model.User.RealName);
+        var expectedCode2 = model.User.PinyinCode;
         Assert.Equal(expectedCode2, model.PinyinCode);
         Assert.Equal(dto.Remark, model.Remark);
         Assert.Equal(dto.ContactNumber, model.ContactNumber);


### PR DESCRIPTION
## Summary
- set doctor `PinyinCode` from associated `User` rather than recalculating
- adjust unit tests to expect user's `PinyinCode`

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `/usr/lib/dotnet/dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6878ab2f9a408333b303119d2d91b153