### PR TITLE
Fix missing AutoCompleteBox

### DIFF
--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
@@ -41,12 +41,12 @@
                     </DataGridTemplateColumn.CellTemplate>
                     <DataGridTemplateColumn.CellEditingTemplate>
                         <DataTemplate>
-                            <materialDesign:AutoCompleteBox IsTextCompletionEnabled="False" MinimumPrefixLength="0"
-                                                     ItemsSource="{Binding FilteredHerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                     DisplayMemberPath="Name" SelectedValuePath="Id"
-                                                     SelectedValue="{Binding HerbId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                     KeyUp="HerbCombo_KeyUp" KeyDown="HerbCombo_KeyDown"
-                                                     SelectionChanged="HerbCombo_SelectionChanged" />
+                            <ComboBox IsEditable="True"
+                                      ItemsSource="{Binding FilteredHerbCatalog, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                      DisplayMemberPath="Name" SelectedValuePath="Id"
+                                      SelectedValue="{Binding HerbId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      KeyUp="HerbCombo_KeyUp" KeyDown="HerbCombo_KeyDown"
+                                      SelectionChanged="HerbCombo_SelectionChanged" />
                         </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
@@ -5,7 +5,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using MaterialDesignThemes.Wpf;
 using LYBT.Common.HerbCombination;
 using LYBT.Module.Herbs.Dtos;
 
@@ -202,7 +201,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
 
         private void HerbCombo_KeyUp(object sender, KeyEventArgs e)
         {
-            if (sender is AutoCompleteBox cb)
+            if (sender is ComboBox cb)
             {
                 UpdateFilter(cb.Text);
                 cb.IsDropDownOpen = FilteredHerbCatalog.Count > 0;
@@ -217,7 +216,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
 
         private void HerbCombo_KeyDown(object sender, KeyEventArgs e)
         {
-            if (e.Key == Key.Tab && sender is AutoCompleteBox cb)
+            if (e.Key == Key.Tab && sender is ComboBox cb)
             {
                 if (FilteredHerbCatalog.Count > 0)
                 {
@@ -227,7 +226,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
                     e.Handled = true;
                 }
             }
-            else if (e.Key == Key.Enter && sender is AutoCompleteBox cbEnter)
+            else if (e.Key == Key.Enter && sender is ComboBox cbEnter)
             {
                 if (cbEnter.SelectedItem == null && FilteredHerbCatalog.Count == 1)
                     cbEnter.SelectedItem = FilteredHerbCatalog[0];
@@ -237,7 +236,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
 
         private void HerbCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (e.AddedItems.Count > 0 && sender is AutoCompleteBox cb && cb.DataContext is HerbCombinationItem item && e.AddedItems[0] is HerbDto dto)
+            if (e.AddedItems.Count > 0 && sender is ComboBox cb && cb.DataContext is HerbCombinationItem item && e.AddedItems[0] is HerbDto dto)
             {
                 item.HerbId = dto.Id.ToString();
                 item.Name = dto.Name;
@@ -270,12 +269,12 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
             }
         }
 
-        private AutoCompleteBox? GetEditingComboBox(DataGrid grid)
+        private ComboBox? GetEditingComboBox(DataGrid grid)
         {
-            if (grid.CurrentCell.Column.GetCellContent(grid.CurrentItem) is AutoCompleteBox cb)
+            if (grid.CurrentCell.Column.GetCellContent(grid.CurrentItem) is ComboBox cb)
                 return cb;
             if (grid.CurrentCell.Column.GetCellContent(grid.CurrentItem) is ContentPresenter cp)
-                return FindVisualChild<AutoCompleteBox>(cp);
+                return FindVisualChild<ComboBox>(cp);
             return null;
         }
 


### PR DESCRIPTION
## Summary
- replace removed `AutoCompleteBox` with `ComboBox`
- adjust event handlers and helper methods for `ComboBox`

## Testing
- `dotnet build LYBT.WPFControls/LYBT.WPFControls.csproj --no-restore -c Release`
- `dotnet test` *(fails: requires .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6879e2284d888333b47da7ccdc2aef68