### PR TITLE
修复WebAPI驻留后台问题

### DIFF
--- a/LYBT.WebAPI/Program.cs
+++ b/LYBT.WebAPI/Program.cs
@@ -209,6 +209,12 @@ Console.CancelKeyPress += (sender, e) => {
     e.Cancel = true; // 取消默认的强制终止
     cancellationTokenSource.Cancel(); // 触发取消令牌
 };
+AppDomain.CurrentDomain.ProcessExit += (_, __) => {
+    Console.WriteLine("\n⚠️  正在关闭程序...");
+    cancellationTokenSource.Cancel();
+    // 等待应用优雅关闭并确保资源释放
+    app.StopAsync().GetAwaiter().GetResult();
+};
 
 try {
     await app.RunAsync(cancellationTokenSource.Token);


### PR DESCRIPTION
## Summary
- 在 `Program.cs` 添加 `ProcessExit` 事件，确保关闭时能通知 `WebApplication` 停止

## Testing
- `dotnet build LYBTZYZS.sln --no-restore` *(fails: missing referenced modules)*

------
https://chatgpt.com/codex/tasks/task_e_6887ee6a048c83339d4034a2282d78e3