### PR TITLE
Modify admin tab style to use overline

### DIFF
--- a/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
@@ -8,7 +8,8 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <TabControl SelectedIndex="{Binding SelectedTabIndex}">
         <TabControl.Resources>
-            <!-- Preserve MaterialDesign underline styling for selected tab -->
+            <!-- Override MaterialDesignTabItem to draw selection overline -->
+            <ResourceDictionary Source="pack://application:,,,/LYBT.UI.WPF;component/Views/Navigation/Styles/AdminTabItemStyle.xaml" />
             <Style TargetType="TabItem" BasedOn="{StaticResource MaterialDesignTabItem}">
                 <Setter Property="Padding" Value="12,8" />
             </Style>

--- a/LYBT.UI.WPF/Views/Navigation/Styles/AdminTabItemStyle.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/Styles/AdminTabItemStyle.xaml
@@ -1,0 +1,244 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:wpf="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf"
+                    xmlns:converters="clr-namespace:MaterialDesignThemes.Wpf.Converters;assembly=MaterialDesignThemes.Wpf">
+
+  <Style x:Key="MaterialDesignTabItem" TargetType="{x:Type TabItem}">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="FocusVisualStyle" Value="{StaticResource FocusVisual}" />
+    <!-- Foreground is for the content, not the header -->
+    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(TextElement.Foreground), FallbackValue=Black}" />
+    <Setter Property="Height" Value="48" />
+    <Setter Property="MinWidth" Value="90" />
+    <Setter Property="Padding" Value="16,12" />
+    <Setter Property="Template">
+      <Setter.Value>
+        <ControlTemplate TargetType="{x:Type TabItem}">
+          <ControlTemplate.Resources>
+            <Storyboard x:Key="SelectHorizontalTabItem">
+              <DoubleAnimation Storyboard.TargetName="ScaleTransform"
+                               Storyboard.TargetProperty="ScaleY"
+                               From="0"
+                               To="1"
+                               Duration="0" />
+              <DoubleAnimation Storyboard.TargetName="ScaleTransform"
+                               Storyboard.TargetProperty="ScaleX"
+                               From="0"
+                               To="1"
+                               Duration="0:0:0.3">
+                <DoubleAnimation.EasingFunction>
+                  <SineEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+              <DoubleAnimation BeginTime="0:0:0.3"
+                               Storyboard.TargetName="PART_BackgroundSelection"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0.12"
+                               Duration="0" />
+            </Storyboard>
+            <Storyboard x:Key="SelectVerticalTabItem">
+              <DoubleAnimation Storyboard.TargetName="ScaleTransform"
+                               Storyboard.TargetProperty="ScaleX"
+                               From="0"
+                               To="1"
+                               Duration="0" />
+              <DoubleAnimation Storyboard.TargetName="ScaleTransform"
+                               Storyboard.TargetProperty="ScaleY"
+                               From="0"
+                               To="1"
+                               Duration="0:0:0.3">
+                <DoubleAnimation.EasingFunction>
+                  <SineEase EasingMode="EaseOut" />
+                </DoubleAnimation.EasingFunction>
+              </DoubleAnimation>
+              <DoubleAnimation BeginTime="0:0:0.3"
+                               Storyboard.TargetName="PART_BackgroundSelection"
+                               Storyboard.TargetProperty="Opacity"
+                               To="0.12"
+                               Duration="0" />
+            </Storyboard>
+          </ControlTemplate.Resources>
+          <Grid x:Name="Root" Cursor="{Binding Path=(wpf:TabAssist.TabHeaderCursor), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}">
+            <!-- This is the Header label ColorZone. -->
+            <wpf:ColorZone x:Name="ColorZoneHeader"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch"
+                           wpf:ColorZoneAssist.Background="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Background)}"
+                           wpf:ColorZoneAssist.Foreground="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}"
+                           Focusable="False"
+                           Mode="Custom">
+              <wpf:Ripple x:Name="contentPresenter"
+                          Padding="{TemplateBinding Padding}"
+                          HorizontalContentAlignment="Center"
+                          VerticalContentAlignment="Center"
+                          Content="{TemplateBinding Header}"
+                          ContentStringFormat="{TemplateBinding HeaderStringFormat}"
+                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                          ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}"
+                          Focusable="False"
+                          Opacity=".82"
+                          RecognizesAccessKey="True"
+                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"
+                          TextBlock.FontSize="14"
+                          TextBlock.FontWeight="Medium"
+                          TextOptions.TextFormattingMode="Ideal"
+                          TextOptions.TextRenderingMode="Auto"
+                          Typography.Capitals="{TemplateBinding Typography.Capitals}" />
+            </wpf:ColorZone>
+            <Border x:Name="SelectionHighlightBorder"
+                    BorderBrush="{Binding Path=Foreground, ElementName=ColorZoneHeader}"
+                    BorderThickness="0,2,0,0"
+                    RenderTransformOrigin="0.5,0.5"
+                    Visibility="Hidden">
+              <Border.RenderTransform>
+                <ScaleTransform x:Name="ScaleTransform" ScaleX="0" ScaleY="0" />
+              </Border.RenderTransform>
+              <Rectangle x:Name="PART_BackgroundSelection"
+                         Fill="{TemplateBinding Background}"
+                         IsHitTestVisible="False"
+                         Opacity="0.0" />
+            </Border>
+          </Grid>
+          <ControlTemplate.Triggers>
+            <Trigger Property="IsMouseOver" Value="True" SourceName="ColorZoneHeader">
+              <Setter TargetName="Root" Property="Background" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}, Converter={x:Static converters:BrushOpacityConverter.Instance}, ConverterParameter=0.16}" />
+            </Trigger>
+            <Trigger Property="IsEnabled" Value="False">
+              <Setter Property="Opacity" Value="0.38" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+              <Setter TargetName="SelectionHighlightBorder" Property="Visibility" Value="Visible" />
+              <Setter TargetName="contentPresenter" Property="Opacity" Value="1" />
+              <Setter TargetName="contentPresenter" Property="wpf:RippleAssist.IsDisabled" Value="True" />
+            </Trigger>
+            <DataTrigger Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Bottom">
+              <Setter TargetName="SelectionHighlightBorder" Property="BorderThickness" Value="0,0,0,2" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Left">
+              <Setter TargetName="SelectionHighlightBorder" Property="BorderThickness" Value="0,0,2,0" />
+            </DataTrigger>
+            <DataTrigger Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Right">
+              <Setter TargetName="SelectionHighlightBorder" Property="BorderThickness" Value="2,0,0,0" />
+            </DataTrigger>
+
+            <!-- Selected TabItem animations (vary depending on TabControl.TabStripPlacement value) -->
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Top" />
+              </MultiDataTrigger.Conditions>
+              <MultiDataTrigger.EnterActions>
+                <BeginStoryboard Storyboard="{StaticResource SelectHorizontalTabItem}" />
+              </MultiDataTrigger.EnterActions>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Bottom" />
+              </MultiDataTrigger.Conditions>
+              <MultiDataTrigger.EnterActions>
+                <BeginStoryboard Storyboard="{StaticResource SelectHorizontalTabItem}" />
+              </MultiDataTrigger.EnterActions>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Left" />
+              </MultiDataTrigger.Conditions>
+              <MultiDataTrigger.EnterActions>
+                <BeginStoryboard Storyboard="{StaticResource SelectVerticalTabItem}" />
+              </MultiDataTrigger.EnterActions>
+            </MultiDataTrigger>
+            <MultiDataTrigger>
+              <MultiDataTrigger.Conditions>
+                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsSelected}" Value="True" />
+                <Condition Binding="{Binding TabStripPlacement, RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, FallbackValue=Top}" Value="Right" />
+              </MultiDataTrigger.Conditions>
+              <MultiDataTrigger.EnterActions>
+                <BeginStoryboard Storyboard="{StaticResource SelectVerticalTabItem}" />
+              </MultiDataTrigger.EnterActions>
+            </MultiDataTrigger>
+
+            <!-- Force the header foreground do be MaterialDesign.Brush.Foreground by default (only for not filled tabs) -->
+            <Trigger Property="wpf:TabAssist.HasFilledTab" Value="False">
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
+            </Trigger>
+
+            <!-- The header foreground color change when focused (only for not filled tabs) -->
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="Standard" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="PrimaryLight" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Light}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="PrimaryMid" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="PrimaryDark" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Primary.Dark}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="SecondaryLight" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Light}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="SecondaryMid" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="SecondaryDark" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{DynamicResource MaterialDesign.Brush.Secondary.Dark}" />
+            </MultiTrigger>
+            <MultiTrigger>
+              <MultiTrigger.Conditions>
+                <Condition Property="wpf:TabAssist.HasFilledTab" Value="False" />
+                <Condition Property="IsSelected" Value="True" />
+                <Condition Property="wpf:ColorZoneAssist.Mode" Value="Custom" />
+              </MultiTrigger.Conditions>
+              <Setter TargetName="ColorZoneHeader" Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=(wpf:ColorZoneAssist.Foreground)}" />
+            </MultiTrigger>
+          </ControlTemplate.Triggers>
+        </ControlTemplate>
+      </Setter.Value>
+    </Setter>
+    <Setter Property="wpf:ColorZoneAssist.Background" Value="Transparent" />
+    <Setter Property="wpf:ColorZoneAssist.Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:ColorZoneAssist.Foreground), FallbackValue=Black}" />
+    <Setter Property="wpf:ColorZoneAssist.Mode" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:ColorZoneAssist.Mode), FallbackValue=Standard}" />
+    <Setter Property="wpf:DialogHost.RestoreFocusElement" Value="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=TabControl}}" />
+    <Setter Property="wpf:RippleAssist.Feedback" Value="{DynamicResource MaterialDesign.Brush.Button.Ripple}" />
+    <Setter Property="wpf:TabAssist.HasFilledTab" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=(wpf:TabAssist.HasFilledTab), FallbackValue=False}" />
+  </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- override MaterialDesignTabItem style in admin module
- load custom style resource for admin TabControl

## Testing
- `dotnet build LYBTZYZS.sln -restore`

------
https://chatgpt.com/codex/tasks/task_e_6878be1f8cd0833394a09abd550bb742