### PR TITLE
Fix HerbInputControl DataContext

### DIFF
--- a/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
@@ -19,7 +19,6 @@ namespace LYBT.WPFControls {
             AddCommand = new RelayCommand(_ => AddCurrent(), _ => CanAdd());
             RemoveCommand = new RelayCommand(p => RemoveItem(p as PrescriptionItemDto));
             InitializeComponent();
-            DataContext = this;
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
## Summary
- remove explicit DataContext assignment from `HerbInputControl`

## Testing
- `dotnet test LYBT.Tests/LYBT.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6878f216ff908333b88dc2308e792165