### PR TITLE
Fix DataContext for DoctorProfileView

### DIFF
--- a/LYBT.UI.WPF/App.xaml.cs
+++ b/LYBT.UI.WPF/App.xaml.cs
@@ -12,6 +12,7 @@ using System.Text.Json.Serialization;
 using System.Windows;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.UI.WPF.Views.Navigation;
+using Prism.Mvvm;
 
 namespace LYBT.UI.WPF {
     /// <summary>
@@ -122,6 +123,8 @@ namespace LYBT.UI.WPF {
             containerRegistry.Register<FormulaTemplatesProfileViewModel>();
             containerRegistry.Register<DoctorProfileViewModel>();
             containerRegistry.Register<PatientProfileViewModel>();
+            // Map profile views to their view models where naming conventions don't match
+            ViewModelLocationProvider.Register<DoctorProfileView, DoctorProfileViewModel>();
             // 5. 如果你还有其他API接口，也用同样方式new出来后RegisterInstance  
             containerRegistry.RegisterForNavigation<LoginView>("LoginView");
             containerRegistry.RegisterForNavigation<MainWindow>("MainWindow");


### PR DESCRIPTION
## Summary
- ensure DoctorProfileView resolves its ViewModel
- map DoctorProfileView to DoctorProfileViewModel in DI container

## Testing
- `dotnet test` *(fails: requires .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68791a29a6a88333915772c37fd750f4