### PR TITLE
Use MaterialDesign AutoSuggestBox for list search

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Admin/HerbManagementViewModel.cs
@@ -18,6 +18,7 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         private readonly IHerbService _herbService;
 
         public ObservableCollection<HerbDto> Herbs => Items;
+        public ObservableCollection<HerbDto> FilteredHerbs { get; } = new();
 
         private HerbDto? _selectedHerb;
         public HerbDto? SelectedHerb {
@@ -31,7 +32,15 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
         }
 
         private string _searchKeyword = string.Empty;
-        public string SearchKeyword { get => _searchKeyword; set => SetProperty(ref _searchKeyword, value); }
+        public string SearchKeyword
+        {
+            get => _searchKeyword;
+            set
+            {
+                if (SetProperty(ref _searchKeyword, value))
+                    UpdateFilter();
+            }
+        }
 
         public HerbProfileViewModel HerbProfileViewModel { get; }
 
@@ -51,12 +60,27 @@ namespace LYBT.UI.WPF.ViewModels.Admin {
             DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), () => SelectedHerb != null).ObservesProperty(() => SelectedHerb);
             ImportCommand = new DelegateCommand(async () => await ImportAsync());
             ExportCommand = new DelegateCommand(async () => await ExportAsync());
+            Items.CollectionChanged += (_, __) => UpdateFilter();
             _ = LoadPageAsync();
         }
 
         protected override async Task<PagedResultDto<HerbDto>> GetPagedAsync(int page, int pageSize) {
             var query = new HerbPagedQueryDto { Keyword = SearchKeyword, Page = page, PageSize = pageSize };
             return await _herbService.GetPagedAsync(query);
+        }
+
+        private void UpdateFilter()
+        {
+            FilteredHerbs.Clear();
+            foreach (var h in Herbs)
+            {
+                if (string.IsNullOrWhiteSpace(SearchKeyword) ||
+                    h.Name.Contains(SearchKeyword, System.StringComparison.OrdinalIgnoreCase) ||
+                    (!string.IsNullOrEmpty(h.Pinyin) && h.Pinyin.Contains(SearchKeyword, System.StringComparison.OrdinalIgnoreCase)))
+                {
+                    FilteredHerbs.Add(h);
+                }
+            }
         }
 
         private void Add() {

--- a/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/HerbManagementView.xaml
@@ -11,9 +11,10 @@
         </Grid.ColumnDefinitions>
         <Border Grid.Column="0" Margin="0,0,10,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
             <controls:CommonListView ShowPaging="True"
-                                 ItemsSource="{Binding Herbs}"
+                                 ItemsSource="{Binding FilteredHerbs}"
                                  SelectedItem="{Binding SelectedHerb, Mode=TwoWay}"
                                  SearchKeyword="{Binding SearchKeyword, UpdateSourceTrigger=PropertyChanged}"
+                                 SearchHint="Search for herbs..."
                                  SearchCommand="{Binding SearchCommand}"
                                  LoadPageCommand="{Binding LoadPageCommand}"
                                  IsBusy="{Binding IsBusy}">

--- a/LYBT.WPFControls/Controls/CommonListView.xaml
+++ b/LYBT.WPFControls/Controls/CommonListView.xaml
@@ -1,7 +1,8 @@
 <UserControl x:Class="LYBT.WPFControls.CommonListView"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:LYBT.WPFControls">
+              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+              xmlns:controls="clr-namespace:LYBT.WPFControls"
+              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </UserControl.Resources>
@@ -16,9 +17,10 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
-            <TextBox Margin="0,0,8,0"
-                     HorizontalAlignment="Stretch"
-                     Text="{Binding SearchKeyword, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=PropertyChanged}"/>
+            <materialDesign:AutoSuggestBox Margin="0,0,8,0"
+                                         Text="{Binding SearchKeyword, RelativeSource={RelativeSource AncestorType=UserControl}, UpdateSourceTrigger=PropertyChanged}"
+                                         materialDesign:HintAssist.Hint="{Binding SearchHint, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         materialDesign:TextFieldAssist.HasClearButton="True"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
                 <Button Content="查找" Margin="0,0,8,0"
                         Command="{Binding SearchCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"/>

--- a/LYBT.WPFControls/Controls/CommonListView.xaml.cs
+++ b/LYBT.WPFControls/Controls/CommonListView.xaml.cs
@@ -93,6 +93,19 @@ namespace LYBT.WPFControls {
         public static readonly DependencyProperty ShowPagingProperty =
             DependencyProperty.Register(nameof(ShowPaging), typeof(bool), typeof(CommonListView), new PropertyMetadata(true));
 
+        public string SearchHint
+        {
+            get => (string)GetValue(SearchHintProperty);
+            set => SetValue(SearchHintProperty, value);
+        }
+
+        public static readonly DependencyProperty SearchHintProperty =
+            DependencyProperty.Register(
+                nameof(SearchHint),
+                typeof(string),
+                typeof(CommonListView),
+                new PropertyMetadata("Search..."));
+
         private static void OnSearchKeywordChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
             if (d is CommonListView view)
                 view.ExecuteSearchCommand();


### PR DESCRIPTION
## Summary
- switch CommonListView search field to `AutoSuggestBox`
- support configurable search hint text
- filter herbs in real time using `FilteredHerbs`
- show hint in HerbManagementView and bind to new filtered list

## Testing
- `dotnet build LYBT.WPFControls/LYBT.WPFControls.csproj -clp:ErrorsOnly`
- `dotnet build LYBTZYZS.sln -clp:ErrorsOnly`


------
https://chatgpt.com/codex/tasks/task_e_6879e388373c8333b17390fef927bbf1