### PR TITLE
Implement herb matching and auto-row creation

### DIFF
--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
@@ -31,11 +31,11 @@
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
                         <DataTemplate>
-                            <ComboBox IsEditable="True" IsTextSearchEnabled="True" StaysOpenOnEdit="True"
-                                      ItemsSource="{Binding HerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                            <ComboBox IsEditable="True" IsTextSearchEnabled="False" StaysOpenOnEdit="True"
+                                      ItemsSource="{Binding FilteredHerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                       DisplayMemberPath="Name" SelectedValuePath="Id" TextSearch.TextPath="Name"
                                       SelectedValue="{Binding HerbId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                      SelectionChanged="HerbCombo_SelectionChanged" />
+                                      KeyUp="HerbCombo_KeyUp" SelectionChanged="HerbCombo_SelectionChanged" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
@@ -92,7 +92,34 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
         }
 
         public static readonly DependencyProperty HerbCatalogProperty =
-            DependencyProperty.Register(nameof(HerbCatalog), typeof(IEnumerable<HerbDto>), typeof(HerbCombinationEditorControl), new PropertyMetadata(Array.Empty<HerbDto>()));
+            DependencyProperty.Register(
+                nameof(HerbCatalog),
+                typeof(IEnumerable<HerbDto>),
+                typeof(HerbCombinationEditorControl),
+                new PropertyMetadata(Array.Empty<HerbDto>(), OnHerbCatalogChanged));
+
+        public ObservableCollection<HerbDto> FilteredHerbCatalog { get; } = new();
+
+        private static void OnHerbCatalogChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is HerbCombinationEditorControl ctrl)
+                ctrl.UpdateFilter(string.Empty);
+        }
+
+        private void UpdateFilter(string text)
+        {
+            FilteredHerbCatalog.Clear();
+            IEnumerable<HerbDto> query = HerbCatalog;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                var upper = text.ToUpperInvariant();
+                query = query.Where(h =>
+                    h.Name.Contains(text, StringComparison.OrdinalIgnoreCase) ||
+                    (!string.IsNullOrEmpty(h.Pinyin) && h.Pinyin.Contains(upper)));
+            }
+            foreach (var h in query)
+                FilteredHerbCatalog.Add(h);
+        }
 
         private void Grid_PreviewKeyDown(object sender, KeyEventArgs e) {
             if (e.Key == Key.Tab && !ReadOnly) {
@@ -117,18 +144,40 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
                 var grid = (DataGrid)sender;
                 var rowIndex = grid.Items.IndexOf(grid.CurrentItem);
                 var colIndex = grid.Columns.IndexOf(grid.CurrentCell.Column);
-                if (colIndex == grid.Columns.Count - 1 && rowIndex >= 0 && rowIndex < HerbItems.Count) {
+                if (rowIndex >= 0 && rowIndex < HerbItems.Count) {
                     var item = HerbItems[rowIndex];
-                    if (!string.IsNullOrWhiteSpace(item.Name) && item.Dosage != null) {
+                    if (colIndex == 0) {
+                        e.Handled = true;
+                        grid.Dispatcher.InvokeAsync(() => {
+                            grid.CurrentCell = new DataGridCellInfo(grid.Items[rowIndex], grid.Columns[1]);
+                            grid.BeginEdit();
+                        });
+                    }
+                    else if (!string.IsNullOrWhiteSpace(item.Name) && item.Dosage != null) {
+                        e.Handled = true;
                         if (rowIndex == HerbItems.Count - 1)
                             HerbItems.Add(new HerbCombinationItem());
-                        e.Handled = true;
                         grid.Dispatcher.InvokeAsync(() => {
                             grid.SelectedIndex = rowIndex + 1;
                             grid.CurrentCell = new DataGridCellInfo(grid.Items[rowIndex + 1], grid.Columns[0]);
                             grid.BeginEdit();
                         });
                     }
+                }
+            }
+        }
+
+        private void HerbCombo_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (sender is ComboBox cb)
+            {
+                UpdateFilter(cb.Text);
+                cb.IsDropDownOpen = FilteredHerbCatalog.Count > 0;
+                if (FilteredHerbCatalog.Count == 1 &&
+                    FilteredHerbCatalog[0].Name.Equals(cb.Text, StringComparison.OrdinalIgnoreCase))
+                {
+                    cb.SelectedItem = FilteredHerbCatalog[0];
+                    cb.IsDropDownOpen = false;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- enhance `HerbCombinationEditorControl` with real-time herb filtering
- auto-focus dosage field and create new rows on <Enter>
- wire up combo box key events

## Testing
- `dotnet test -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879bc4573948333946756347b9aa8aa