### PR TITLE
Fix DataGrid new item placeholder binding

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -44,7 +44,7 @@
                             <TextBlock Text="名称" Width="60"/>
                             <TextBox Text="{Binding Template.Name}" Width="300"/>
                         </StackPanel>
-                        <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False"
+                        <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" CanUserAddRows="False"
                                   SelectedItem="{Binding SelectedItem}" Height="200" Margin="0,0,0,10"
                                   Visibility="{Binding IsEditable, Converter={StaticResource BoolToVisibilityConverter}}"
                                   CellEditEnding="EditItemsGrid_CellEditEnding">
@@ -79,7 +79,7 @@
                                 </DataGridTemplateColumn>
                             </DataGrid.Columns>
                         </DataGrid>
-                        <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" SelectedItem="{Binding SelectedItem}" Height="200" Margin="0,0,0,10" Visibility="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}">
+                        <DataGrid ItemsSource="{Binding Items}" AutoGenerateColumns="False" CanUserAddRows="False" SelectedItem="{Binding SelectedItem}" Height="200" Margin="0,0,0,10" Visibility="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}">
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
                                 <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>

--- a/LYBT.UI.WPF/Views/Admin/PrescriptionManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/PrescriptionManagementView.xaml
@@ -54,7 +54,7 @@
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                             <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
                         </StackPanel>
-                        <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}" AutoGenerateColumns="False" Height="200" Margin="0,0,0,10">
+                        <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="False" Height="200" Margin="0,0,0,10">
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
                                 <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>


### PR DESCRIPTION
## Summary
- prevent `DataGrid.SelectedItem` from binding to `{NewItemPlaceholder}` by disabling automatic row creation
- update prescription management view accordingly

## Testing
- `DOTNET_ROOT=/usr/lib/dotnet PATH=/usr/lib/dotnet:$PATH /usr/lib/dotnet/dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687931b670dc8333915631d23c9468cb