### PR TITLE
Implement MaterialDesign autocomplete for herb input

### DIFF
--- a/LYBT.Common/HerbCombination/HerbCombinationEditorViewModel.cs
+++ b/LYBT.Common/HerbCombination/HerbCombinationEditorViewModel.cs
@@ -10,6 +10,19 @@ public class HerbCombinationEditorViewModel : INotifyPropertyChanged
 {
     public ObservableCollection<HerbCombinationItem> Items { get; } = new();
 
+    /// <summary>
+    /// Remove rows where both name and dosage are empty.
+    /// </summary>
+    public void CleanEmptyRows()
+    {
+        for (int i = Items.Count - 1; i >= 0; i--)
+        {
+            var it = Items[i];
+            if (string.IsNullOrWhiteSpace(it.Name) && it.Dosage == null)
+                Items.RemoveAt(i);
+        }
+    }
+
     private string _formulaName = string.Empty;
     public string FormulaName
     {
@@ -36,9 +49,11 @@ public class HerbCombinationEditorViewModel : INotifyPropertyChanged
         for (int i = 0; i < Items.Count; i++)
         {
             var it = Items[i];
-            if (string.IsNullOrWhiteSpace(it.HerbId) || string.IsNullOrWhiteSpace(it.Name) || it.Dosage == null)
+            bool error = string.IsNullOrWhiteSpace(it.HerbId) || string.IsNullOrWhiteSpace(it.Name) || it.Dosage == null;
+            it.HasError = error;
+            if (error)
             {
-                message = $"Row {i + 1} requires a valid herb and dosage";
+                message = "Incomplete herb information";
                 return false;
             }
         }

--- a/LYBT.Common/HerbCombination/HerbCombinationItem.cs
+++ b/LYBT.Common/HerbCombination/HerbCombinationItem.cs
@@ -3,20 +3,91 @@ namespace LYBT.Common.HerbCombination;
 /// <summary>
 /// Represents a single herb entry within a combination.
 /// </summary>
-public class HerbCombinationItem
+using System.ComponentModel;
+
+public class HerbCombinationItem : INotifyPropertyChanged
 {
     /// <summary>
     /// Linked herb identifier from the master Herbs table.
     /// </summary>
-    public string? HerbId { get; set; }
+    private string? _herbId;
+    public string? HerbId
+    {
+        get => _herbId;
+        set
+        {
+            _herbId = value;
+            OnPropertyChanged(nameof(HerbId));
+        }
+    }
 
-    public string Name { get; set; } = string.Empty;
+    private string _name = string.Empty;
+    public string Name
+    {
+        get => _name;
+        set
+        {
+            _name = value;
+            OnPropertyChanged(nameof(Name));
+        }
+    }
 
-    public decimal? Dosage { get; set; }
+    private decimal? _dosage;
+    public decimal? Dosage
+    {
+        get => _dosage;
+        set
+        {
+            _dosage = value;
+            OnPropertyChanged(nameof(Dosage));
+        }
+    }
 
-    public string? Unit { get; set; }
+    private string? _unit;
+    public string? Unit
+    {
+        get => _unit;
+        set
+        {
+            _unit = value;
+            OnPropertyChanged(nameof(Unit));
+        }
+    }
 
-    public string? Usage { get; set; }
+    private string? _usage;
+    public string? Usage
+    {
+        get => _usage;
+        set
+        {
+            _usage = value;
+            OnPropertyChanged(nameof(Usage));
+        }
+    }
 
-    public string? Remark { get; set; }
+    private string? _remark;
+    public string? Remark
+    {
+        get => _remark;
+        set
+        {
+            _remark = value;
+            OnPropertyChanged(nameof(Remark));
+        }
+    }
+
+    private bool _hasError;
+    public bool HasError
+    {
+        get => _hasError;
+        set
+        {
+            _hasError = value;
+            OnPropertyChanged(nameof(HasError));
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged(string name) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
 }

--- a/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
@@ -98,6 +98,7 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         }
 
         private async Task SaveAsync() {
+            HerbEditor.CleanEmptyRows();
             if (!HerbEditor.Validate(out var msg)) {
                 MessageBox.Show(msg!, "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
                 return;

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:LYBT.WPFControls"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              xmlns:local="clr-namespace:LYBT.WPFControls.HerbCombinationEditor">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
@@ -22,6 +23,15 @@
                   ItemsSource="{Binding HerbItems, RelativeSource={RelativeSource AncestorType=UserControl}}"
                   IsReadOnly="{Binding ReadOnly, RelativeSource={RelativeSource AncestorType=UserControl}}"
                   PreviewKeyDown="Grid_PreviewKeyDown" CellEditEnding="Grid_CellEditEnding">
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding HasError}" Value="True">
+                            <Setter Property="Background" Value="#FFFDECEA" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </DataGrid.RowStyle>
             <DataGrid.Columns>
                 <DataGridTemplateColumn Header="药材" Width="*">
                     <DataGridTemplateColumn.CellTemplate>
@@ -31,12 +41,12 @@
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
                         <DataTemplate>
-                            <ComboBox IsEditable="True" IsTextSearchEnabled="False" StaysOpenOnEdit="True"
-                                      ItemsSource="{Binding FilteredHerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                      DisplayMemberPath="Name" SelectedValuePath="Id" TextSearch.TextPath="Name"
-                                      SelectedValue="{Binding HerbId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                      KeyUp="HerbCombo_KeyUp" KeyDown="HerbCombo_KeyDown"
-                                      SelectionChanged="HerbCombo_SelectionChanged" />
+                            <materialDesign:AutoCompleteBox IsTextCompletionEnabled="False" MinimumPrefixLength="0"
+                                                     ItemsSource="{Binding FilteredHerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                     DisplayMemberPath="Name" SelectedValuePath="Id"
+                                                     SelectedValue="{Binding HerbId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     KeyUp="HerbCombo_KeyUp" KeyDown="HerbCombo_KeyDown"
+                                                     SelectionChanged="HerbCombo_SelectionChanged" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using MaterialDesignThemes.Wpf;
 using LYBT.Common.HerbCombination;
 using LYBT.Module.Herbs.Dtos;
 
@@ -201,7 +202,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
 
         private void HerbCombo_KeyUp(object sender, KeyEventArgs e)
         {
-            if (sender is ComboBox cb)
+            if (sender is AutoCompleteBox cb)
             {
                 UpdateFilter(cb.Text);
                 cb.IsDropDownOpen = FilteredHerbCatalog.Count > 0;
@@ -216,7 +217,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
 
         private void HerbCombo_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Tab && sender is ComboBox cb)
+            if (e.Key == Key.Tab && sender is AutoCompleteBox cb)
             {
                 if (FilteredHerbCatalog.Count > 0)
                 {
@@ -226,7 +227,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
                     e.Handled = true;
                 }
             }
-            else if (e.Key == Key.Enter && sender is ComboBox cbEnter)
+            else if (e.Key == Key.Enter && sender is AutoCompleteBox cbEnter)
             {
                 if (cbEnter.SelectedItem == null && FilteredHerbCatalog.Count == 1)
                     cbEnter.SelectedItem = FilteredHerbCatalog[0];
@@ -236,7 +237,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
 
         private void HerbCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (e.AddedItems.Count > 0 && sender is ComboBox cb && cb.DataContext is HerbCombinationItem item && e.AddedItems[0] is HerbDto dto)
+            if (e.AddedItems.Count > 0 && sender is AutoCompleteBox cb && cb.DataContext is HerbCombinationItem item && e.AddedItems[0] is HerbDto dto)
             {
                 item.HerbId = dto.Id.ToString();
                 item.Name = dto.Name;
@@ -269,12 +270,12 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
             }
         }
 
-        private ComboBox? GetEditingComboBox(DataGrid grid)
+        private AutoCompleteBox? GetEditingComboBox(DataGrid grid)
         {
-            if (grid.CurrentCell.Column.GetCellContent(grid.CurrentItem) is ComboBox cb)
+            if (grid.CurrentCell.Column.GetCellContent(grid.CurrentItem) is AutoCompleteBox cb)
                 return cb;
             if (grid.CurrentCell.Column.GetCellContent(grid.CurrentItem) is ContentPresenter cp)
-                return FindVisualChild<ComboBox>(cp);
+                return FindVisualChild<AutoCompleteBox>(cp);
             return null;
         }
 


### PR DESCRIPTION
## Summary
- add change tracking to `HerbCombinationItem` and flag invalid rows
- trim empty rows and highlight incomplete data in `HerbCombinationEditorViewModel`
- clean empty rows before saving formula templates
- style `HerbCombinationEditorControl` with MaterialDesign `AutoCompleteBox`

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879cc20769483339f6298d313e3c02c