### PR TITLE
Fix MaterialDesign reference for Herb editor

### DIFF
--- a/LYBT.WPFControls/LYBT.WPFControls.csproj
+++ b/LYBT.WPFControls/LYBT.WPFControls.csproj
@@ -12,4 +12,9 @@
     <ProjectReference Include="..\LYBT.Models\LYBT.Models.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MaterialDesignColors" Version="5.2.1" />
+    <PackageReference Include="MaterialDesignThemes" Version="5.2.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add MaterialDesign packages to `LYBT.WPFControls`

## Testing
- `dotnet test --no-build --framework net8.0` *(fails: Assert.Contains() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6879df4ba94c8333b29bab0462534d9c