### PR TITLE
Fix PopupBox property usage

### DIFF
--- a/LYBT.UI.WPF/Views/Main/MainWindow.xaml
+++ b/LYBT.UI.WPF/Views/Main/MainWindow.xaml
@@ -52,8 +52,10 @@
                                             VerticalAlignment="Center"
                                             Margin="0,0,22,0"
                                             StaysOpen="False"
-                                            PopupPlacement="Bottom">
-                        <materialDesign:PackIcon Kind="AccountCircle" />
+                                            PlacementMode="BottomAndAlignRightEdges">
+                        <materialDesign:PopupBox.ToggleContent>
+                            <materialDesign:PackIcon Kind="AccountCircle" />
+                        </materialDesign:PopupBox.ToggleContent>
                         <materialDesign:PopupBox.PopupContent>
                             <StackPanel Margin="8">
                                 <Button Style="{StaticResource MaterialDesignFlatButton}"


### PR DESCRIPTION
## Summary
- fix placement property for MaterialDesign PopupBox
- set toggle content explicitly to avoid multiple PopupContent error

## Testing
- `dotnet test` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687905b499548333bc0992a3029994d6