### PR TITLE
Fix EF Core warnings for lists and decimals

### DIFF
--- a/LYBT.Infrastructure/Data/AppDbContext.cs
+++ b/LYBT.Infrastructure/Data/AppDbContext.cs
@@ -18,6 +18,8 @@ using LYBT.Models.Users;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using System.Linq;
 
 namespace LYBT.Infrastructure.Data {
 
@@ -283,15 +285,21 @@ namespace LYBT.Infrastructure.Data {
             entity.HasKey(r => r.Id);
             var stringListConverter = new ValueConverter<List<string>, string>(
                 v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
-                v => string.IsNullOrWhiteSpace(v) ? new List<string>() : JsonSerializer.Deserialize<List<string>>(v) ?? new List<string>());
+                v => string.IsNullOrWhiteSpace(v) ? new List<string>() : JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new List<string>());
+            var stringListComparer = new ValueComparer<List<string>>(
+                (c1, c2) => c1.SequenceEqual(c2),
+                c => c.Aggregate(0, (a, v) => HashCode.Combine(a, v == null ? 0 : v.GetHashCode())),
+                c => c.ToList());
 
-            entity.Property(r => r.DiagnosisResults)
-                  .HasConversion(stringListConverter)
-                  .HasColumnType("nvarchar(max)");
+            var diagProp = entity.Property(r => r.DiagnosisResults)
+                                  .HasConversion(stringListConverter)
+                                  .HasColumnType("nvarchar(max)");
+            diagProp.Metadata.SetValueComparer(stringListComparer);
 
-            entity.Property(r => r.SharedToDoctorIds)
-                  .HasConversion(stringListConverter)
-                  .HasColumnType("nvarchar(max)");
+            var sharedProp = entity.Property(r => r.SharedToDoctorIds)
+                                    .HasConversion(stringListConverter)
+                                    .HasColumnType("nvarchar(max)");
+            sharedProp.Metadata.SetValueComparer(stringListComparer);
 
             entity.OwnsMany(r => r.HerbalFormula, b => {
                 b.ToTable("RecordHerbalFormulas");

--- a/LYBT.Models/DiagnosisTreatment/HerbItemModel.cs
+++ b/LYBT.Models/DiagnosisTreatment/HerbItemModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace LYBT.Models.DiagnosisTreatment {
@@ -31,12 +32,14 @@ namespace LYBT.Models.DiagnosisTreatment {
         /// 剂量
         /// </summary>
         [DisplayName("剂量")]
+        [Column(TypeName = "decimal(18,2)")]
         public decimal Amount { get; set; }
 
         /// <summary>
         /// 单价
         /// </summary>
         [DisplayName("单价")]
+        [Column(TypeName = "decimal(18,2)")]
         public decimal UnitPrice { get; set; }
 
         /// <summary>

--- a/LYBT.Models/DiagnosisTreatment/TreatmentItemModel.cs
+++ b/LYBT.Models/DiagnosisTreatment/TreatmentItemModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace LYBT.Models.DiagnosisTreatment {
@@ -25,6 +26,7 @@ namespace LYBT.Models.DiagnosisTreatment {
         /// 单价
         /// </summary>
         [DisplayName("单价")]
+        [Column(TypeName = "decimal(18,2)")]
         public decimal Price { get; set; }
 
         /// <summary>

--- a/LYBT.Models/Herbs/HerbModel.cs
+++ b/LYBT.Models/Herbs/HerbModel.cs
@@ -28,6 +28,7 @@ namespace LYBT.Models.Herbs {
         /// 药材基础规格数值（如：1，用于计算实际用量）
         /// </summary>
         [DisplayName("规格")]
+        [Column(TypeName = "decimal(18,2)")]
         public decimal Specification { get; set; } = 1;
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add decimal precision attributes to TreatmentItemModel, HerbItemModel, HerbModel
- add value comparer for RecordModel list properties
- include necessary using directives

## Testing
- `dotnet build LYBTZYZS.sln`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6888372a38348333ac283a1a2b8c04cc