### PR TITLE
Fix freeze when typing herbs

### DIFF
--- a/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/HerbInputControl.xaml.cs
@@ -95,7 +95,8 @@ namespace LYBT.WPFControls {
             var items = Herbs.Where(h => !ItemsSource.Any(i => i.HerbId == h.Id) &&
                 (h.Name.Contains(text, StringComparison.OrdinalIgnoreCase) ||
                  (!string.IsNullOrEmpty(h.Pinyin) && h.Pinyin.Contains(text, StringComparison.OrdinalIgnoreCase)) ||
-                 (!string.IsNullOrEmpty(h.Pinyin) && GetInitials(h.Pinyin).StartsWith(text))));
+                 (!string.IsNullOrEmpty(h.Pinyin) && GetInitials(h.Pinyin).StartsWith(text))))
+                .Take(20); // limit suggestion count to avoid UI freeze with large lists
             foreach (var h in items)
                 FilteredHerbs.Add(h);
             IsSuggestionVisible = FilteredHerbs.Count > 0;


### PR DESCRIPTION
## Summary
- limit herb suggestion list size to avoid UI freeze

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687928840d7883339b3674120cdacce8