### PR TITLE
Fix missing TabAssist property

### DIFF
--- a/LYBT.UI.WPF/Views/Navigation/Styles/AdminTabItemStyle.xaml
+++ b/LYBT.UI.WPF/Views/Navigation/Styles/AdminTabItemStyle.xaml
@@ -58,7 +58,7 @@
                                Duration="0" />
             </Storyboard>
           </ControlTemplate.Resources>
-          <Grid x:Name="Root" Cursor="{Binding Path=(wpf:TabAssist.TabHeaderCursor), RelativeSource={RelativeSource AncestorType={x:Type TabControl}}}">
+          <Grid x:Name="Root">
             <!-- This is the Header label ColorZone. -->
             <wpf:ColorZone x:Name="ColorZoneHeader"
                            HorizontalAlignment="Stretch"


### PR DESCRIPTION
## Summary
- remove TabAssist.TabHeaderCursor binding that causes XamlParseException

## Testing
- `/usr/share/dotnet/dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6878f1db9fb083339f60157b42ff931f