### PR TITLE
Fix missing DI setup for prescriptions module

### DIFF
--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -33,6 +33,10 @@ using LYBT.Module.Patients.Interfaces;
 using LYBT.Module.Patients.Mapping;
 using LYBT.Module.Patients.Repositories;
 using LYBT.Module.Patients.Services;
+using LYBT.Module.Prescriptions.Interfaces;
+using LYBT.Module.Prescriptions.Mapping;
+using LYBT.Module.Prescriptions.Repositories;
+using LYBT.Module.Prescriptions.Services;
 using LYBT.Module.Queueing.Interfaces;
 using LYBT.Module.Queueing.Mapping;
 using LYBT.Module.Queueing.Repositories;
@@ -113,6 +117,10 @@ builder.Services.AddScoped<IRecordRepository, RecordRepository>();
 builder.Services.AddScoped<ILogService, LogService>();
 builder.Services.AddScoped<ILogRepository, LogRepository>();
 
+// 处方管理
+builder.Services.AddScoped<IPrescriptionService, PrescriptionService>();
+builder.Services.AddScoped<IPrescriptionRepository, PrescriptionRepository>();
+
 // 同步管理
 builder.Services.AddScoped<ISyncService, SyncService>();
 builder.Services.AddScoped<ISyncRepository, SyncRepository>();
@@ -135,6 +143,7 @@ builder.Services.AddAutoMapper(
     typeof(FormulaTemplateMappingProfile),
     typeof(LogMappingProfile),
     typeof(SyncMappingProfile),
+    typeof(PrescriptionMappingProfile),
    typeof(SettingsMappingProfile)
 );
 


### PR DESCRIPTION
## Summary
- add DI wiring for prescriptions module to WebAPI
- include prescription AutoMapper profile

## Testing
- `dotnet test LYBT.Tests/LYBT.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687924d00c7c8333a833ca082d25601e