### PR TITLE
Improve herb EF mapping

### DIFF
--- a/LYBT.Infrastructure/Data/AppDbContext.cs
+++ b/LYBT.Infrastructure/Data/AppDbContext.cs
@@ -212,6 +212,12 @@ namespace LYBT.Infrastructure.Data {
             entity.HasKey(h => h.Id);
             entity.Property(h => h.Name).HasMaxLength(100);
             entity.Property(h => h.PinyinCode).HasMaxLength(20);
+            entity.Property(h => h.WuBiCode).HasMaxLength(20);
+            entity.Property(h => h.BatchNo).HasMaxLength(32);
+            entity.HasIndex(h => h.Name);
+            entity.HasIndex(h => h.PinyinCode);
+            entity.HasIndex(h => h.WuBiCode);
+            entity.HasIndex(h => h.ExpireDate);
         }
 
         private static void ConfigureFormulaTemplates(ModelBuilder modelBuilder) {

--- a/LYBT.Models/Herbs/HerbModel.cs
+++ b/LYBT.Models/Herbs/HerbModel.cs
@@ -115,13 +115,13 @@ namespace LYBT.Models.Herbs {
         /// 创建时间
         /// </summary>
         [DisplayName("创建时间")]
-        public DateTime CreatedAt { get; set; } = DateTime.Now;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// 更新时间
         /// </summary>
         [DisplayName("更新时间")]
-        public DateTime UpdatedAt { get; set; } = DateTime.Now;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
         /// <summary>
         /// 最后操作者ID

--- a/LYBT.Module.Herbs/Repositories/HerbRepository.cs
+++ b/LYBT.Module.Herbs/Repositories/HerbRepository.cs
@@ -1,5 +1,5 @@
 ﻿using LYBT.Models.Herbs;
-using LYBT.Module.Herbs.Data;
+using LYBT.Infrastructure.Data;
 using LYBT.Module.Herbs.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -9,13 +9,13 @@ namespace LYBT.Module.Herbs.Repositories {
     /// 药材仓储实现类，实现数据库操作
     /// </summary>
     public class HerbRepository : IHerbRepository {
-        private readonly HerbDbContext _herbDbContext;
+        private readonly AppDbContext _herbDbContext;
         private readonly ILogger<HerbRepository> _logger;
 
         /// <summary>
         /// 构造方法，注入数据库上下文
         /// </summary>
-        public HerbRepository(HerbDbContext herbDbContext, ILogger<HerbRepository> logger) {
+        public HerbRepository(AppDbContext herbDbContext, ILogger<HerbRepository> logger) {
             _herbDbContext = herbDbContext;
             _logger = logger;
         }

--- a/LYBT.Module.Herbs/Services/HerbService.cs
+++ b/LYBT.Module.Herbs/Services/HerbService.cs
@@ -3,7 +3,7 @@ using LYBT.Common.Enums.Herbs;
 using LYBT.Common.Extensions;
 using LYBT.Common.Models;
 using LYBT.Models.Herbs;
-using LYBT.Module.Herbs.Data;
+using LYBT.Infrastructure.Data;
 using LYBT.Module.Herbs.Interfaces;
 using Microsoft.EntityFrameworkCore;
 
@@ -15,12 +15,12 @@ namespace LYBT.Module.Herbs.Services {
     public class HerbService : IHerbService {
         private readonly IHerbRepository _repository;
         private readonly IMapper _mapper;
-        private readonly HerbDbContext _context;
+        private readonly AppDbContext _context;
 
         /// <summary>
         /// 构造方法，注入仓储与对象映射
         /// </summary>
-        public HerbService(IHerbRepository repository, IMapper mapper, HerbDbContext context) {
+        public HerbService(IHerbRepository repository, IMapper mapper, AppDbContext context) {
             _repository = repository;
             _mapper = mapper;
             _context = context;


### PR DESCRIPTION
## Summary
- use `AppDbContext` for herb repository and service
- add database indexes for herb model
- standardize herb timestamp defaults to UTC

## Testing
- `dotnet build LYBTZYZS.sln` *(fails: missing module DbContexts)*

------
https://chatgpt.com/codex/tasks/task_e_6887f259e35c833398aa86442e181280