### PR TITLE
Update herb template editor

### DIFF
--- a/LYBT.WPFControls/Converters/HideInTemplateConverter.cs
+++ b/LYBT.WPFControls/Converters/HideInTemplateConverter.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+using LYBT.Common.HerbCombination;
+
+namespace LYBT.WPFControls.Converters;
+
+/// <summary>
+/// Converts <see cref="HerbEditorMode"/> to <see cref="Visibility"/>.
+/// Collapses element when mode is <see cref="HerbEditorMode.Template"/>.
+/// </summary>
+public class HideInTemplateConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is HerbEditorMode mode && mode == HerbEditorMode.Template)
+            return Visibility.Collapsed;
+        return Visibility.Visible;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => Binding.DoNothing;
+}

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml
@@ -3,9 +3,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:controls="clr-namespace:LYBT.WPFControls"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-             xmlns:local="clr-namespace:LYBT.WPFControls.HerbCombinationEditor">
+             xmlns:local="clr-namespace:LYBT.WPFControls.HerbCombinationEditor"
+             xmlns:conv="clr-namespace:LYBT.WPFControls.Converters">
     <UserControl.Resources>
         <BooleanToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        <conv:HideInTemplateConverter x:Key="HideInTemplateConverter" />
     </UserControl.Resources>
     <Grid>
         <Grid.RowDefinitions>
@@ -51,9 +53,12 @@
                     </DataGridTemplateColumn.CellEditingTemplate>
                 </DataGridTemplateColumn>
                 <DataGridTextColumn Header="剂量" Binding="{Binding Dosage, UpdateSourceTrigger=PropertyChanged}" Width="80"/>
-                <DataGridTextColumn Header="单位" Binding="{Binding Unit, UpdateSourceTrigger=PropertyChanged}" Width="80"/>
-                <DataGridTextColumn Header="用法" Binding="{Binding Usage, UpdateSourceTrigger=PropertyChanged}" Width="120"/>
-                <DataGridTextColumn Header="备注" Binding="{Binding Remark, UpdateSourceTrigger=PropertyChanged}" Width="150"/>
+                <DataGridTextColumn Header="单位" Binding="{Binding Unit, UpdateSourceTrigger=PropertyChanged}" Width="80"
+                                   Visibility="{Binding Mode, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource HideInTemplateConverter}}"/>
+                <DataGridTextColumn Header="用法" Binding="{Binding Usage, UpdateSourceTrigger=PropertyChanged}" Width="120"
+                                   Visibility="{Binding Mode, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource HideInTemplateConverter}}"/>
+                <DataGridTextColumn Header="备注" Binding="{Binding Remark, UpdateSourceTrigger=PropertyChanged}" Width="150"
+                                   Visibility="{Binding Mode, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource HideInTemplateConverter}}"/>
             </DataGrid.Columns>
         </DataGrid>
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,8,0,0">

--- a/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
+++ b/LYBT.WPFControls/HerbCombinationEditor/HerbCombinationEditorControl.xaml.cs
@@ -118,7 +118,7 @@ namespace LYBT.WPFControls.HerbCombinationEditor {
                     h.Name.Contains(text, StringComparison.OrdinalIgnoreCase) ||
                     (!string.IsNullOrEmpty(h.Pinyin) && h.Pinyin.Contains(upper)));
             }
-            foreach (var h in query)
+            foreach (var h in query.Take(5))
                 FilteredHerbCatalog.Add(h);
         }
 


### PR DESCRIPTION
## Summary
- limit herb autocomplete results to top 5
- hide unit/usage/remark columns when editing templates
- add converter for HerbEditorMode visibility

## Testing
- `dotnet restore --locked-mode`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687a460762f4833380caf82edc07d2af