### PR TITLE
Fix DrawerHost property for MaterialDesign v5

### DIFF
--- a/LYBT.UI.WPF/Views/Main/HomeView.xaml
+++ b/LYBT.UI.WPF/Views/Main/HomeView.xaml
@@ -4,7 +4,7 @@
              xmlns:prism="http://prismlibrary.com/"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              prism:ViewModelLocator.AutoWireViewModel="True">
-    <materialDesign:DrawerHost IsLeftDrawerOpen="{Binding DataContext.IsNavDrawerOpen, RelativeSource={RelativeSource AncestorType=Window}, Mode=TwoWay}" AutoCloseDrawer="True">
+    <materialDesign:DrawerHost IsLeftDrawerOpen="{Binding DataContext.IsNavDrawerOpen, RelativeSource={RelativeSource AncestorType=Window}, Mode=TwoWay}" LeftDrawerCloseOnClickAway="True">
         <materialDesign:DrawerHost.LeftDrawerContent>
             <ListBox Width="180"
                      ItemsSource="{Binding NavigationItems}"


### PR DESCRIPTION
## Summary
- update `HomeView.xaml` to use `LeftDrawerCloseOnClickAway` instead of the old `AutoCloseDrawer`

## Testing
- `dotnet build LYBTZYZS.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6878fdeba028833386351ff6da1a1f37