### PR TITLE
Add Quick Add Herbs to formula templates UI

### DIFF
--- a/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
+++ b/LYBT.UI.WPF/ViewModels/Profile/FormulaTemplatesProfileViewModel.cs
@@ -9,6 +9,7 @@ using LYBT.Common.Enums;
 using LYBT.Module.FormulaTemplates.Dtos;
 using LYBT.UI.WPF.Interfaces;
 using LYBT.Module.Herbs.Dtos;
+using LYBT.Module.Prescriptions.Dtos;
 
 namespace LYBT.UI.WPF.ViewModels.Profile {
     /// <summary>
@@ -22,6 +23,15 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
         public FormulaTemplateDetailDto Template {
             get => _template;
             set => SetProperty(ref _template, value);
+        }
+
+        public ObservableCollection<PrescriptionItemDto> Items { get; } = new();
+        public ObservableCollection<HerbDto> AllHerbs { get; } = new();
+
+        private PrescriptionItemDto? _selectedItem;
+        public PrescriptionItemDto? SelectedItem {
+            get => _selectedItem;
+            set => SetProperty(ref _selectedItem, value);
         }
 
 
@@ -51,6 +61,8 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
 
         public DelegateCommand SaveCommand { get; }
         public DelegateCommand CancelCommand { get; }
+        public DelegateCommand AddItemCommand { get; }
+        public DelegateCommand<object?> RemoveItemCommand { get; }
 
         public Action? CancelAction { get; set; }
 
@@ -59,6 +71,9 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             _herbService = herbService;
             SaveCommand = new DelegateCommand(async () => await SaveAsync());
             CancelCommand = new DelegateCommand(Cancel);
+            AddItemCommand = new DelegateCommand(AddItem);
+            RemoveItemCommand = new DelegateCommand<object?>(param => RemoveItem(param as PrescriptionItemDto));
+            _ = LoadHerbsAsync();
         }
 
         public async Task LoadAsync(Guid? id = null, ProfileMode mode = ProfileMode.View) {
@@ -70,10 +85,17 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
                 Template = new FormulaTemplateDetailDto();
             }
 
+            Items.Clear();
+            foreach (var h in Template.Herbs)
+                Items.Add(new PrescriptionItemDto { HerbId = h.Id, HerbName = h.Name });
+
             var herbs = await _herbService.GetListAsync();
             HerbCatalog.Clear();
-            foreach (var h in herbs)
+            AllHerbs.Clear();
+            foreach (var h in herbs) {
                 HerbCatalog.Add(h);
+                AllHerbs.Add(h);
+            }
 
 
 
@@ -104,8 +126,10 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             try {
                 bool success;
                 if (Template.Id == Guid.Empty) {
+                    Template.Herbs = Items.Select(i => new HerbDto { Id = i.HerbId, Name = i.HerbName }).ToList();
                     success = await _service.AddAsync(Template);
                 } else {
+                    Template.Herbs = Items.Select(i => new HerbDto { Id = i.HerbId, Name = i.HerbName }).ToList();
                     success = await _service.UpdateAsync(Template);
                 }
                 if (!success)
@@ -126,6 +150,22 @@ namespace LYBT.UI.WPF.ViewModels.Profile {
             IsEditable = false;
             EditModeTitle = "模板详细信息";
             CancelAction?.Invoke();
+        }
+
+        private void AddItem() {
+            Items.Add(new PrescriptionItemDto());
+        }
+
+        private void RemoveItem(PrescriptionItemDto? item) {
+            if (item != null)
+                Items.Remove(item);
+        }
+
+        private async Task LoadHerbsAsync() {
+            var list = await _herbService.GetListAsync();
+            AllHerbs.Clear();
+            foreach (var h in list)
+                AllHerbs.Add(h);
         }
     }
 }

--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -43,7 +43,25 @@
                         <TextBlock Text="经验方名称" />
                         <TextBox Text="{Binding Template.Name}" Margin="0,0,0,8"
                                  IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
-                        <TextBlock Text="药材组合" />
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+                            <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
+                        </StackPanel>
+                        <DataGrid ItemsSource="{Binding Items}" SelectedItem="{Binding SelectedItem, Mode=TwoWay}" AutoGenerateColumns="False" CanUserAddRows="False" Height="200" Margin="0,0,0,10">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="药材" Binding="{Binding HerbName}" Width="*"/>
+                                <DataGridTextColumn Header="剂量" Binding="{Binding Quantity}" Width="80"/>
+                                <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="80"/>
+                                <DataGridTemplateColumn Width="60">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <Button Content="删除" Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                        <controls:QuickAddHerbsControl TargetItems="{Binding Items}" Herbs="{Binding AllHerbs}" Margin="0,0,0,10" />
+                        <TextBlock Text="备注" />
                         <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,8"
                                  AcceptsReturn="True" TextWrapping="Wrap"
                                  IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>


### PR DESCRIPTION
## Summary
- enhance `FormulaTemplatesProfileViewModel` to manage herb items
- hook up `QuickAddHerbsControl` and herb list editing in `FormulaTemplatesManagementView`

## Testing
- `dotnet build` *(fails: missing .NET 8 runtime)*

------
https://chatgpt.com/codex/tasks/task_e_687a62f9d30c8333b5df02dd647ad1bb