### PR TITLE
Fix Binding error with MultiBinding

### DIFF
--- a/LYBT.UI.WPF/App.xaml
+++ b/LYBT.UI.WPF/App.xaml
@@ -36,6 +36,7 @@
             <!-- 空转布尔转换器 -->
             <local:NullToBoolConverter x:Key="NullToBoolConverter"/>
             <local:StringEqualsConverter x:Key="StringEqualsConverter"/>
+            <local:StringEqualsMultiConverter x:Key="StringEqualsMultiConverter"/>
             <local:ZeroToVisibilityConverter x:Key="ZeroToVisibilityConverter"/>
         </ResourceDictionary>
     </Application.Resources>

--- a/LYBT.UI.WPF/Converters/StringEqualsMultiConverter.cs
+++ b/LYBT.UI.WPF/Converters/StringEqualsMultiConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace LYBT.UI.WPF.Converters {
+    /// <summary>
+    /// Compare two bound strings using MultiBinding.
+    /// </summary>
+    public class StringEqualsMultiConverter : IMultiValueConverter {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture) {
+            if (values.Length >= 2)
+                return values[0]?.ToString() == values[1]?.ToString();
+            return false;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture) {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LYBT.WPFControls/Controls/QuickAddHerbsControl.xaml
+++ b/LYBT.WPFControls/Controls/QuickAddHerbsControl.xaml
@@ -23,8 +23,14 @@
                     <DataTemplate>
                         <ToggleButton Content="{Binding}"
                                       Margin="0,0,8,0"
-                                      IsChecked="{Binding SelectedCategory, ElementName=root, Converter={StaticResource StringEqualsConverter}, ConverterParameter={Binding}}"
-                                      Click="CategoryButton_Click"/>
+                                      Click="CategoryButton_Click">
+                            <ToggleButton.IsChecked>
+                                <MultiBinding Converter="{StaticResource StringEqualsMultiConverter}">
+                                    <Binding Path="SelectedCategory" ElementName="root"/>
+                                    <Binding />
+                                </MultiBinding>
+                            </ToggleButton.IsChecked>
+                        </ToggleButton>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>


### PR DESCRIPTION
## Summary
- add `StringEqualsMultiConverter` for comparing values via MultiBinding
- update QuickAddHerbsControl to use MultiBinding
- register new converter in `App.xaml`

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6a784ad88333a9c9adda8019f5c4