### PR TITLE
Refactor formula templates management layout

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -7,6 +7,7 @@
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*"/>
+            <ColumnDefinition Width="3*"/>
             <ColumnDefinition Width="2*"/>
         </Grid.ColumnDefinitions>
         <Border Grid.Column="0" Margin="0,0,10,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
@@ -40,9 +41,6 @@
                                        IsEditable="{Binding IsEditable}">
                 <controls:CommonProfileView.ProfileContent>
                     <StackPanel>
-                        <TextBlock Text="经验方名称" />
-                        <TextBox Text="{Binding Template.Name}" Margin="0,0,0,8"
-                                 IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
                             <Button Content="添加药材" Command="{Binding AddItemCommand}" Margin="0,0,5,0"/>
                         </StackPanel>
@@ -60,14 +58,27 @@
                                 </DataGridTemplateColumn>
                             </DataGrid.Columns>
                         </DataGrid>
-                        <controls:QuickAddHerbsControl TargetItems="{Binding Items}" Herbs="{Binding AllHerbs}" Margin="0,0,0,10" />
-                        <TextBlock Text="备注" />
-                        <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,8"
-                                 AcceptsReturn="True" TextWrapping="Wrap"
-                                 IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        <StackPanel Margin="0,10,0,0">
+                            <TextBlock Text="经验方名称" />
+                            <TextBox Text="{Binding Template.Name}" Margin="0,0,0,8"
+                                     IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                            <TextBlock Text="功效" />
+                            <TextBox Margin="0,0,0,8"/>
+                            <TextBlock Text="主治" />
+                            <TextBox Margin="0,0,0,8"/>
+                            <TextBlock Text="备注" />
+                            <TextBox Text="{Binding Template.Remark}" Margin="0,0,0,8"
+                                     AcceptsReturn="True" TextWrapping="Wrap"
+                                     IsReadOnly="{Binding IsEditable, Converter={StaticResource InverseBooleanConverter}}"/>
+                        </StackPanel>
                     </StackPanel>
                 </controls:CommonProfileView.ProfileContent>
             </controls:CommonProfileView>
+        </Border>
+        <Border Grid.Column="2" Margin="10,0,0,0" Padding="18" Background="#FAFAFA" CornerRadius="8" BorderBrush="#CCC" BorderThickness="1">
+            <controls:QuickAddHerbsControl DataContext="{Binding ProfileViewModel}"
+                                           TargetItems="{Binding Items}"
+                                           Herbs="{Binding AllHerbs}"/>
         </Border>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- restructure FormulaTemplatesManagementView into three columns
- move quick add herbs section to its own column
- add editable fields after ingredient list

## Testing
- `dotnet test --no-build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a71e9b3a083338234c2f11cb67edb