### PR TITLE
Add modern herb add UI

### DIFF
--- a/LYBT.Models/Herbs/Dtos/HerbDto.cs
+++ b/LYBT.Models/Herbs/Dtos/HerbDto.cs
@@ -44,5 +44,9 @@ namespace LYBT.Module.Herbs.Dtos {
         public string? BatchNo { get; set; }
         [DisplayName("有效期")]
         public DateTime? ExpireDate { get; set; }
+
+        /// <summary>功效说明</summary>
+        [DisplayName("功效说明")]
+        public string? Effect { get; set; }
     }
 }

--- a/LYBT.UI.WPF/App.xaml
+++ b/LYBT.UI.WPF/App.xaml
@@ -35,6 +35,8 @@
 
             <!-- 空转布尔转换器 -->
             <local:NullToBoolConverter x:Key="NullToBoolConverter"/>
+            <local:StringEqualsConverter x:Key="StringEqualsConverter"/>
+            <local:ZeroToVisibilityConverter x:Key="ZeroToVisibilityConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </prism:PrismApplication>

--- a/LYBT.UI.WPF/Converters/StringEqualsConverter.cs
+++ b/LYBT.UI.WPF/Converters/StringEqualsConverter.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace LYBT.UI.WPF.Converters {
+    /// <summary>
+    /// Compare a bound string with converter parameter.
+    /// </summary>
+    public class StringEqualsConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+            => value?.ToString() == parameter?.ToString();
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+            => (value is bool b && b) ? parameter : Binding.DoNothing;
+    }
+}

--- a/LYBT.UI.WPF/Converters/ZeroToVisibilityConverter.cs
+++ b/LYBT.UI.WPF/Converters/ZeroToVisibilityConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace LYBT.UI.WPF.Converters {
+    /// <summary>
+    /// Convert zero to Visible, non-zero to Collapsed.
+    /// </summary>
+    public class ZeroToVisibilityConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if (value is int intValue)
+                return intValue == 0 ? Visibility.Visible : Visibility.Collapsed;
+            return Visibility.Collapsed;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LYBT.WPFControls/Controls/QuickAddHerbsControl.xaml
+++ b/LYBT.WPFControls/Controls/QuickAddHerbsControl.xaml
@@ -2,36 +2,58 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-             xmlns:mod="clr-namespace:LYBT.Module.Prescriptions.Dtos;assembly=LYBT.Models"
+             xmlns:herbs="clr-namespace:LYBT.Module.Herbs.Dtos;assembly=LYBT.Models"
              x:Name="root">
     <StackPanel>
-        <ComboBox x:Name="PART_SearchBox"
-                  IsEditable="True"
-                  Text="{Binding SearchText, ElementName=root, UpdateSourceTrigger=PropertyChanged}"
-                  ItemsSource="{Binding Suggestions, ElementName=root}"
-                  DisplayMemberPath="Name"
-                  StaysOpenOnEdit="True"
-                  materialDesign:HintAssist.Hint="输入药材名称或拼音"
-                  SelectionChanged="SearchBox_SelectionChanged" />
-        <ItemsControl ItemsSource="{Binding Pending, ElementName=root}" Margin="0,5,0,5">
-            <ItemsControl.ItemsPanel>
+        <Grid Margin="0,0,0,8">
+            <TextBox x:Name="PART_SearchBox"
+                     Style="{StaticResource MaterialDesignOutlinedTextBox}"
+                     Text="{Binding SearchText, ElementName=root, UpdateSourceTrigger=PropertyChanged}"
+                     materialDesign:HintAssist.Hint="搜索药材（支持拼音首字母）"/>
+            <materialDesign:PackIcon Kind="Magnify" Width="20" Height="20" Margin="0,0,8,0" VerticalAlignment="Center" HorizontalAlignment="Right" />
+        </Grid>
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled" Margin="0,0,0,8">
+            <ItemsControl ItemsSource="{Binding Categories, ElementName=root}">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <StackPanel Orientation="Horizontal" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <ToggleButton Content="{Binding}"
+                                      Margin="0,0,8,0"
+                                      IsChecked="{Binding SelectedCategory, ElementName=root, Converter={StaticResource StringEqualsConverter}, ConverterParameter={Binding}}"
+                                      Click="CategoryButton_Click"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+        <ListBox ItemsSource="{Binding FilteredHerbs, ElementName=root}" x:Name="PART_List" ScrollViewer.VerticalScrollBarVisibility="Auto">
+            <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <WrapPanel />
+                    <VirtualizingStackPanel />
                 </ItemsPanelTemplate>
-            </ItemsControl.ItemsPanel>
-            <ItemsControl.ItemTemplate>
-                <DataTemplate DataType="{x:Type mod:PrescriptionItemDto}">
-                    <Border Background="#EEE" Margin="2" Padding="4" CornerRadius="4">
-                        <StackPanel Orientation="Horizontal">
-                            <TextBlock Text="{Binding HerbName}" Margin="0,0,4,0"/>
-                            <Button Content="x" Width="16" Height="16" Padding="0"
-                                    Command="{Binding DataContext.RemovePendingCommand, ElementName=root}"
-                                    CommandParameter="{Binding}"/>
-                        </StackPanel>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+                <DataTemplate DataType="{x:Type herbs:HerbDto}">
+                    <Border BorderThickness="1" BorderBrush="#DDD" CornerRadius="4" Padding="8" Margin="0,0,0,8">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel>
+                                <TextBlock Text="{Binding Name}" FontWeight="Bold" />
+                                <TextBlock Text="{Binding Effect}" TextWrapping="Wrap" Foreground="#666"/>
+                            </StackPanel>
+                            <Button Grid.Column="1" Content="+" Foreground="White" Background="#2196F3" Width="28" Height="28" Margin="8,0,0,0" Command="{Binding AddHerbCommand, ElementName=root}" CommandParameter="{Binding}" />
+                        </Grid>
                     </Border>
                 </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>
-        <Button Content="导入" Command="{Binding ImportCommand, ElementName=root}" Width="80" />
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <TextBlock Text="未找到匹配的药材" Foreground="#888" HorizontalAlignment="Center" Margin="0,8,0,0"
+                   Visibility="{Binding FilteredHerbs.Count, ElementName=root, Converter={StaticResource ZeroToVisibilityConverter}}"/>
     </StackPanel>
 </UserControl>

--- a/LYBT.WPFControls/Controls/QuickAddHerbsControl.xaml.cs
+++ b/LYBT.WPFControls/Controls/QuickAddHerbsControl.xaml.cs
@@ -5,26 +5,26 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
 
 namespace LYBT.WPFControls {
     /// <summary>
-    /// Control providing fuzzy search and batch import of herbs.
+    /// Herb selection control with search and category filter.
     /// </summary>
     public partial class QuickAddHerbsControl : UserControl {
         private IEnumerable<HerbDto> _herbs = Array.Empty<HerbDto>();
+        private readonly Dictionary<Guid, string> _categoryCache = new();
 
         public QuickAddHerbsControl() {
             InitializeComponent();
-            ImportCommand = new DelegateCommand(Import);
-            RemovePendingCommand = new DelegateCommand<PrescriptionItemDto?>(RemovePending);
+            AddHerbCommand = new DelegateCommand<HerbDto?>(AddHerb);
+            Categories.Add("全部");
+            Categories.Add("解表");
+            Categories.Add("清热");
+            Categories.Add("其他");
         }
-
-        public ObservableCollection<HerbDto> Suggestions { get; } = new();
-
-        public ObservableCollection<PrescriptionItemDto> Pending { get; } = new();
 
         public IEnumerable<HerbDto>? Herbs {
             get => (IEnumerable<HerbDto>?)GetValue(HerbsProperty);
@@ -53,58 +53,75 @@ namespace LYBT.WPFControls {
             DependencyProperty.Register(nameof(SearchText), typeof(string), typeof(QuickAddHerbsControl),
                 new PropertyMetadata(string.Empty, OnSearchTextChanged));
 
-        public DelegateCommand ImportCommand { get; }
-        public DelegateCommand<PrescriptionItemDto?> RemovePendingCommand { get; }
+        public ObservableCollection<string> Categories { get; } = new();
+        public ObservableCollection<HerbDto> FilteredHerbs { get; } = new();
+
+        private string _selectedCategory = "全部";
+        public string SelectedCategory {
+            get => _selectedCategory;
+            set {
+                if (_selectedCategory != value) {
+                    _selectedCategory = value;
+                    UpdateFilter();
+                }
+            }
+        }
+
+        public DelegateCommand<HerbDto?> AddHerbCommand { get; }
 
         private static void OnSearchTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
             if (d is QuickAddHerbsControl c)
-                c.UpdateSuggestions();
+                c.UpdateFilter();
         }
 
         private static void OnHerbsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e) {
             if (d is QuickAddHerbsControl c) {
                 c._herbs = e.NewValue as IEnumerable<HerbDto> ?? Array.Empty<HerbDto>();
-                c.UpdateSuggestions();
+                c.UpdateFilter();
             }
         }
 
-        private void UpdateSuggestions() {
-            Suggestions.Clear();
-            if (string.IsNullOrWhiteSpace(SearchText))
-                return;
-            foreach (var h in _herbs.Where(h =>
-                h.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase) ||
-                (!string.IsNullOrEmpty(h.Pinyin) && h.Pinyin.Contains(SearchText, StringComparison.OrdinalIgnoreCase))))
-                Suggestions.Add(h);
-        }
-
-        private void SearchBox_SelectionChanged(object sender, SelectionChangedEventArgs e) {
-            if (e.AddedItems.Count > 0 && e.AddedItems[0] is HerbDto herb)
-                AddPending(herb);
-            ((ComboBox)sender).Text = string.Empty;
-            Suggestions.Clear();
-        }
-
-        private void AddPending(HerbDto herb) {
-            if (Pending.Any(p => p.HerbId == herb.Id))
-                return;
-            Pending.Add(new PrescriptionItemDto { HerbId = herb.Id, HerbName = herb.Name });
-        }
-
-        private void RemovePending(PrescriptionItemDto? item) {
-            if (item != null)
-                Pending.Remove(item);
-        }
-
-        private void Import() {
-            if (TargetItems == null)
-                return;
-            foreach (var p in Pending) {
-                if (TargetItems.Any(t => t.HerbId == p.HerbId))
-                    continue;
-                TargetItems.Add(new PrescriptionItemDto { HerbId = p.HerbId, HerbName = p.HerbName });
+        private void UpdateFilter() {
+            FilteredHerbs.Clear();
+            IEnumerable<HerbDto> query = _herbs;
+            if (!string.IsNullOrWhiteSpace(SearchText)) {
+                query = query.Where(h => h.Name.Contains(SearchText, StringComparison.OrdinalIgnoreCase)
+                    || (!string.IsNullOrEmpty(h.Pinyin) && h.Pinyin.Contains(SearchText, StringComparison.OrdinalIgnoreCase)));
             }
-            Pending.Clear();
+            if (SelectedCategory != "全部")
+                query = query.Where(h => GetCategory(h) == SelectedCategory);
+            foreach (var h in query)
+                FilteredHerbs.Add(h);
+        }
+
+        private string GetCategory(HerbDto herb) {
+            if (_categoryCache.TryGetValue(herb.Id, out var cat))
+                return cat;
+            if (!string.IsNullOrWhiteSpace(herb.Effect)) {
+                if (herb.Effect.Contains("解表"))
+                    cat = "解表";
+                else if (herb.Effect.Contains("清热"))
+                    cat = "清热";
+                else
+                    cat = "其他";
+            } else {
+                cat = "其他";
+            }
+            _categoryCache[herb.Id] = cat;
+            return cat;
+        }
+
+        private void AddHerb(HerbDto? herb) {
+            if (herb == null || TargetItems == null)
+                return;
+            if (TargetItems.Any(t => t.HerbId == herb.Id))
+                return;
+            TargetItems.Add(new PrescriptionItemDto { HerbId = herb.Id, HerbName = herb.Name });
+        }
+
+        private void CategoryButton_Click(object sender, RoutedEventArgs e) {
+            if (sender is ToggleButton btn && btn.Content is string cat)
+                SelectedCategory = cat;
         }
     }
 }


### PR DESCRIPTION
## Summary
- include herb effect in `HerbDto`
- update quick add herbs control with search bar, category tags and list display
- add converters for string equality and zero visibility
- register converters in app resources

## Testing
- `dotnet build --no-restore`
- `DOTNET_ROOT=/usr/lib/dotnet /usr/lib/dotnet/dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687a667bcdc08333b6516dde662058cd