### PR TITLE
Move ListBoxExtensions to common extensions

### DIFF
--- a/LYBT.Common/Extensions/ListBoxExtensions.cs
+++ b/LYBT.Common/Extensions/ListBoxExtensions.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Windows;
 using System.Windows.Controls;
 
-namespace LYBT.UI.WPF.Helpers {
+namespace LYBT.Common.Extensions {
     /// <summary>
     /// Provides binding support for <see cref="ListBox.SelectedItems"/>.
     /// </summary>

--- a/LYBT.Common/LYBT.Common.csproj
+++ b/LYBT.Common/LYBT.Common.csproj
@@ -1,11 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<BaseOutputPath>..\BIN</BaseOutputPath>
-	</PropertyGroup>
+        <PropertyGroup>
+                <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <BaseOutputPath>..\BIN</BaseOutputPath>
+        </PropertyGroup>
+        <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+                <UseWPF>true</UseWPF>
+        </PropertyGroup>
+
+        <ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+                <Compile Remove="Extensions/ListBoxExtensions.cs" />
+                <Compile Include="Extensions/ListBoxExtensions.cs" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(TargetFramework)' != 'net8.0-windows'">
+                <Compile Remove="Extensions/ListBoxExtensions.cs" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.17" />

--- a/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/UserManagementView.xaml
@@ -2,7 +2,7 @@
               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
               xmlns:prism="http://prismlibrary.com/"
-              xmlns:helpers="clr-namespace:LYBT.UI.WPF.Helpers"
+              xmlns:helpers="clr-namespace:LYBT.Common.Extensions;assembly=LYBT.Common"
               xmlns:converters="clr-namespace:LYBT.UI.WPF.Converters;assembly=LYBT.UI.WPF"
               xmlns:controls="clr-namespace:LYBT.WPFControls;assembly=LYBT.WPFControls"
               prism:ViewModelLocator.AutoWireViewModel="True">


### PR DESCRIPTION
## Summary
- move ListBoxExtensions from `LYBT.UI.WPF` into `LYBT.Common` for centralized reuse
- multi-target `LYBT.Common` for `net8.0` and `net8.0-windows`
- update XAML to use the new namespace

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: .NET 8 runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878bd145e7c833393078bb6fd37d1e8