### PR TITLE
Fix herb auto-complete suggestion not hiding

### DIFF
--- a/LYBT.WPFControls/Controls/HerbInputControl.xaml
+++ b/LYBT.WPFControls/Controls/HerbInputControl.xaml
@@ -14,7 +14,8 @@
             <Grid>
                 <TextBox x:Name="PART_HerbBox" Width="160" Margin="0"
                          Text="{Binding HerbText, ElementName=root, UpdateSourceTrigger=PropertyChanged}"
-                         KeyDown="PART_HerbBox_KeyDown"/>
+                         KeyDown="PART_HerbBox_KeyDown"
+                         LostKeyboardFocus="PART_HerbBox_LostKeyboardFocus"/>
                 <Border Background="White" BorderBrush="#DDD" BorderThickness="1" 
                         Visibility="{Binding IsSuggestionVisible, ElementName=root, Converter={StaticResource BoolToVisibilityConverter}}"
                         Margin="0,23,0,0">

--- a/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
@@ -145,12 +145,21 @@ namespace LYBT.WPFControls {
                     e.Handled = true;
                     PART_AmountBox.Focus();
                 }
+            } else if (e.Key == Key.Tab) {
+                if (IsSuggestionVisible && SelectedSuggestion != null) {
+                    // Use Tab to accept the suggestion and move focus
+                    HerbText = SelectedSuggestion.Name;
+                    IsSuggestionVisible = false;
+                }
             }
         }
 
         private void PART_SuggestionList_KeyDown(object sender, KeyEventArgs e) {
             if (e.Key == Key.Enter) {
                 if (SelectedSuggestion != null) {
+                    // confirm the selected herb and hide suggestion list
+                    HerbText = SelectedSuggestion.Name;
+                    IsSuggestionVisible = false;
                     PART_AmountBox.Focus();
                 }
             }
@@ -162,6 +171,12 @@ namespace LYBT.WPFControls {
                     AddCommand.Execute(null);
                     e.Handled = true;
                 }
+            }
+        }
+
+        private void PART_HerbBox_LostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e) {
+            if (!PART_SuggestionList.IsKeyboardFocusWithin) {
+                IsSuggestionVisible = false;
             }
         }
     }


### PR DESCRIPTION
## Summary
- hide suggestion list when user commits a herb choice
- allow Tab to select suggestion from herb textbox
- hide suggestion list when textbox loses focus

## Testing
- `dotnet test LYBTZYZS.sln -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792178f11483338423c45ea80bb17f