### PR TITLE
Fix RemoveItemCommand binding

### DIFF
--- a/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
+++ b/LYBT.UI.WPF/Views/Admin/FormulaTemplatesManagementView.xaml
@@ -52,7 +52,9 @@
                                 <DataGridTemplateColumn Width="60">
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
-                                            <Button Content="删除" Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=UserControl}}" CommandParameter="{Binding}"/>
+                                            <Button Content="删除"
+                                                    Command="{Binding DataContext.RemoveItemCommand, RelativeSource={RelativeSource AncestorType=controls:CommonProfileView}}"
+                                                    CommandParameter="{Binding}"/>
                                         </DataTemplate>
                                     </DataGridTemplateColumn.CellTemplate>
                                 </DataGridTemplateColumn>


### PR DESCRIPTION
## Summary
- ensure delete button in formula template management view resolves the correct ancestor for RemoveItemCommand

## Testing
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687a749611948333bb85e2dbf44a8cef