### PR TITLE
Fix WPF namescope error

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -44,7 +44,7 @@
                             <TextBlock Text="名称" Width="60"/>
                             <TextBox Text="{Binding Template.Name}" Width="300"/>
                         </StackPanel>
-                        <DataGrid x:Name="EditItemsGrid" ItemsSource="{Binding Items}" AutoGenerateColumns="False"
+                        <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False"
                                   SelectedItem="{Binding SelectedItem}" Height="200" Margin="0,0,0,10"
                                   Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"
                                   CellEditEnding="EditItemsGrid_CellEditEnding">


### PR DESCRIPTION
## Summary
- remove `x:Name` from the DataGrid inside `CommonProfileView`'s content to avoid duplicate namescope errors

## Testing
- `dotnet test LYBT.Tests/LYBT.Tests.csproj --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68792f8375c08333a1cb39d46b5fb739