### PR TITLE
Reduce EF command logs

### DIFF
--- a/LYBT.WebAPI/appsettings.Development.json
+++ b/LYBT.WebAPI/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   }
 }

--- a/LYBT.WebAPI/appsettings.example.json
+++ b/LYBT.WebAPI/appsettings.example.json
@@ -21,7 +21,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   },
   "AllowedHosts": "*"

--- a/LYBT.WebAPI/appsettings.json
+++ b/LYBT.WebAPI/appsettings.json
@@ -21,7 +21,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
## Summary
- quiet Entity Framework command logs by setting `Microsoft.EntityFrameworkCore.Database.Command` level to Warning

## Testing
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68791107b08c83339a5f0112a0f11ee6