### PR TITLE
fix(ci): 修复 validate-and-track 工作流平台兼容性 [CI-862]

### DIFF
--- a/.github/workflows/validate-and-track.yml
+++ b/.github/workflows/validate-and-track.yml
@@ -7,10 +7,18 @@ on:
     types: [closed]
 
 jobs:
-  validate:
+  build:
     if: github.event_name == 'pull_request'
     runs-on: windows-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore LYBT.Server.sln
+      - name: Build (Release)
+        run: dotnet build LYBT.Server.sln -c Release --no-restore
       - name: Check PR references feature IDs
         shell: bash
         run: |


### PR DESCRIPTION
## 概述
修复 validate-and-track.yml 工作流的平台兼容性问题

## 问题
- validate job 使用 Windows runner 但缺少构建步骤
- 缺少对 LYBT.Server.sln 的构建验证

## 改动
✅ 重命名 job 为 `build` 以更准确反映职责
✅ 添加 .NET restore 和 build 步骤
✅ 使用 `LYBT.Server.sln`(包含跨平台项目 + ArchTests)
✅ 保持 Windows runner 配置

## 验证
- [x] 本地编译通过
- [ ] CI 工作流通过

## 相关 Issue
Related: #913, #914
Fixes #862