### PR TITLE
Update Formula Templates Profile view

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
@@ -101,7 +101,24 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         }
 
         private async Task SaveAsync() {
-
+            try {
+                bool success;
+                if (Template.Id == Guid.Empty) {
+                    success = await _service.AddAsync(Template);
+                } else {
+                    success = await _service.UpdateAsync(Template);
+                }
+                if (!success)
+                    MessageBox.Show("保存失败", "提示", MessageBoxButton.OK, MessageBoxImage.Warning);
+                else {
+                    Mode = ProfileMode.View;
+                    IsEditable = false;
+                    EditModeTitle = "模板详细信息";
+                    CancelAction?.Invoke();
+                }
+            } catch (Exception ex) {
+                MessageBox.Show($"保存失败：{ex.Message}", "错误", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private void Cancel() {

--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -33,11 +33,23 @@
             </Grid>
         </Border>
         <Border Grid.Column="1" Margin="0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
-            <StackPanel DataContext="{Binding ProfileViewModel}">
-                <TextBlock Text="{Binding EditModeTitle}" FontSize="16" FontWeight="Bold" Margin="0,0,0,8"/>
-
-                <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,8" IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-            </StackPanel>
+            <controls:CommonProfileView DataContext="{Binding ProfileViewModel}"
+                                       Title="{Binding EditModeTitle}"
+                                       SaveCommand="{Binding SaveCommand}"
+                                       CancelCommand="{Binding CancelCommand}"
+                                       IsEditable="{Binding IsEditable}">
+                <controls:CommonProfileView.ProfileContent>
+                    <StackPanel>
+                        <TextBlock Text="经验方名称" />
+                        <TextBox Text="{Binding Template.Name}" Margin="0,0,0,8"
+                                 IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <TextBlock Text="药材组合" />
+                        <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,8"
+                                 AcceptsReturn="True" TextWrapping="Wrap"
+                                 IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                    </StackPanel>
+                </controls:CommonProfileView.ProfileContent>
+            </controls:CommonProfileView>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- hook up FormulaTemplates profile editing to use `CommonProfileView`
- implement save logic in `FormulaTemplatesProfileViewModel`
- show template name and herb combination fields

## Testing
- `dotnet test --no-build` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687a55bbf7088333a1e51e65c79c8578