### PR TITLE
fix(desktop): 登录窗口优先显示，移除自动登录 - Issue #861

### DIFF
--- a/src/Client/Desktop/Core/LYBT.Desktop.Services/Business/IUsernameStorageService.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Services/Business/IUsernameStorageService.cs
@@ -1,0 +1,33 @@
+namespace LYBT.Desktop.Services.Business
+{
+    /// <summary>
+    /// 用户名存储服务接口 - Issue #861
+    /// 专门管理"记住用户名"功能，与 Token 存储分离
+    /// </summary>
+    public interface IUsernameStorageService
+    {
+        /// <summary>
+        /// 保存用户名
+        /// </summary>
+        /// <param name="username">用户名</param>
+        /// <param name="rememberMe">是否记住用户名</param>
+        Task SaveUsernameAsync(string username, bool rememberMe);
+
+        /// <summary>
+        /// 获取已保存的用户名
+        /// </summary>
+        /// <returns>用户名，如果未保存则返回 null</returns>
+        Task<string?> GetSavedUsernameAsync();
+
+        /// <summary>
+        /// 检查是否启用了"记住用户名"
+        /// </summary>
+        /// <returns>如果启用返回 true，否则返回 false</returns>
+        Task<bool> IsRememberMeEnabledAsync();
+
+        /// <summary>
+        /// 清除已保存的用户名
+        /// </summary>
+        Task ClearUsernameAsync();
+    }
+}

--- a/src/Client/Desktop/Core/LYBT.Desktop.Services/Business/UsernameStorageService.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Services/Business/UsernameStorageService.cs
@@ -1,0 +1,174 @@
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace LYBT.Desktop.Services.Business
+{
+    /// <summary>
+    /// 用户名存储服务实现 - Issue #861
+    /// 使用 JSON 文件存储用户名和"记住用户名"设置
+    /// 存储路径: %LOCALAPPDATA%\LYBT\Desktop\username.json
+    /// </summary>
+    public class UsernameStorageService : IUsernameStorageService
+    {
+        private readonly ILogger<UsernameStorageService> _logger;
+        private readonly string _storageFilePath;
+        private UsernameStorage? _cachedStorage; // 内存缓存
+
+        public UsernameStorageService(ILogger<UsernameStorageService> logger)
+        {
+            _logger = logger;
+
+            // 存储路径: %LOCALAPPDATA%\LYBT\Desktop\username.json
+            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var lybtFolder = Path.Combine(appDataPath, "LYBT", "Desktop");
+
+            // 确保目录存在
+            if (!Directory.Exists(lybtFolder))
+            {
+                Directory.CreateDirectory(lybtFolder);
+            }
+
+            _storageFilePath = Path.Combine(lybtFolder, "username.json");
+        }
+
+        /// <summary>
+        /// 保存用户名
+        /// </summary>
+        public async Task SaveUsernameAsync(string username, bool rememberMe)
+        {
+            try
+            {
+                if (rememberMe)
+                {
+                    // 保存到文件
+                    var storage = new UsernameStorage
+                    {
+                        Username = username,
+                        RememberMe = true
+                    };
+
+                    var json = JsonSerializer.Serialize(storage, new JsonSerializerOptions
+                    {
+                        WriteIndented = true,
+                        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                    });
+
+                    await File.WriteAllTextAsync(_storageFilePath, json, System.Text.Encoding.UTF8);
+                    _cachedStorage = storage;
+                    _logger.LogInformation("用户名已保存: {Username}", username);
+                }
+                else
+                {
+                    // 不记住用户名，删除文件
+                    await ClearUsernameAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "保存用户名失败");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// 获取已保存的用户名
+        /// </summary>
+        public async Task<string?> GetSavedUsernameAsync()
+        {
+            try
+            {
+                // 优先返回内存缓存
+                if (_cachedStorage != null)
+                {
+                    return _cachedStorage.RememberMe ? _cachedStorage.Username : null;
+                }
+
+                // 从文件加载
+                if (File.Exists(_storageFilePath))
+                {
+                    var json = await File.ReadAllTextAsync(_storageFilePath, System.Text.Encoding.UTF8);
+                    _cachedStorage = JsonSerializer.Deserialize<UsernameStorage>(json);
+
+                    if (_cachedStorage?.RememberMe == true)
+                    {
+                        _logger.LogInformation("从本地加载用户名: {Username}", _cachedStorage.Username);
+                        return _cachedStorage.Username;
+                    }
+                }
+
+                return null;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "读取用户名失败");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// 检查是否启用了"记住用户名"
+        /// </summary>
+        public async Task<bool> IsRememberMeEnabledAsync()
+        {
+            try
+            {
+                // 优先检查内存缓存
+                if (_cachedStorage != null)
+                {
+                    return _cachedStorage.RememberMe;
+                }
+
+                // 从文件加载
+                if (File.Exists(_storageFilePath))
+                {
+                    var json = await File.ReadAllTextAsync(_storageFilePath, System.Text.Encoding.UTF8);
+                    _cachedStorage = JsonSerializer.Deserialize<UsernameStorage>(json);
+                    return _cachedStorage?.RememberMe ?? false;
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "检查RememberMe状态失败");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 清除已保存的用户名
+        /// </summary>
+        public async Task ClearUsernameAsync()
+        {
+            try
+            {
+                // 清除内存缓存
+                _cachedStorage = null;
+
+                // 删除文件
+                if (File.Exists(_storageFilePath))
+                {
+                    File.Delete(_storageFilePath);
+                    _logger.LogInformation("已清除保存的用户名");
+                }
+
+                await Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "清除用户名失败");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// 用户名存储数据结构
+        /// </summary>
+        private class UsernameStorage
+        {
+            public string Username { get; set; } = string.Empty;
+            public bool RememberMe { get; set; }
+        }
+    }
+}

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginViewModel.cs
@@ -22,6 +22,7 @@ namespace LYBT.Desktop.Auth.ViewModels
         private readonly IAuthService _authService;
         private readonly IRegionManager _regionManager;
         private readonly IApiHealthCheckService? _apiHealthCheckService;
+        private readonly LYBT.Desktop.Services.Business.IUsernameStorageService? _usernameStorage;
 
         private string _username = string.Empty;
         private string _password = string.Empty;
@@ -38,19 +39,22 @@ namespace LYBT.Desktop.Auth.ViewModels
             IRegionManager regionManager,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
-            IApiHealthCheckService? apiHealthCheckService = null)
+            IApiHealthCheckService? apiHealthCheckService = null,
+            LYBT.Desktop.Services.Business.IUsernameStorageService? usernameStorage = null)
             : base(eventAggregator, loggerFactory)
         {
             _authService = authService;
             _regionManager = regionManager;
             _apiHealthCheckService = apiHealthCheckService;
+            _usernameStorage = usernameStorage;
 
             LoginCommand = new DelegateCommand(async () => await ExecuteLoginAsync(), CanExecuteLogin);
 
-            // 在后台线程启动健康检查,避免阻塞 UI 线程
+            // Issue #861: 在后台线程加载保存的用户名
             _ = Task.Run(async () =>
             {
                 await Task.Delay(100); // 短暂延迟,让 UI 先完成初始化
+                await LoadSavedUsernameAsync();
                 await CheckApiHealthAsyncSafe();
             });
         }
@@ -72,6 +76,37 @@ namespace LYBT.Desktop.Auth.ViewModels
                     ApiStatus = ApiHealthStatus.Unhealthy;
                     ApiStatusMessage = $"健康检查失败: {ex.Message}";
                 });
+            }
+        }
+
+        /// <summary>
+        /// 加载保存的用户名 - Issue #861
+        /// </summary>
+        private async Task LoadSavedUsernameAsync()
+        {
+            try
+            {
+                if (_usernameStorage == null)
+                {
+                    return;
+                }
+
+                var savedUsername = await _usernameStorage.GetSavedUsernameAsync();
+                var isRememberMeEnabled = await _usernameStorage.IsRememberMeEnabledAsync();
+
+                if (!string.IsNullOrEmpty(savedUsername))
+                {
+                    await Application.Current.Dispatcher.InvokeAsync(() =>
+                    {
+                        Username = savedUsername;
+                        RememberMe = isRememberMeEnabled;
+                        Logger.LogInformation("已自动填充用户名: {Username}", savedUsername);
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "加载保存的用户名失败");
             }
         }
 
@@ -229,6 +264,12 @@ namespace LYBT.Desktop.Auth.ViewModels
 
                     // 保存Token和用户信息
                     await _authService.SaveAuthenticationAsync(response.Data);
+
+                    // Issue #861: 保存用户名（如果勾选了"记住用户名"）
+                    if (_usernameStorage != null)
+                    {
+                        await _usernameStorage.SaveUsernameAsync(Username, RememberMe);
+                    }
 
                     // 根据角色导航到对应的工作台
                     NavigateBasedOnRole(response.Data.User.Role, response.Data.User, response.Data.Token);

--- a/src/Client/Desktop/Shell/App.xaml
+++ b/src/Client/Desktop/Shell/App.xaml
@@ -19,6 +19,7 @@
             <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
             <converters:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
             <converters:BoolToBrushConverter x:Key="BoolToBrushConverter" />
+            <converters:StringToVisibilityConverter x:Key="StringToVisibilityConverter" />
 
 
             <!--  应用级全局样式覆盖  -->

--- a/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
@@ -345,6 +345,10 @@ namespace LYBT.Desktop.Shell.Extensions
             containerRegistry.RegisterSingleton<LYBT.Desktop.Services.Business.ITokenStorageService,
                 LYBT.Desktop.Services.Business.TokenStorageService>();
 
+            // Issue #861: 注册用户名存储服务（记住用户名功能）
+            containerRegistry.RegisterSingleton<LYBT.Desktop.Services.Business.IUsernameStorageService,
+                LYBT.Desktop.Services.Business.UsernameStorageService>();
+
             // Issue #835: 注册 IAuthenticationService 适配器(供 MainWindowViewModel 使用)
             containerRegistry.RegisterSingleton<LYBT.Desktop.Services.Auth.IAuthenticationService,
                 LYBT.Desktop.Services.Auth.AuthenticationService>();

--- a/src/Client/Desktop/Shell/ViewModels/MainWindowViewModel.cs
+++ b/src/Client/Desktop/Shell/ViewModels/MainWindowViewModel.cs
@@ -378,57 +378,25 @@ public class MainWindowViewModel : UnifiedViewModelBase
     }
 
     /// <summary>
-    /// 检查登录状态 - UltraThink性能优化版
+    /// 检查登录状态 - Issue #861 修复: 始终显示登录窗口
+    /// 原因: 安全性考虑，不再根据保存的 Token 自动登录
+    /// 用户必须手动输入密码才能进入系统
     /// </summary>
     private async Task CheckLoginStatusAsync()
     {
-        System.Diagnostics.Debug.WriteLine(" CheckLoginStatusAsync 开始");
+        System.Diagnostics.Debug.WriteLine(" CheckLoginStatusAsync 开始 - Issue #861: 始终显示登录窗口");
         try
         {
-            // UltraThink修复: 使用AuthenticationService进行状态检查，确保与登录流程一致
-            var isLoggedIn = await _servicesFacade.AuthenticationService.IsLoggedInAsync();
-            System.Diagnostics.Debug.WriteLine($" AuthenticationService.IsLoggedInAsync = {isLoggedIn}");
-
-            if (isLoggedIn)
-            {
-                System.Diagnostics.Debug.WriteLine(" 尝试通过AuthenticationService获取当前用户...");
-                var user = await _servicesFacade.AuthenticationService.GetCurrentUserAsync();
-
-                if (user != null)
-                {
-                    System.Diagnostics.Debug.WriteLine($" 获取到当前用户 {user.UserName} - {user.RealName}");
-                    CurrentUser = user;
-                    IsLoggedIn = true;
-
-                    // 更新命令状态
-                    TestApiCommand.RaiseCanExecuteChanged();
-                    ShowControlExamplesCommand.RaiseCanExecuteChanged();
-                    UpdateKeyboardShortcutCommands();
-
-                    System.Diagnostics.Debug.WriteLine(" 准备加载主界面内容..");
-
-                    // 加载工作台模块
-                    await EnsureWorkstationModulesLoaded(user);
-
-                    LoadMainContent();
-                    return;
-                }
-                else
-                {
-                    System.Diagnostics.Debug.WriteLine($" AuthenticationService.GetCurrentUserAsync 返回null");
-                }
-            }
-            else
-            {
-                System.Diagnostics.Debug.WriteLine(" 用户未登录，显示登录界面");
-            }
-
+            // Issue #861 修复: 移除自动登录逻辑
+            // 即使有保存的 Token，也不自动登录，确保安全性
+            // 用户名会在 LoginViewModel 中自动填充（如果启用了"记住用户名"）
+            System.Diagnostics.Debug.WriteLine(" 显示登录界面，等待用户手动登录");
             ShowLoginDialog();
         }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($" CheckLoginStatusAsync 异常: {ex.Message}");
-            await ShowErrorMessageAsync($"检查登录状态失败:{ex.Message}");
+            await ShowErrorMessageAsync($"初始化登录界面失败:{ex.Message}");
             ShowLoginDialog();
         }
     }


### PR DESCRIPTION
## 概述
修复 Issue #861 - 实现应用启动时优先显示登录窗口，移除自动登录功能，提升安全性。

## 实现方案
### 架构设计
- **分离关注点**：Token 存储（安全/会话）与用户名存储（便捷性）独立管理
- **新增服务**：`IUsernameStorageService` - 专门管理"记住用户名"功能
- **存储路径**：`%LOCALAPPDATA%\LYBT\Desktop\username.json`

### 核心变更
1. **移除自动登录**（MainWindowViewModel.cs:380-402）
   - 简化 `CheckLoginStatusAsync()`，始终显示登录窗口
   - 即使存在有效 Token，也不自动登录

2. **用户名自动填充**（LoginViewModel.cs:37-111,268-272）
   - 构造函数注入 `IUsernameStorageService`
   - 后台加载保存的用户名（`LoadSavedUsernameAsync()`）
   - 登录成功时保存用户名偏好

3. **服务注册**（ServiceCollectionExtensions.cs:348-350）
   - 注册 `IUsernameStorageService` 为 Singleton

4. **XAML 修复**（App.xaml:22）
   - 添加缺失的 `StringToVisibilityConverter` 全局资源

## 验收标准
✅ 应用启动始终显示登录窗口（不自动登录）  
✅ 用户名自动填充（如果启用"记住用户名"）  
✅ 密码框始终为空（安全要求）  
✅ "记住用户名"复选框状态正确同步  
✅ 编译通过（Debug & Release）  

## 测试结果
### 功能测试
- [x] 首次启动显示空白登录窗口
- [x] 勾选"记住用户名"登录 → 生成 `username.json`
- [x] 重启应用 → 用户名自动填充，密码为空
- [x] 取消勾选"记住用户名"登录 → 删除 `username.json`
- [x] 重启应用 → 用户名和密码均为空

### 编译验证
```bash
dotnet build LYBT.Desktop.sln -c Release --no-restore
```
**结果**：✅ 已成功生成（0 警告，0 错误）

## 变更文件
- **新增**：
  - `IUsernameStorageService.cs` - 用户名存储接口
  - `UsernameStorageService.cs` - JSON 文件存储实现
- **修改**：
  - `MainWindowViewModel.cs` - 移除自动登录逻辑
  - `LoginViewModel.cs` - 添加用户名自动填充
  - `ServiceCollectionExtensions.cs` - 注册服务
  - `App.xaml` - 添加 Converter

## 安全性
- ✅ 密码永不保存（每次必须手动输入）
- ✅ Token 与用户名分离存储
- ✅ 用户可随时清除/更改保存的用户名

Closes #861

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>