### PR TITLE
Add herb entry editor behaviors

### DIFF
--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
@@ -21,9 +21,24 @@
         <DataGrid x:Name="PART_Grid" Grid.Row="1" AutoGenerateColumns="False" CanUserAddRows="False"
                   ItemsSource="{Binding HerbItems, RelativeSource={RelativeSource AncestorType=UserControl}}"
                   IsReadOnly="{Binding ReadOnly, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                  PreviewKeyDown="Grid_PreviewKeyDown">
+                  PreviewKeyDown="Grid_PreviewKeyDown" CellEditEnding="Grid_CellEditEnding">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="药材" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                <DataGridTemplateColumn Header="药材" Width="*">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding Name}" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                        <DataTemplate>
+                            <ComboBox IsEditable="True" IsTextSearchEnabled="True" StaysOpenOnEdit="True"
+                                      ItemsSource="{Binding HerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                      DisplayMemberPath="Name" SelectedValuePath="Name"
+                                      SelectedValue="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      SelectionChanged="HerbCombo_SelectionChanged" />
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                </DataGridTemplateColumn>
                 <DataGridTextColumn Header="剂量" Binding="{Binding Dosage, UpdateSourceTrigger=PropertyChanged}" Width="80"/>
                 <DataGridTextColumn Header="单位" Binding="{Binding Unit, UpdateSourceTrigger=PropertyChanged}" Width="80"/>
                 <DataGridTextColumn Header="用法" Binding="{Binding Usage, UpdateSourceTrigger=PropertyChanged}" Width="120"/>

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
@@ -1,14 +1,18 @@
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using LYBT.Common.HerbCombination;
+using LYBT.Module.Herbs.Dtos;
 
 namespace LYBT.WPFControls.HerbCombinationEditor {
     public partial class HerbCombinationEditorControl : UserControl {
         public HerbCombinationEditorControl() {
             HerbItems = new ObservableCollection<HerbCombinationItem>();
             InitializeComponent();
+            Loaded += (_, __) => EnsureBlankRow();
         }
 
         public ObservableCollection<HerbCombinationItem> HerbItems {
@@ -75,6 +79,21 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
         public static readonly DependencyProperty CancelCommandProperty =
             DependencyProperty.Register(nameof(CancelCommand), typeof(ICommand), typeof(HerbCombinationEditorControl));
 
+        private void EnsureBlankRow()
+        {
+            if (!ReadOnly && HerbItems.Count == 0)
+                HerbItems.Add(new HerbCombinationItem());
+        }
+
+        public IEnumerable<HerbDto> HerbCatalog
+        {
+            get => (IEnumerable<HerbDto>)GetValue(HerbCatalogProperty);
+            set => SetValue(HerbCatalogProperty, value);
+        }
+
+        public static readonly DependencyProperty HerbCatalogProperty =
+            DependencyProperty.Register(nameof(HerbCatalog), typeof(IEnumerable<HerbDto>), typeof(HerbCombinationEditorControl), new PropertyMetadata(Array.Empty<HerbDto>()));
+
         private void Grid_PreviewKeyDown(object sender, KeyEventArgs e) {
             if (e.Key == Key.Tab && !ReadOnly) {
                 var grid = (DataGrid)sender;
@@ -92,6 +111,63 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
                         grid.BeginEdit();
                     }
                 });
+                e.Handled = true;
+            }
+            else if (e.Key == Key.Enter && !ReadOnly) {
+                var grid = (DataGrid)sender;
+                var rowIndex = grid.Items.IndexOf(grid.CurrentItem);
+                var colIndex = grid.Columns.IndexOf(grid.CurrentCell.Column);
+                if (colIndex == grid.Columns.Count - 1 && rowIndex >= 0 && rowIndex < HerbItems.Count) {
+                    var item = HerbItems[rowIndex];
+                    if (!string.IsNullOrWhiteSpace(item.Name) && item.Dosage != null) {
+                        if (rowIndex == HerbItems.Count - 1)
+                            HerbItems.Add(new HerbCombinationItem());
+                        e.Handled = true;
+                        grid.Dispatcher.InvokeAsync(() => {
+                            grid.SelectedIndex = rowIndex + 1;
+                            grid.CurrentCell = new DataGridCellInfo(grid.Items[rowIndex + 1], grid.Columns[0]);
+                            grid.BeginEdit();
+                        });
+                    }
+                }
+            }
+        }
+
+        private void HerbCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.AddedItems.Count > 0 && sender is ComboBox cb && cb.DataContext is HerbCombinationItem item && e.AddedItems[0] is HerbDto dto)
+            {
+                item.HerbId = dto.Id.ToString();
+                item.Name = dto.Name;
+                item.Unit = dto.Unit;
+            }
+        }
+
+        private void Grid_CellEditEnding(object sender, DataGridCellEditEndingEventArgs e)
+        {
+            if (e.Column.DisplayIndex == 0 && e.EditingElement is TextBox tb)
+            {
+                var input = tb.Text.Trim();
+                if (!string.IsNullOrEmpty(input))
+                {
+                    var matches = HerbCatalog.Where(h => string.Equals(h.Name, input, System.StringComparison.OrdinalIgnoreCase) || (h.Pinyin?.StartsWith(input, System.StringComparison.OrdinalIgnoreCase) ?? false)).ToList();
+                    if (matches.Count == 0)
+                    {
+                        MessageBox.Show("No such herb found in the database.", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    }
+                    else if (matches.Count == 1 && e.Row.Item is HerbCombinationItem item)
+                    {
+                        var dto = matches[0];
+                        item.HerbId = dto.Id.ToString();
+                        item.Name = dto.Name;
+                        item.Unit = dto.Unit;
+                        var grid = (DataGrid)sender;
+                        grid.Dispatcher.InvokeAsync(() => {
+                            grid.CurrentCell = new DataGridCellInfo(e.Row.Item, grid.Columns[1]);
+                            grid.BeginEdit();
+                        });
+                    }
+                }
             }
         }
     }

--- a/LYBT.WPFControls/HerbCombinationEditor/README.md
+++ b/LYBT.WPFControls/HerbCombinationEditor/README.md
@@ -18,3 +18,17 @@ Set `Mode` to `Template` to display the formula name input. In `Prescription`
 mode the name field is hidden. Bind `HerbItems` to an
 `ObservableCollection<HerbCombinationItem>` for editing.
 Use `ReadOnly="True"` to disable editing.
+
+## Interaction Design
+
+The herb entry table uses a DataGrid and supports full keyboard operation for fast batch input.
+
+1. A blank row is always present at the end of the grid so the user can start typing immediately.
+2. When editing the **herb name** cell:
+   - If the typed name does not exist in the master herb list, the editor should display a message: `"No such herb found in the database."`.
+   - When the input uniquely matches one herb (by full name or pinyin code), the herb is auto-selected. Pressing **Enter** confirms the choice and moves focus to the dosage cell.
+   - If multiple matches are found, a dropdown list appears. The user can cycle through candidates with **Tab** or the **Up/Down** keys. Pressing **Enter** confirms the current selection and also moves focus to the dosage field.
+3. After both **herb name** and **dosage** in the current row are filled, pressing **Enter** on the last editable cell automatically creates a new blank row and focuses the herb name field in that row.
+4. All interactions are designed to be completed with the keyboard without requiring the mouse.
+5. The workflow repeats for each new row to maximise entry efficiency.
+


### PR DESCRIPTION
## Summary
- implement auto-complete ComboBox for herb name
- show validation when herb not found and focus dosage on unique match
- auto-create new row on Enter

## Testing
- `dotnet test LYBTZYZS.sln -v minimal` *(fails: missing Microsoft.NETCore.App 8.0 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68799f493efc8333aee84c274fc6d285