### PR TITLE
Add MaterialDesign theme toggling

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -76,6 +76,8 @@ namespace LYBT.UI.WPF {
             var queueingService = new QueueingService(queueingApi);
             var diagnosisTreatmentService = new DiagnosisTreatmentService(diagnosisTreatmentApi);
 
+            var themeService = new ThemeService();
+
 
             // 4. 用RegisterInstance注册，后续所有用IAuthService和IAuthApi的地方都能用  
             containerRegistry.RegisterInstance(authApi);
@@ -112,6 +114,7 @@ namespace LYBT.UI.WPF {
             containerRegistry.RegisterInstance<IRecordService>(recordService);
             containerRegistry.RegisterInstance<IQueueingService>(queueingService);
             containerRegistry.RegisterInstance<IDiagnosisTreatmentService>(diagnosisTreatmentService);
+            containerRegistry.RegisterInstance<IThemeService>(themeService);
             // Register profile view models for dependency injection
             containerRegistry.Register<HerbProfileViewModel>();
             containerRegistry.Register<PrescriptionProfileViewModel>();

--- a/LYBT.UI.WPF/Interfaces/IThemeService.cs
+++ b/LYBT.UI.WPF/Interfaces/IThemeService.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace LYBT.UI.WPF.Interfaces {
+    /// <summary>
+    /// Provides theme switching capabilities.
+    /// </summary>
+    public interface IThemeService {
+        /// <summary>
+        /// Indicates whether the dark theme is currently active.
+        /// </summary>
+        bool IsDarkTheme { get; }
+
+        /// <summary>
+        /// Toggles between light and dark base themes.
+        /// </summary>
+        void ToggleTheme();
+    }
+}

--- a/LYBT.UI.WPF/Services/ThemeService.cs
+++ b/LYBT.UI.WPF/Services/ThemeService.cs
@@ -1,0 +1,26 @@
+using MaterialDesignThemes.Wpf;
+using LYBT.UI.WPF.Interfaces;
+
+namespace LYBT.UI.WPF.Services {
+    /// <summary>
+    /// Default implementation for <see cref="IThemeService"/> using MaterialDesignThemes.
+    /// </summary>
+    public class ThemeService : IThemeService {
+        private readonly PaletteHelper _paletteHelper = new();
+
+        /// <inheritdoc />
+        public bool IsDarkTheme {
+            get {
+                var theme = _paletteHelper.GetTheme();
+                return theme.GetBaseTheme() == BaseTheme.Dark;
+            }
+        }
+
+        /// <inheritdoc />
+        public void ToggleTheme() {
+            var theme = _paletteHelper.GetTheme();
+            theme.SetBaseTheme(IsDarkTheme ? BaseTheme.Light : BaseTheme.Dark);
+            _paletteHelper.SetTheme(theme);
+        }
+    }
+}

--- a/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Main/MainWindowViewModel.cs
@@ -60,6 +60,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
         public DelegateCommand ShowChangeProfileCommand { get; }
         public DelegateCommand ShowDoctorProfileCommand { get; }
         public DelegateCommand ShowPatientProfileCommand { get; }
+        public DelegateCommand ToggleThemeCommand { get; }
 
 
         private readonly IEventAggregator _eventAggregator;
@@ -67,12 +68,16 @@ namespace LYBT.UI.WPF.ViewModels.Main {
 
         private readonly IAuthService _authService;
         private readonly IDoctorService _doctorService;
+        private readonly IThemeService _themeService;
 
-        public MainWindowViewModel(IEventAggregator eventAggregator, IRegionManager regionManager, IAuthService authService, IDoctorService doctorService) {
+        public MainWindowViewModel(IEventAggregator eventAggregator, IRegionManager regionManager,
+                                   IAuthService authService, IDoctorService doctorService,
+                                   IThemeService themeService) {
             _eventAggregator = eventAggregator;
             _regionManager = regionManager;
             _authService = authService;
             _doctorService = doctorService;
+            _themeService = themeService;
 
             // 订阅登录成功事件
             _eventAggregator.GetEvent<LoginSuccessEvent>().Subscribe(OnLoginSuccess);
@@ -83,6 +88,7 @@ namespace LYBT.UI.WPF.ViewModels.Main {
             ShowChangeProfileCommand = new DelegateCommand(ShowChangeProfile);
             ShowDoctorProfileCommand = new DelegateCommand(ShowDoctorProfile);
             ShowPatientProfileCommand = new DelegateCommand(ShowPatientProfile);
+            ToggleThemeCommand = new DelegateCommand(() => _themeService.ToggleTheme());
 
             System.Diagnostics.Debug.WriteLine("MainWindowViewModel constructed");
         }

--- a/LYBT.UI.WPF/Views/Main/MainWindow.xaml
+++ b/LYBT.UI.WPF/Views/Main/MainWindow.xaml
@@ -68,6 +68,11 @@
                     Background="#FF57606A" Foreground="White"
                     FontWeight="Bold" BorderThickness="0"
                     Cursor="Hand"/>
+                        <Button Style="{StaticResource MaterialDesignToolButton}"
+                                Command="{Binding ToggleThemeCommand}"
+                                Margin="0,0,10,0">
+                            <materialDesign:PackIcon Kind="ThemeLightDark"/>
+                        </Button>
                         <Button Style="{StaticResource MaterialDesignRaisedButton}" Content="退出登录"
                     Width="100" Height="34"
                     Command="{Binding LogoutCommand}"


### PR DESCRIPTION
## Summary
- add IThemeService and ThemeService for MaterialDesign palette control
- register ThemeService in App startup
- expose ToggleThemeCommand in MainWindowViewModel
- add toggle button in the main window header

## Testing
- `dotnet build LYBT.UI.WPF/LYBT.UI.WPF.csproj`
- `dotnet test --no-build` *(fails: required .NET SDK/runtime mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6878f458cf8483338cb6d1ecba5424bf