### PR TITLE
Fix WPF AdminView resources

### DIFF
--- a/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/AdminView.xaml
@@ -8,11 +8,15 @@
              d:DesignHeight="450" d:DesignWidth="800">
     <TabControl SelectedIndex="{Binding SelectedTabIndex}">
         <TabControl.Resources>
-            <!-- Override MaterialDesignTabItem to draw selection overline -->
-            <ResourceDictionary Source="pack://application:,,,/LYBT.UI.WPF;component/Views/Navigation/Styles/AdminTabItemStyle.xaml" />
-            <Style TargetType="TabItem" BasedOn="{StaticResource MaterialDesignTabItem}">
-                <Setter Property="Padding" Value="12,8" />
-            </Style>
+            <ResourceDictionary>
+                <!-- Override MaterialDesignTabItem to draw selection overline -->
+                <ResourceDictionary.MergedDictionaries>
+                    <ResourceDictionary Source="pack://application:,,,/LYBT.UI.WPF;component/Views/Navigation/Styles/AdminTabItemStyle.xaml" />
+                </ResourceDictionary.MergedDictionaries>
+                <Style TargetType="TabItem" BasedOn="{StaticResource MaterialDesignTabItem}">
+                    <Setter Property="Padding" Value="12,8" />
+                </Style>
+            </ResourceDictionary>
         </TabControl.Resources>
         <TabItem Header="用户管理">
             <admin:UserManagementView/>


### PR DESCRIPTION
## Summary
- wrap AdminView TabControl resources in a ResourceDictionary

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c44e79e0833382d578757578fe49