### PR TITLE
Introduce modular DB context for Users

### DIFF
--- a/LYBT.Infrastructure/Helpers/AdminSeeder.cs
+++ b/LYBT.Infrastructure/Helpers/AdminSeeder.cs
@@ -1,4 +1,5 @@
 using LYBT.Common.Helpers;
+using LYBT.Module.Users.Data;
 
 namespace LYBT.Infrastructure.Helpers {
 
@@ -12,7 +13,7 @@ namespace LYBT.Infrastructure.Helpers {
         /// </summary>
         /// <param name="context">参数context</param>
         /// <param name="defaultPassword">参数defaultPassword</param>
-        public static void Seed(AppDbContext context, string defaultPassword) {
+        public static void Seed(UsersDbContext context, string defaultPassword) {
             // Default sysadmin credentials stored only in AdminSecrets table.
             // No corresponding record in Users table.
             if (!context.AdminSecrets.Any(s => s.UserName == "sysadmin")) {

--- a/LYBT.Module.Users/Data/UsersDbContext.cs
+++ b/LYBT.Module.Users/Data/UsersDbContext.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using LYBT.Common.Enums.Users;
+using LYBT.Module.Users.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace LYBT.Module.Users.Data {
+    /// <summary>
+    /// DbContext for Users module containing Users and AdminSecrets tables
+    /// </summary>
+    public class UsersDbContext : DbContext {
+        public UsersDbContext(DbContextOptions<UsersDbContext> options) : base(options) { }
+
+        public DbSet<UserModel> Users { get; set; }
+        public DbSet<AdminSecretModel> AdminSecrets { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) {
+            base.OnModelCreating(modelBuilder);
+            ConfigureUserModule(modelBuilder);
+        }
+
+        private static void ConfigureUserModule(ModelBuilder modelBuilder) {
+            var userEntity = modelBuilder.Entity<UserModel>();
+            userEntity.HasIndex(u => u.UserName).IsUnique().HasDatabaseName("IX_Users_UserName");
+            userEntity.HasIndex(u => u.IsActive).HasDatabaseName("IX_Users_IsActive");
+            userEntity.HasIndex(u => u.PinyinCode).HasDatabaseName("IX_Users_PinyinCode");
+            userEntity.HasIndex(u => u.PhoneNumber).HasDatabaseName("IX_Users_PhoneNumber");
+
+            userEntity.Property(x => x.Roles)
+                .HasConversion(
+                    roles => string.Join(",", roles.Select(r => (int)r)),
+                    value => ParseUserRoles(value))
+                .Metadata.SetValueComparer(CreateListComparer<UserRole>());
+        }
+
+        private static List<UserRole> ParseUserRoles(string value) {
+            if (string.IsNullOrEmpty(value))
+                return new List<UserRole>();
+            return value.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Where(s => int.TryParse(s, out _))
+                .Select(s => (UserRole)int.Parse(s))
+                .ToList();
+        }
+
+        private static ValueComparer<List<T>> CreateListComparer<T>() {
+            return new ValueComparer<List<T>>(
+                (c1, c2) => (c1 == null && c2 == null) || (c1 != null && c2 != null && c1.SequenceEqual(c2)),
+                c => c == null ? 0 : c.Aggregate(0, (a, v) => HashCode.Combine(a, v != null ? v.GetHashCode() : 0)),
+                c => c != null ? c.ToList() : new List<T>()
+            );
+        }
+    }
+}

--- a/LYBT.Module.Users/Repositories/UserRepository.cs
+++ b/LYBT.Module.Users/Repositories/UserRepository.cs
@@ -1,4 +1,4 @@
-﻿using LYBT.Infrastructure;
+﻿using LYBT.Module.Users.Data;
 using LYBT.Module.Users.Interfaces;
 using LYBT.Module.Users.Models;
 using Microsoft.EntityFrameworkCore;
@@ -10,9 +10,9 @@ namespace LYBT.Module.Users.Repositories {
     /// 实现软删除策略：用户只能禁用/启用，不能物理删除
     /// </summary>
     public class UserRepository : IUserRepository {
-        private readonly AppDbContext _dbContext;
+        private readonly UsersDbContext _dbContext;
 
-        public UserRepository(AppDbContext dbContext) {
+        public UserRepository(UsersDbContext dbContext) {
             _dbContext = dbContext;
         }
 

--- a/LYBT.Module.Users/UsersModule.cs
+++ b/LYBT.Module.Users/UsersModule.cs
@@ -1,6 +1,8 @@
 ﻿using LYBT.Module.Users.Interfaces;
 using LYBT.Module.Users.Repositories;
 using LYBT.Module.Users.Services;
+using LYBT.Module.Users.Data;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LYBT.Module.Users {
@@ -13,7 +15,8 @@ namespace LYBT.Module.Users {
         /// <summary>
         /// 注册本模块所有服务到 DI 容器
         /// </summary>
-        public static IServiceCollection AddUsersModule(this IServiceCollection services) {
+        public static IServiceCollection AddUsersModule(this IServiceCollection services, string connectionString) {
+            services.AddDbContext<UsersDbContext>(opts => opts.UseSqlServer(connectionString));
             services.AddScoped<IUserRepository, UserRepository>(); // 仓储层
             services.AddScoped<IUserService, UserService>();           // 业务层
             return services;

--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -60,6 +60,7 @@ using LYBT.Module.Users.Mapping;
 using LYBT.Module.Users.Repositories;
 using LYBT.Module.Users.Services;
 using LYBT.WebAPI.Extensions;
+using LYBT.Module.Users.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.EntityFrameworkCore;
@@ -74,9 +75,7 @@ builder.Services.Configure<UserOptions>(builder.Configuration.GetSection("UserDe
 
 // =========== 1. 注册所有模块的 Service 和 Repository ===========
 
-// 用户管理
-builder.Services.AddScoped<IUserService, UserService>();
-builder.Services.AddScoped<IUserRepository, UserRepository>();
+// 用户管理 registered via module
 builder.Services.AddScoped<IAuthRepository, AuthRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 
@@ -176,6 +175,8 @@ builder.Services.AddCorsPolicy();
 var connection = builder.Configuration.GetConnectionString("DefaultConnection");
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseSqlServer(connection));
+// Users module context
+builder.Services.AddUsersModule(connection);
 
 // =========== 5. JWT 认证配置 ===========
 builder.Services.AddJwtAuthentication(builder.Configuration);
@@ -189,7 +190,7 @@ app.UseMiddleware<ExceptionMiddleware>();
 
 // ensure default admin user exists
 using (var scope = app.Services.CreateScope()) {
-    var context = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var context = scope.ServiceProvider.GetRequiredService<UsersDbContext>();
     var opts = scope.ServiceProvider.GetRequiredService<IOptions<UserOptions>>();
     AdminSeeder.Seed(context, opts.Value.DefaultUserPassword);
 }


### PR DESCRIPTION
## Summary
- add `UsersDbContext` for Users module
- register the new context in `UsersModule`
- use `UsersDbContext` in `UserRepository` and admin seeding
- wire `AddUsersModule` and seed with the new context in WebAPI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68831df6606c8333b2568465b4b78518