### PR TITLE
Implement API versioning and response standardization

### DIFF
--- a/LYBT.Common/Responses/ApiResponse.cs
+++ b/LYBT.Common/Responses/ApiResponse.cs
@@ -5,16 +5,16 @@ namespace LYBT.Common.Responses {
     /// 接口统一响应体
     /// </summary>
     public class ApiResponse<T> {
-        public int Code { get; set; } = 200;
-        public string Message { get; set; } = "操作成功";
-        public T? Data { get; set; } // Marked as nullable to resolve CS8618
+        public bool IsSuccess { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public T? Data { get; set; }
+        public int StatusCode { get; set; }
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
 
-        public static ApiResponse<T> Success(T data, string message = "操作成功") {
-            return new ApiResponse<T> { Code = 200, Message = message, Data = data };
-        }
+        public static ApiResponse<T> Success(T data, string message = "Success")
+            => new() { IsSuccess = true, Data = data, Message = message, StatusCode = 200 };
 
-        public static ApiResponse<T> Fail(string message, int code = 500) {
-            return new ApiResponse<T> { Code = code, Message = message };
-        }
+        public static ApiResponse<T> Fail(string message, int statusCode = 400)
+            => new() { IsSuccess = false, Message = message, StatusCode = statusCode };
     }
 }

--- a/LYBT.WebAPI/Controllers/AuthController.cs
+++ b/LYBT.WebAPI/Controllers/AuthController.cs
@@ -11,8 +11,9 @@ namespace LYBT.WebAPI.Controllers {
     /// 认证相关接口
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class AuthController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+public class AuthController : ControllerBase {
         private readonly IAuthService _authService;
         private readonly JwtOptions _jwtOptions;
 

--- a/LYBT.WebAPI/Controllers/BillingController.cs
+++ b/LYBT.WebAPI/Controllers/BillingController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.Billing.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Billing.Interfaces;
 using LYBT.Common.Enums;
 using Microsoft.AspNetCore.Mvc;
@@ -9,8 +11,10 @@ namespace LYBT.Module.Billing.Controllers {
     /// 费用结算 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class BillingController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class BillingController : ControllerBase {
         private readonly IBillingService _billingService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/DiagnosisCatalogController.cs
+++ b/LYBT.WebAPI/Controllers/DiagnosisCatalogController.cs
@@ -1,12 +1,16 @@
 using LYBT.Module.Settings.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Settings.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LYBT.WebAPI.Controllers {
 
     [ApiController]
-    [Route("api/[controller]")]
-    public class DiagnosisCatalogController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class DiagnosisCatalogController : ControllerBase {
         private readonly IDiagnosisCatalogService _service;
 
         public DiagnosisCatalogController(IDiagnosisCatalogService service) {

--- a/LYBT.WebAPI/Controllers/DiagnosisTreatmentController.cs
+++ b/LYBT.WebAPI/Controllers/DiagnosisTreatmentController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.DiagnosisTreatment.Interfaces;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.DiagnosisTreatment.Models.Dtos;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,8 +10,10 @@ namespace LYBT.Module.DiagnosisTreatment.Controllers {
     /// 诊疗 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class DiagnosisTreatmentController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class DiagnosisTreatmentController : ControllerBase {
         private readonly IDiagnosisTreatmentService _diagnosisTreatmentService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/DoctorsController.cs
+++ b/LYBT.WebAPI/Controllers/DoctorsController.cs
@@ -1,4 +1,6 @@
 using LYBT.Common.Models;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Doctors.Dtos;
 using LYBT.Module.Doctors.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -9,8 +11,10 @@ namespace LYBT.WebAPI.Controllers {
     /// 医生管理接口
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class DoctorsController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class DoctorsController : ControllerBase {
         private readonly IDoctorService _doctorService;
         public DoctorsController(IDoctorService doctorService) {
             _doctorService = doctorService;

--- a/LYBT.WebAPI/Controllers/EnumMappingsController.cs
+++ b/LYBT.WebAPI/Controllers/EnumMappingsController.cs
@@ -1,11 +1,15 @@
 using LYBT.Module.Settings.Interfaces;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LYBT.WebAPI.Controllers {
 
     [ApiController]
-    [Route("api/[controller]")]
-    public class EnumMappingsController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class EnumMappingsController : ControllerBase {
         private readonly IEnumMappingsService _service;
 
         public EnumMappingsController(IEnumMappingsService service) {

--- a/LYBT.WebAPI/Controllers/FormulaTemplatesController.cs
+++ b/LYBT.WebAPI/Controllers/FormulaTemplatesController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.FormulaTemplates.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.FormulaTemplates.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using LYBT.Common.Models;
@@ -10,8 +12,10 @@ namespace LYBT.Module.FormulaTemplates.Controllers {
     /// 经验方模板 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class FormulaTemplateController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class FormulaTemplateController : ControllerBase {
         private readonly IFormulaTemplateService _service;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/GlobalSettingsController.cs
+++ b/LYBT.WebAPI/Controllers/GlobalSettingsController.cs
@@ -1,12 +1,16 @@
 using LYBT.Module.Settings.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Settings.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LYBT.WebAPI.Controllers {
 
     [ApiController]
-    [Route("api/[controller]")]
-    public class GlobalSettingsController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class GlobalSettingsController : ControllerBase {
         private readonly IGlobalSettingsService _service;
 
         public GlobalSettingsController(IGlobalSettingsService service) {

--- a/LYBT.WebAPI/Controllers/HerbsController.cs
+++ b/LYBT.WebAPI/Controllers/HerbsController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.Herbs.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Herbs.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
@@ -11,7 +13,8 @@ namespace LYBT.Module.Herbs.Controllers {
     /// </summary>
     [ApiController]
     [Route("api/herbs")]
-    public class HerbsController : ControllerBase {
+    [Authorize]
+public class HerbsController : ControllerBase {
         private readonly IHerbService _herbService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/LogController.cs
+++ b/LYBT.WebAPI/Controllers/LogController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Common.Enums.Users;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Logs.Dtos;
 using LYBT.Module.Logs.Interfaces;
 using Microsoft.AspNetCore.Mvc;
@@ -7,7 +9,9 @@ using Microsoft.AspNetCore.Mvc;
 /// 操作日志Web API控制器，提供日志写入与查询接口
 /// </summary>
 [ApiController]
-[Route("api/[controller]")]
+[ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+[Authorize]
 public class LogController : ControllerBase {
     private readonly ILogService _logService;
 

--- a/LYBT.WebAPI/Controllers/PatientsController.cs
+++ b/LYBT.WebAPI/Controllers/PatientsController.cs
@@ -1,9 +1,11 @@
 ﻿using LYBT.Common.Models;
+using LYBT.Common.Responses;
 using LYBT.Module.Patients.Dtos;
 using LYBT.Module.Patients.Interfaces;
 using LYBT.Module.Records.Dtos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using System.Security.Claims;
 
 namespace LYBT.WebAPI.Controllers {
@@ -12,13 +14,16 @@ namespace LYBT.WebAPI.Controllers {
     /// 病人管理API接口
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [Authorize]
     public class PatientsController : ControllerBase {
         private readonly IPatientService _patientService;
+        private readonly IMemoryCache _cache;
 
-        public PatientsController(IPatientService patientService) {
+        public PatientsController(IPatientService patientService, IMemoryCache cache) {
             _patientService = patientService;
+            _cache = cache;
         }
 
         private (Guid operatorId, string operatorName) GetOperator() {
@@ -32,117 +37,131 @@ namespace LYBT.WebAPI.Controllers {
         /// <summary>
         /// 新增病人
         /// </summary>
-        [HttpPost("add")]
+        [HttpPost]
         public async Task<IActionResult> Add([FromBody] PatientDetailDto dto) {
             var (operatorId, operatorName) = GetOperator();
             var result = await _patientService.AddAsync(dto, operatorId, operatorName);
-            return result ? Ok() : BadRequest("新增失败，必填项不完整或已存在。");
+            return result
+                ? Ok(ApiResponse<object>.Success(null))
+                : BadRequest(ApiResponse<object>.Fail("新增失败，必填项不完整或已存在。"));
         }
 
         /// <summary>
         /// 编辑病人
         /// </summary>
-        [HttpPut("edit")]
-        public async Task<IActionResult> Edit([FromBody] PatientDetailDto dto) {
+        [HttpPut("{id}")]
+        public async Task<IActionResult> Edit(Guid id, [FromBody] PatientDetailDto dto) {
             var (operatorId, operatorName) = GetOperator();
+            dto.Id = id;
             var result = await _patientService.UpdateAsync(dto, operatorId, operatorName);
-            return result ? Ok() : BadRequest("更新失败，必填项不完整或病人不存在。");
+            return result
+                ? Ok(ApiResponse<object>.Success(null))
+                : BadRequest(ApiResponse<object>.Fail("更新失败，必填项不完整或病人不存在。"));
         }
 
-        [HttpPut("enable/{id}")]
+        [HttpPatch("{id}/enable")]
         public async Task<IActionResult> Enable(Guid id) {
             var (operatorId, operatorName) = GetOperator();
             var result = await _patientService.EnableAsync(id, operatorId, operatorName);
-            return result ? Ok() : NotFound();
+            return result ? Ok(ApiResponse<object>.Success(null)) : NotFound();
         }
 
-        [HttpPut("disable/{id}")]
+        [HttpPatch("{id}/disable")]
         public async Task<IActionResult> Disable(Guid id) {
             var (operatorId, operatorName) = GetOperator();
             var result = await _patientService.DisableAsync(id, operatorId, operatorName);
-            return result ? Ok() : NotFound();
+            return result ? Ok(ApiResponse<object>.Success(null)) : NotFound();
         }
 
         /// <summary>
         /// 获取病人详情
         /// </summary>
-        [HttpGet("get/{id}")]
-        public async Task<ActionResult<PatientDetailDto>> GetById(Guid id) {
-            var data = await _patientService.GetByIdAsync(id);
-            return data != null ? Ok(data) : NotFound();
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ApiResponse<PatientDetailDto>>> GetById(Guid id) {
+            if (!_cache.TryGetValue($"patient:{id}", out PatientDetailDto? data)) {
+                data = await _patientService.GetByIdAsync(id);
+                if (data != null)
+                    _cache.Set($"patient:{id}", data, TimeSpan.FromMinutes(5));
+            }
+            return data != null
+                ? Ok(ApiResponse<PatientDetailDto>.Success(data))
+                : NotFound(ApiResponse<object>.Fail("未找到"));
         }
 
         /// <summary>
         /// 获取全部病人（小数据量场景，分页请用 /paged）
         /// </summary>
-        [HttpGet("all")]
-        public async Task<ActionResult<List<PatientDetailDto>>> GetAll() {
-            var data = await _patientService.GetAllAsync();
-            return Ok(data);
+        [HttpGet]
+        public async Task<ActionResult<ApiResponse<List<PatientDetailDto>>>> GetAll() {
+            if (!_cache.TryGetValue("patients:all", out List<PatientDetailDto>? data)) {
+                data = await _patientService.GetAllAsync();
+                _cache.Set("patients:all", data, TimeSpan.FromMinutes(5));
+            }
+            return Ok(ApiResponse<List<PatientDetailDto>>.Success(data));
         }
 
         /// <summary>
         /// 分页条件查询
         /// </summary>
         [HttpPost("paged")]
-        public async Task<ActionResult<PagedResultDto<PatientDetailDto>>> GetPaged([FromBody] PatientPagedQueryDto query) {
+        public async Task<ActionResult<ApiResponse<PagedResultDto<PatientDetailDto>>>> GetPaged([FromBody] PatientPagedQueryDto query) {
             var result = await _patientService.GetPagedAsync(query);
-            return Ok(result);
+            return Ok(ApiResponse<PagedResultDto<PatientDetailDto>>.Success(result));
         }
 
         /// <summary>
         /// 批量删除病人
         /// </summary>
-        [HttpPost("batchDelete")]
+        [HttpDelete]
         public async Task<IActionResult> BatchDelete([FromBody] List<string> ids) {
             var (operatorId, operatorName) = GetOperator();
             var count = await _patientService.BatchDeleteAsync(ids, operatorId, operatorName);
-            return Ok(new { DeletedCount = count });
+            return Ok(ApiResponse<object>.Success(new { DeletedCount = count }));
         }
 
-        [HttpPost("batch-disable")]
+        [HttpPatch("batch-disable")]
         public async Task<IActionResult> BatchDisable([FromBody] BatchIdsDto dto) {
             var (operatorId, operatorName) = GetOperator();
             var count = await _patientService.BatchDisableAsync(dto.Ids, operatorId, operatorName);
-            return Ok(new { DisabledCount = count });
+            return Ok(ApiResponse<object>.Success(new { DisabledCount = count }));
         }
 
         [HttpGet("search")]
-        public async Task<ActionResult<List<PatientDetailDto>>> Search([FromQuery] string keyword) {
+        public async Task<ActionResult<ApiResponse<List<PatientDetailDto>>>> Search([FromQuery] string keyword) {
             var list = await _patientService.SearchAsync(keyword);
-            return Ok(list);
+            return Ok(ApiResponse<List<PatientDetailDto>>.Success(list));
         }
 
         [HttpGet("doctor/{doctorId}")]
-        public async Task<ActionResult<List<PatientDetailDto>>> GetForDoctor(Guid doctorId) {
+        public async Task<ActionResult<ApiResponse<List<PatientDetailDto>>>> GetForDoctor(Guid doctorId) {
             var list = await _patientService.GetForDoctorAsync(doctorId);
-            return Ok(list);
+            return Ok(ApiResponse<List<PatientDetailDto>>.Success(list));
         }
 
-        [HttpPost("{id}/assign-doctor")]
+        [HttpPatch("{id}/assign-doctor")]
         public async Task<IActionResult> AssignDoctor(Guid id, [FromBody] AssignDoctorDto dto) {
             var (operatorId, operatorName) = GetOperator();
             var result = await _patientService.AssignDoctorAsync(id, dto.DoctorId, operatorId, operatorName);
-            return result ? Ok() : BadRequest();
+            return result ? Ok(ApiResponse<object>.Success(null)) : BadRequest(ApiResponse<object>.Fail("失败"));
         }
 
         [HttpPost("import")]
         public async Task<IActionResult> Import([FromBody] List<PatientDetailDto> dtos) {
             var (operatorId, operatorName) = GetOperator();
             var count = await _patientService.ImportAsync(dtos, operatorId, operatorName);
-            return Ok(new { Imported = count });
+            return Ok(ApiResponse<object>.Success(new { Imported = count }));
         }
 
-        [HttpPost("export")]
-        public async Task<ActionResult<List<PatientDetailDto>>> Export() {
+        [HttpGet("export")]
+        public async Task<ActionResult<ApiResponse<List<PatientDetailDto>>>> Export() {
             var data = await _patientService.ExportAsync();
-            return Ok(data);
+            return Ok(ApiResponse<List<PatientDetailDto>>.Success(data));
         }
 
         [HttpGet("{id}/records")]
-        public async Task<ActionResult<List<RecordDto>>> GetHistory(Guid id) {
+        public async Task<ActionResult<ApiResponse<List<RecordDto>>>> GetHistory(Guid id) {
             var data = await _patientService.GetHistoryRecordsAsync(id);
-            return Ok(data);
+            return Ok(ApiResponse<List<RecordDto>>.Success(data));
         }
     }
 }

--- a/LYBT.WebAPI/Controllers/PharmacyController.cs
+++ b/LYBT.WebAPI/Controllers/PharmacyController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.Pharmacy.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Pharmacy.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,8 +10,10 @@ namespace LYBT.Module.Pharmacy.Controllers {
     /// 药房 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class PharmacyController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class PharmacyController : ControllerBase {
         private readonly IPharmacyService _pharmacyService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -1,4 +1,6 @@
 using LYBT.Module.Prescriptions.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Prescriptions.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -7,8 +9,10 @@ namespace LYBT.WebAPI.Controllers {
     /// 处方管理 API
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class PrescriptionsController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class PrescriptionsController : ControllerBase {
         private readonly IPrescriptionService _service;
         public PrescriptionsController(IPrescriptionService service) {
             _service = service;

--- a/LYBT.WebAPI/Controllers/QueueingController.cs
+++ b/LYBT.WebAPI/Controllers/QueueingController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.Queueing.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Queueing.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,8 +10,10 @@ namespace LYBT.Module.Queueing.Controllers {
     /// 排队管理 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class QueueingController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class QueueingController : ControllerBase {
         private readonly IQueueingService _queueingService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/RecordsController.cs
+++ b/LYBT.WebAPI/Controllers/RecordsController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.Records.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Records.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,8 +10,10 @@ namespace LYBT.Module.Records.Controllers {
     /// 病历 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class RecordController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class RecordController : ControllerBase {
         private readonly IRecordService _recordService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/RegistrationController.cs
+++ b/LYBT.WebAPI/Controllers/RegistrationController.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Module.Registration.Dtos;
+using LYBT.Common.Responses;
 using LYBT.Module.Registration.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
@@ -9,7 +10,8 @@ namespace LYBT.Module.Registration.Controllers {
     /// 挂号管理 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
     [Authorize]
     public class RegistrationController : ControllerBase {
         private readonly IRegistrationService _registrationService;

--- a/LYBT.WebAPI/Controllers/SettingsController.cs
+++ b/LYBT.WebAPI/Controllers/SettingsController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.Settings.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Settings.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,8 +10,10 @@ namespace LYBT.Module.Settings.Controllers {
     /// 系统设置 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class SettingsController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class SettingsController : ControllerBase {
         private readonly ISettingsService _settingsService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/SyncController.cs
+++ b/LYBT.WebAPI/Controllers/SyncController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Common.Enums;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Settings.Interfaces;
 using LYBT.Module.Sync.Dtos;
 using LYBT.Module.Sync.Interfaces;
@@ -10,8 +12,10 @@ namespace LYBT.Module.Sync.Controllers {
     /// 数据同步任务与日志 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class SyncController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class SyncController : ControllerBase {
         private readonly ISyncService _syncService;
         private readonly IGlobalSettingsService _settingsService;
 

--- a/LYBT.WebAPI/Controllers/TreatmentCatalogController.cs
+++ b/LYBT.WebAPI/Controllers/TreatmentCatalogController.cs
@@ -1,12 +1,16 @@
 using LYBT.Module.Settings.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.Settings.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LYBT.WebAPI.Controllers {
 
     [ApiController]
-    [Route("api/[controller]")]
-    public class TreatmentCatalogController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class TreatmentCatalogController : ControllerBase {
         private readonly ITreatmentCatalogService _service;
 
         public TreatmentCatalogController(ITreatmentCatalogService service) {

--- a/LYBT.WebAPI/Controllers/TreatmentRoomController.cs
+++ b/LYBT.WebAPI/Controllers/TreatmentRoomController.cs
@@ -1,4 +1,6 @@
 ﻿using LYBT.Module.TreatmentRoom.Dtos;
+using LYBT.Common.Responses;
+using Microsoft.AspNetCore.Authorization;
 using LYBT.Module.TreatmentRoom.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,8 +10,10 @@ namespace LYBT.Module.TreatmentRoom.Controllers {
     /// 治疗室 API 控制器
     /// </summary>
     [ApiController]
-    [Route("api/[controller]")]
-    public class TreatmentRoomController : ControllerBase {
+    [ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [Authorize]
+public class TreatmentRoomController : ControllerBase {
         private readonly ITreatmentRoomService _treatmentRoomService;
 
         /// <summary>

--- a/LYBT.WebAPI/Controllers/UsersController.cs
+++ b/LYBT.WebAPI/Controllers/UsersController.cs
@@ -1,4 +1,5 @@
 ﻿using LYBT.Module.Users.Dtos;
+using LYBT.Common.Responses;
 using LYBT.Module.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -9,7 +10,8 @@ using LYBT.Module.Users.Interfaces;
 /// 用户管理控制器，提供RESTful API接口
 /// </summary>
 [ApiController]
-[Route("api/[controller]")]
+[ApiVersion("1.0")]
+    [Route("api/v{version:apiVersion}/[controller]")]
 [Authorize] // 全部接口必须登录
 public class UsersController : ControllerBase {
     private readonly IUserService _userService;

--- a/LYBT.WebAPI/LYBT.WebAPI.csproj
+++ b/LYBT.WebAPI/LYBT.WebAPI.csproj
@@ -14,9 +14,10 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-		<PackageReference Include="NPOI" Version="2.7.4" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
-	</ItemGroup>
+                <PackageReference Include="NPOI" Version="2.7.4" />
+                <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+                <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\LYBT.Common\LYBT.Common.csproj" />

--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -65,6 +65,8 @@ using LYBT.Module.Users.Services;
 using LYBT.Module.Users.Repositories;
 using LYBT.Module.Users.Interfaces;
 using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Versioning;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -150,6 +152,18 @@ builder.Services.AddAutoMapper(
 builder.Services.AddControllers().AddJsonOptions(o => {
     o.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
     o.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
+
+builder.Services.AddMemoryCache();
+
+builder.Services.AddApiVersioning(opt =>
+{
+    opt.AssumeDefaultVersionWhenUnspecified = true;
+    opt.DefaultApiVersion = new ApiVersion(1, 0);
+    opt.ReportApiVersions = true;
+    opt.ApiVersionReader = ApiVersionReader.Combine(
+        new UrlSegmentApiVersionReader(),
+        new HeaderApiVersionReader("X-Version"));
 });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options => {


### PR DESCRIPTION
## Summary
- standardize `ApiResponse<T>` model
- add API versioning and memory cache setup in WebAPI Program
- add authorization and versioned routing attributes to controllers
- refactor `PatientsController` endpoints for REST paths, caching and ApiResponse usage

## Testing
- `dotnet build LYBT.WebAPI/LYBT.WebAPI.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_687ec5a33b488333b0efd165e79efbac