### PR TITLE
Phase 3: 修复 ConsultationManagementViewModel DataGrid 行命令类型

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
@@ -66,11 +66,11 @@ namespace LYBT.Desktop.Consultation.ViewModels
         public ICommand LoadDataCommand { get; }
         public ICommand SearchCommand { get; }
         public ICommand RefreshCommand { get; }
-        public ICommand ViewDetailsCommand { get; }
+        public DelegateCommand<ConsultationDto> ViewDetailsCommand { get; }
 
-        public ICommand ViewPrescriptionCommand { get; }
-        public ICommand PrintCommand { get; }
-        public ICommand CopyRecordCommand { get; }
+        public DelegateCommand<ConsultationDto> ViewPrescriptionCommand { get; }
+        public DelegateCommand<ConsultationDto> PrintCommand { get; }
+        public DelegateCommand<ConsultationDto> CopyRecordCommand { get; }
         public ICommand StatisticsCommand { get; }
         public ICommand FirstPageCommand { get; }
         public ICommand LastPageCommand { get; }
@@ -94,15 +94,11 @@ namespace LYBT.Desktop.Consultation.ViewModels
             LoadDataCommand = new DelegateCommand(async () => await LoadDataAsync());
             SearchCommand = new DelegateCommand(async () => await SearchAsync());
             RefreshCommand = new DelegateCommand(async () => await RefreshAsync());
-            ViewDetailsCommand = new DelegateCommand(ViewDetails, () => SelectedConsultation != null)
-            .ObservesProperty(() => SelectedConsultation);
+            ViewDetailsCommand = new DelegateCommand<ConsultationDto>(ViewDetails, item => item != null);
 
-            ViewPrescriptionCommand = new DelegateCommand(ViewPrescription, () => SelectedConsultation != null)
-            .ObservesProperty(() => SelectedConsultation);
-            PrintCommand = new DelegateCommand(Print, () => SelectedConsultation != null)
-            .ObservesProperty(() => SelectedConsultation);
-            CopyRecordCommand = new DelegateCommand(CopyRecord, () => SelectedConsultation != null)
-            .ObservesProperty(() => SelectedConsultation);
+            ViewPrescriptionCommand = new DelegateCommand<ConsultationDto>(ViewPrescription, item => item != null);
+            PrintCommand = new DelegateCommand<ConsultationDto>(Print, item => item != null);
+            CopyRecordCommand = new DelegateCommand<ConsultationDto>(CopyRecord, item => item != null);
             StatisticsCommand = new DelegateCommand(ShowStatistics);
             
             FirstPageCommand = new DelegateCommand(ExecuteFirstPage);
@@ -186,41 +182,37 @@ namespace LYBT.Desktop.Consultation.ViewModels
             await LoadDataAsync();
         }
 
-        private void ViewDetails()
+        private void ViewDetails(ConsultationDto consultation)
         {
-            if (SelectedConsultation != null)
-            {
-                // �򵥵�������ʾ�����漰���ӵ���
-                Logger.LogInformation("�鿴���Ƽ�¼����: {ConsultationId}", SelectedConsultation.Id);
-            }
+            if (consultation == null) return;
+            
+            Logger.LogInformation("查看诊疗记录详情: {ConsultationId}", consultation.Id);
+            ShowInfoMessage("查看详情功能开发中");
         }
 
 
-        private void ViewPrescription()
+        private void ViewPrescription(ConsultationDto consultation)
         {
-            if (SelectedConsultation != null)
-            {
-                Logger.LogInformation("查看处方功能开发中: {ConsultationId}", SelectedConsultation.Id);
-                ShowInfoMessage("查看处方功能开发中");
-            }
+            if (consultation == null) return;
+            
+            Logger.LogInformation("查看处方: {ConsultationId}", consultation.Id);
+            ShowInfoMessage("查看处方功能开发中");
         }
 
-        private void Print()
+        private void Print(ConsultationDto consultation)
         {
-            if (SelectedConsultation != null)
-            {
-                Logger.LogInformation("打印诊疗记录功能开发中: {ConsultationId}", SelectedConsultation.Id);
-                ShowInfoMessage("打印功能开发中");
-            }
+            if (consultation == null) return;
+            
+            Logger.LogInformation("打印诊疗记录: {ConsultationId}", consultation.Id);
+            ShowInfoMessage("打印功能开发中");
         }
 
-        private void CopyRecord()
+        private void CopyRecord(ConsultationDto consultation)
         {
-            if (SelectedConsultation != null)
-            {
-                Logger.LogInformation("复制诊疗记录功能开发中: {ConsultationId}", SelectedConsultation.Id);
-                ShowInfoMessage("复制记录功能开发中");
-            }
+            if (consultation == null) return;
+            
+            Logger.LogInformation("复制诊疗记录: {ConsultationId}", consultation.Id);
+            ShowInfoMessage("复制记录功能开发中");
         }
 
         private void ShowStatistics()


### PR DESCRIPTION
## 关联 Issue
Fixes #890

## 变更摘要
修复 ConsultationManagementViewModel 中 4 个 DataGrid 行命令的类型，从 `ICommand` 改为 `DelegateCommand<ConsultationDto>`，使其能够正确接收 XAML 传递的行数据参数。

## 具体修改

### 1. ConsultationManagementViewModel.cs
修改了 4 个 DataGrid 行命令：
- ✅ ViewDetailsCommand
- ✅ ViewPrescriptionCommand
- ✅ PrintCommand
- ✅ CopyRecordCommand

**变更类型**：
- 命令属性：`ICommand` → `DelegateCommand<ConsultationDto>`
- 命令初始化：移除 `.ObservesProperty()` 模式，使用泛型参数验证
- 执行方法：从使用 `SelectedConsultation` 改为接收 `ConsultationDto` 参数

### 2. 其他管理视图验证
检查了其他管理视图，确认它们已正确使用泛型命令类型：
- ✅ FormulaManagementViewModel - `DelegateCommand<FormulaDto>`
- ✅ UserManagementViewModel - `DelegateCommand<UserDto>`
- ✅ HerbManagementViewModel - `DelegateCommand<HerbDto>`
- ✅ MedicalCaseListViewModel - `DelegateCommand<MedicalCaseDto>`

## 验收标准
- [x] 命令属性类型与 XAML `CommandParameter="{Binding}"` 模式匹配
- [x] 命令初始化使用泛型参数验证（`item => item != null`）
- [x] 执行方法接收并使用行数据参数
- [x] 编译通过（Desktop.sln Release 构建）
- [x] 无编译警告或错误

## 编译验证
```powershell
dotnet build LYBT.Desktop.sln -c Release --no-restore
```

**结果**：
```
已成功生成。
    0 个警告
    0 个错误
已用时间 00:00:20.36
```

## 代码审查清单
- [x] **Claude Code 初审**：已完成自检，符合项目标准
- [ ] **人工审核**：等待人工最终审核

## 影响范围
- **模块**：Desktop.Consultation
- **文件**：1 个（ConsultationManagementViewModel.cs）
- **行数**：+29 -37

## 测试建议
1. 运行 Desktop 应用
2. 导航到诊疗管理视图
3. 验证 DataGrid 行命令（查看详情、查看处方、打印、复制记录）能正常触发
4. 确认命令接收到正确的行数据

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>