### PR TITLE
Reduce async warnings in desktop frontend commands

### DIFF
--- a/src/Frontend/Desktop/BusinessModules/Users/ViewModels/UserAddEditDialogViewModel.cs
+++ b/src/Frontend/Desktop/BusinessModules/Users/ViewModels/UserAddEditDialogViewModel.cs
@@ -139,7 +139,7 @@ namespace LYBT.Desktop.Users.Shared.ViewModels
                 // 新增模式固定为普通用户角�?                SelectedRole = new RoleItem { Value = "用户", DisplayName = "普通用户（医生�? };
             }
 
-            SaveCommand = new DelegateCommand(ExecuteSaveWrapper, CanExecuteSave);
+            SaveCommand = DelegateCommand.FromAsyncHandler(ExecuteSave, CanExecuteSave);
             CancelCommand = new DelegateCommand(ExecuteCancel);
 
             // 监听属性变化以更新命令状态
@@ -167,11 +167,6 @@ namespace LYBT.Desktop.Users.Shared.ViewModels
             return !string.IsNullOrWhiteSpace(UserName) &&
                    !string.IsNullOrWhiteSpace(RealName) &&
                    SelectedRole != null;
-        }
-
-        private async void ExecuteSaveWrapper()
-        {
-            await ExecuteSave();
         }
 
         private async Task ExecuteSave()

--- a/src/Frontend/Desktop/Modules/SystemManagement/Formulas/ViewModels/AddFormulaDialogViewModel.cs
+++ b/src/Frontend/Desktop/Modules/SystemManagement/Formulas/ViewModels/AddFormulaDialogViewModel.cs
@@ -128,7 +128,7 @@ namespace LYBT.Desktop.Admin.Formulas.ViewModels
             _formulaService = formulaService;
             _herbService = herbService;
 
-            SaveCommand = new DelegateCommand(ExecuteSaveWrapper, CanExecuteSave)
+            SaveCommand = DelegateCommand.FromAsyncHandler(ExecuteSave, CanExecuteSave)
                 .ObservesProperty(() => TemplateName)
                 .ObservesProperty(() => Category)
                 .ObservesProperty(() => Indications)
@@ -171,11 +171,6 @@ namespace LYBT.Desktop.Admin.Formulas.ViewModels
                    !string.IsNullOrWhiteSpace(Category) &&
                    !string.IsNullOrWhiteSpace(Indications) &&
                    TemplateHerbs.Count > 0;
-        }
-
-        private async void ExecuteSaveWrapper()
-        {
-            await ExecuteSave();
         }
 
         private async System.Threading.Tasks.Task ExecuteSave()

--- a/src/Frontend/Desktop/Modules/SystemManagement/Herbs/ViewModels/AddHerbDialogViewModel.cs
+++ b/src/Frontend/Desktop/Modules/SystemManagement/Herbs/ViewModels/AddHerbDialogViewModel.cs
@@ -127,7 +127,7 @@ namespace LYBT.Desktop.Admin.Herbs.ViewModels
             _commonDialogService = commonDialogService;
             _herbService = herbService;
 
-            SaveCommand = new DelegateCommand(ExecuteSaveWrapper, CanExecuteSave)
+            SaveCommand = DelegateCommand.FromAsyncHandler(ExecuteSave, CanExecuteSave)
                 .ObservesProperty(() => HerbName)
                 .ObservesProperty(() => Unit)
                 .ObservesProperty(() => Price)
@@ -164,11 +164,6 @@ namespace LYBT.Desktop.Admin.Herbs.ViewModels
                    !string.IsNullOrWhiteSpace(Unit) &&
                    Price > 0 &&
                    Stock >= 0;
-        }
-
-        private async void ExecuteSaveWrapper()
-        {
-            await ExecuteSave();
         }
 
         private async Task ExecuteSave()

--- a/src/Frontend/Desktop/Modules/SystemManagement/Herbs/ViewModels/EditHerbDialogViewModel.cs
+++ b/src/Frontend/Desktop/Modules/SystemManagement/Herbs/ViewModels/EditHerbDialogViewModel.cs
@@ -132,7 +132,7 @@ namespace LYBT.Desktop.Admin.Herbs.ViewModels
             _commonDialogService = commonDialogService;
             _herbService = herbService;
 
-            SaveCommand = new DelegateCommand(ExecuteSaveWrapper, CanExecuteSave);
+            SaveCommand = DelegateCommand.FromAsyncHandler(ExecuteSave, CanExecuteSave);
             CancelCommand = new DelegateCommand(ExecuteCancel);
             RegeneratePinYinCommand = new DelegateCommand(ExecuteRegeneratePinYin);
             RegenerateWuBiCommand = new DelegateCommand(ExecuteRegenerateWuBi);
@@ -189,11 +189,6 @@ namespace LYBT.Desktop.Admin.Herbs.ViewModels
             return !string.IsNullOrWhiteSpace(HerbName) &&
                    !string.IsNullOrWhiteSpace(Unit) &&
                    Price > 0;
-        }
-
-        private async void ExecuteSaveWrapper()
-        {
-            await ExecuteSave();
         }
 
         private async Task ExecuteSave()

--- a/src/Frontend/Desktop/Modules/Users/ViewModels/UserAddEditDialogViewModel.cs
+++ b/src/Frontend/Desktop/Modules/Users/ViewModels/UserAddEditDialogViewModel.cs
@@ -141,7 +141,7 @@ namespace LYBT.Desktop.Users.ViewModels
                 SelectedRole = new RoleItem { Value = "用户", DisplayName = "普通用户（医生）" };
             }
 
-            SaveCommand = new DelegateCommand(ExecuteSaveWrapper, CanExecuteSave);
+            SaveCommand = DelegateCommand.FromAsyncHandler(ExecuteSave, CanExecuteSave);
             CancelCommand = new DelegateCommand(ExecuteCancel);
 
             // 监听属性变化以更新命令状态
@@ -172,11 +172,6 @@ namespace LYBT.Desktop.Users.ViewModels
             return !string.IsNullOrWhiteSpace(UserName) &&
                    !string.IsNullOrWhiteSpace(RealName) &&
                    SelectedRole != null;
-        }
-
-        private async void ExecuteSaveWrapper()
-        {
-            await ExecuteSave();
         }
 
         private async Task ExecuteSave()


### PR DESCRIPTION
## Summary
- replace async void wrappers with `DelegateCommand.FromAsyncHandler`
- keep command logic asynchronous while removing compiler warnings

## Testing
- `dotnet build LYBT.Desktop.sln` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689991c96e9483339d52fe54a1badf05