### PR TITLE
Fix base URL fallback

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -25,8 +25,9 @@ namespace LYBT.UI.WPF {
             // 1. 构造无Token的HttpClient，首次登录还没有token，正常用即可  
             string? baseUrl = ConfigurationManager.AppSettings["WebApiBaseUrl"];
 
-            if (string.IsNullOrEmpty(baseUrl)) {
-                throw new InvalidOperationException("WebApiBaseUrl is not configured in AppSettings.");
+            if (string.IsNullOrWhiteSpace(baseUrl)) {
+                // 如果配置缺失，默认回退到本地 Web API 地址
+                baseUrl = "http://localhost:5297/";
             }
 
             var tokenHandler = new TokenHandler { InnerHandler = new HttpClientHandler() };


### PR DESCRIPTION
## Summary
- default to localhost if `WebApiBaseUrl` isn't set

## Testing
- `dotnet build LYBT.UI.WPF/LYBT.UI.WPF.csproj -c Debug`
- `dotnet test LYBTZYZS.sln -v minimal` *(fails: required .NET runtime 8.0.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68791014a96c8333971768e66e4dd59c