### PR TITLE
[CI-1] 修复 CI 测试超时问题 - Issue #906

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -55,21 +55,24 @@ jobs:
           --no-build \
           --settings .runsettings \
           --logger "trx;LogFileName=users-tests.trx" \
-          --collect:"XPlat Code Coverage"
+          --collect:"XPlat Code Coverage" \
+          -- xUnit.ParallelizeTestCollections=false
           
         dotnet test tests/Backend/LYBT.Module.Patients.Tests/LYBT.Module.Patients.Tests.csproj \
           --configuration ${{ env.CONFIGURATION }} \
           --no-build \
           --settings .runsettings \
           --logger "trx;LogFileName=patients-tests.trx" \
-          --collect:"XPlat Code Coverage"
+          --collect:"XPlat Code Coverage" \
+          -- xUnit.ParallelizeTestCollections=false
           
         dotnet test tests/Backend/LYBT.Module.Herbs.Tests/LYBT.Module.Herbs.Tests.csproj \
           --configuration ${{ env.CONFIGURATION }} \
           --no-build \
           --settings .runsettings \
           --logger "trx;LogFileName=herbs-tests.trx" \
-          --collect:"XPlat Code Coverage"
+          --collect:"XPlat Code Coverage" \
+          -- xUnit.ParallelizeTestCollections=false
           
     - name: 生成测试报告
       uses: dorny/test-reporter@v1

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -111,7 +111,7 @@ jobs:
           --logger "trx;LogFileName=unit-test-results.trx" \
           --logger "html;LogFileName=unit-test-results.html" \
           --collect:"XPlat Code Coverage" \
-          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover xUnit.ParallelizeTestCollections=false
 
     - name: 🧪 运行集成测试
       run: |
@@ -121,7 +121,8 @@ jobs:
           --verbosity normal \
           --settings .runsettings \
           --logger "trx;LogFileName=integration-test-results.trx" \
-          --logger "html;LogFileName=integration-test-results.html"
+          --logger "html;LogFileName=integration-test-results.html" \
+          -- xUnit.ParallelizeTestCollections=false
       if: matrix.configuration == 'Release'
 
     - name: 📊 上传测试结果

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,42 +66,50 @@ jobs:
         echo "运行Users模块测试..."
         dotnet test tests/UnitTests/Modules/Users.UnitTests/LYBT.Module.Users.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行Patients模块测试..."
         dotnet test tests/UnitTests/Modules/Patients.UnitTests/LYBT.Module.Patients.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行Prescriptions模块测试..."
         dotnet test tests/UnitTests/Modules/Prescriptions.UnitTests/LYBT.Module.Prescriptions.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行Consultation模块测试..."
         dotnet test tests/UnitTests/Modules/Consultation.UnitTests/LYBT.Module.Consultation.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行Herbs模块测试..."
         dotnet test tests/UnitTests/Modules/Herbs.UnitTests/LYBT.Module.Herbs.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行Formula模块测试..."
         dotnet test tests/UnitTests/Modules/Formula.UnitTests/LYBT.Module.Formula.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行MedicalCase模块测试..."
         dotnet test tests/UnitTests/Modules/MedicalCase.UnitTests/LYBT.Module.MedicalCase.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
         
         echo "运行Auth模块测试..."
         dotnet test tests/UnitTests/Modules/Auth.UnitTests/LYBT.Module.Auth.Tests.csproj `
           --configuration Release --no-build --verbosity minimal `
-          --settings .runsettings
+          --settings .runsettings `
+          -- xUnit.ParallelizeTestCollections=false
 
     # 强制门禁：架构测试必须全部通过  
     - name: 🚨 强制门禁 - 架构合规测试

--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -60,7 +60,8 @@ jobs:
           --logger "trx;LogFileName=TestResults.trx" \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover \
           -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByFile="**/Migrations/**" \
-          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute"
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute="Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute" \
+          -- xUnit.ParallelizeTestCollections=false
 
     - name: 📊 生成覆盖率报告
       run: |

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -54,7 +54,8 @@ jobs:
           --collect:"XPlat Code Coverage" \
           --logger "trx;LogFileName=users-test-results.trx" \
           --logger "console;verbosity=detailed" \
-          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura || true
+          -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
+          -- xUnit.ParallelizeTestCollections=false || true
     
     - name: 🔧 安装 ReportGenerator
       run: dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,8 @@ jobs:
           --settings .runsettings `
           --logger "trx;LogFileName=$projectName.trx" `
           --logger "html;LogFileName=$projectName.html" `
-          --collect:"XPlat Code Coverage"
+          --collect:"XPlat Code Coverage" `
+          -- xUnit.ParallelizeTestCollections=false
 
     - name: 上传测试结果
       uses: actions/upload-artifact@v4
@@ -127,6 +128,7 @@ jobs:
           --verbosity normal `
           --settings .runsettings `
           --logger "trx;LogFileName=integration-tests.trx" `
+          -- xUnit.ParallelizeTestCollections=false `
           
 
     - name: 运行 Python API 测试


### PR DESCRIPTION
## 概述

[CI-1] 通过禁用 CI 环境中的测试并行化，解决测试超时问题。

## 功能清单

- [x] [CI-1] 在 ci.yml 中禁用测试并行化（8个模块测试）
- [x] [CI-2] 在 test.yml 中禁用测试并行化（单元测试矩阵 + 集成测试）
- [x] [CI-3] 在 backend-ci.yml 中禁用测试并行化（3个模块测试）
- [x] [CI-4] 在 ci-backend.yml 中禁用测试并行化（单元测试 + 集成测试）
- [x] [CI-5] 在 coverage-check.yml 中禁用测试并行化
- [x] [CI-6] 在 test-coverage.yml 中禁用测试并行化

## 问题描述

在 CI 环境中，多个测试模块出现超时问题（2分49秒 ~ 2分56秒超时）：
- Users.UnitTests - 2m49s 超时
- Herbs.UnitTests - 2m41s 超时
- Patients.UnitTests - 2m51s 超时
- WebAPI.IntegrationTests - 2m56s 超时

本地测试（167个测试）仅需6秒，而CI中同样的测试接近3分钟超时。

## 根本原因

`.runsettings` 配置了测试并行化：
```xml
<xUnit>
  <ParallelizeAssembly>false</ParallelizeAssembly>
  <ParallelizeTestCollections>true</ParallelizeTestCollections>
  <MaxParallelThreads>0</MaxParallelThreads>  <!-- 无限制 -->
</xUnit>
```

在 CI 环境的受限资源下（windows-latest runner），无限制的并行线程导致资源竞争和测试超时。

## 修复方案

在所有 `dotnet test` 命令中添加命令行参数，覆盖 `.runsettings` 的并行化设置：

```bash
dotnet test ... -- xUnit.ParallelizeTestCollections=false
```

这样：
- 保留 `.runsettings` 用于本地开发（并行化加速本地测试）
- CI 环境使用串行执行（避免资源竞争）

## 修改的文件

修改了6个 workflow 文件，共计影响多个测试命令：

1. **`.github/workflows/ci.yml`** - Level 2测试门禁（8个模块测试）
2. **`.github/workflows/test.yml`** - 单元测试矩阵 + 集成测试
3. **`.github/workflows/backend-ci.yml`** - 后端CI（3个模块测试）
4. **`.github/workflows/ci-backend.yml`** - UltraThink后端CI（单元测试 + 集成测试）
5. **`.github/workflows/coverage-check.yml`** - 覆盖率检查workflow
6. **`.github/workflows/test-coverage.yml`** - P3覆盖率门禁

## 验收结果

### 本地验证
```powershell
# Users模块测试（禁用并行化）
dotnet test tests/UnitTests/Modules/Users.UnitTests/LYBT.Module.Users.Tests.csproj   --configuration Release --verbosity minimal   --settings .runsettings   -- xUnit.ParallelizeTestCollections=false

# 结果
✅ 167 tests passed in 6 seconds
```

### CI 验证（预期）
- 测试执行时间: 约2分30秒（不再超时于3分钟）
- 测试状态: 从 "CANCELLED" 变为正常完成或 "FAILURE"（如有实际测试失败）

## 已知问题

修复超时后暴露了 Herbs 模块的 AutoMapper 测试失败（5个测试）：
- `Map_HerbUpdateDto_To_Herb_Should_Success`
- `Map_HerbCreateDto_With_CompleteData_Should_Success`
- `MappingConfiguration_Should_BeValid`
- `Map_HerbCreateDto_To_Herb_Should_Success`
- `Map_HerbImportDto_To_Herb_Should_Success`

此问题已在 Issue #907 中追踪，与 Issue #862（Patients模块Age类型问题）类似。

## 技术说明

- 命令行参数 `-- xUnit.ParallelizeTestCollections=false` 会覆盖 `.runsettings` 中的设置
- 不需要修改 `.runsettings` 文件本身，保持本地开发体验
- 仅影响 CI 环境的测试执行方式

## 影响范围

- **变更文件**: 6个 workflow 文件
- **受影响**: CI 测试执行方式
- **生产代码**: 无变更
- **本地开发**: 无影响（仍可使用 `.runsettings` 的并行化配置）

## 相关 Issue/PR

- Fixes #906
- Related: #907 (Herbs模块AutoMapper测试失败，修复超时后暴露)
- Similar to: #862 (Patients模块Age类型问题，已修复)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>