### PR TITLE
fix: 消除后台编译告警

### DIFF
--- a/src/Backend/Services/LYBT.WebAPI/Controllers/PatientsController.cs
+++ b/src/Backend/Services/LYBT.WebAPI/Controllers/PatientsController.cs
@@ -127,13 +127,16 @@ namespace LYBT.WebAPI.Controllers
         public async Task<ActionResult<List<PatientDetailDto>>> GetAll()
         {
             var (_, _, operatorRole) = GetOperator();
+            var cacheKey = $"patients:all:{operatorRole}";
 
-            if (!_cache.TryGetValue($"patients:all:{operatorRole}", out List<PatientDetailDto>? data))
+            if ((_cache?.TryGetValue(cacheKey, out List<PatientDetailDto>? data)) ?? false)
             {
-                data = await _patientService.GetAllAsync();
-                _cache.Set($"patients:all:{operatorRole}", data, TimeSpan.FromMinutes(5));
+                return Ok(data);
             }
-            return Ok(data ?? new List<PatientDetailDto>());
+
+            var result = await _patientService.GetAllAsync();
+            _cache?.Set(cacheKey, result, TimeSpan.FromMinutes(5));
+            return Ok(result);
         }
 
         /// <summary>

--- a/src/Backend/Services/LYBT.WebAPI/Examples/MultiVersionControllerExample.cs
+++ b/src/Backend/Services/LYBT.WebAPI/Examples/MultiVersionControllerExample.cs
@@ -18,11 +18,8 @@ namespace LYBT.WebAPI.Examples
     [Authorize]
     public class ExampleController : BaseController
     {
-        private readonly ILogger<ExampleController> _logger;
-
         public ExampleController(ILogger<ExampleController> logger, IMemoryCache cache) : base(logger, cache)
         {
-            _logger = logger;
         }
 
         #region Version 1.0 APIs
@@ -152,8 +149,8 @@ namespace LYBT.WebAPI.Examples
         [Obsolete("此版本已弃用，请使用v2.0")]
         public IActionResult GetV3()
         {
-            Response.Headers.Add("X-API-Deprecation-Warning", "API v3.0 is deprecated and will be removed in future releases. Please migrate to v2.0.");
-            Response.Headers.Add("X-API-Deprecation-Date", "2024-12-31");
+            Response.Headers.Append("X-API-Deprecation-Warning", "API v3.0 is deprecated and will be removed in future releases. Please migrate to v2.0.");
+            Response.Headers.Append("X-API-Deprecation-Date", "2024-12-31");
             
             return Ok(new
             {


### PR DESCRIPTION
## Summary
- 清理 `ExampleController` 中多余的日志字段，避免覆盖父类成员
- 调整接口示例中响应头设置方式，使用 `Headers.Append`
- 优化 `PatientsController` 缓存读取逻辑，避免空引用警告

## Testing
- `dotnet build LYBT.Backend.sln`
- `dotnet test LYBT.Backend.sln` *(无测试用例)*

------
https://chatgpt.com/codex/tasks/task_e_6895ed396be083338c151cdd770fa7ef