### PR TITLE
fix(ci): 修复 Docs Normalization 模块名格式不匹配问题 - Issue #900

### DIFF
--- a/.github/workflows/docs-normalization.yml
+++ b/.github/workflows/docs-normalization.yml
@@ -47,8 +47,16 @@ jobs:
             pwsh -NoLogo -NoProfile -File scripts/ensure-module-readme-structure.ps1 -Root "src/Client/Desktop/Modules/$m"
           }
           # Fill API/Refs only for changed modules
-          $mods = @(); if ($server) { $mods += $server.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries) }; if ($client) { $mods += $client.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries) }
-          if ($mods.Count -gt 0) { pwsh -NoLogo -NoProfile -File scripts/fill-module-readme-api.ps1 -Modules $mods }
+          $mods = @()
+          if ($server) {
+            $mods += $server.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object { $_ -replace '^LYBT\.Module\.', '' }
+          }
+          if ($client) {
+            $mods += $client.Split(' ',[System.StringSplitOptions]::RemoveEmptyEntries)
+          }
+          if ($mods.Count -gt 0) {
+            pwsh -NoLogo -NoProfile -File scripts/fill-module-readme-api.ps1 -Root "." -Modules $mods
+          }
 
       - name: Check for changes
         id: diff


### PR DESCRIPTION
## 🎯 修复内容

修复 \ 中模块名格式不匹配导致的 \ 脚本执行失败。

---

## 📋 问题描述

**错误日志**：
\
**根本原因**：
1. Workflow 通过 AWK 提取变更模块名：2. 对于路径 \，提取结果为 **\**（完整格式）
3. \ 脚本期望接收**短模块名**（如 \）
4. 格式不匹配导致路径构造错误

---

## 🔧 修复方案

在传递给脚本前，将服务端模块名从 \ 转换为 \：

\
---

## ✅ 验收标准

- [x] Workflow 修改完成
- [ ] CI 检查通过（Docs Normalization）
- [ ] 脚本正确处理变更的服务端模块

---

## 🔍 Claude Code 初审

- [x] 符合 Issue #900 验收标准
- [x] 遵守 PowerShell 命令规范
- [x] 修改最小化（仅调整模块名转换逻辑）
- [x] 添加显式 \ 参数提高可读性

---

Fixes #900