### PR TITLE
fix(tests): 删除 AuthServiceTests 中重复的 Dispose 方法

### DIFF
--- a/tests/UnitTests/Modules/Auth.UnitTests/Services/AuthServiceTests.cs
+++ b/tests/UnitTests/Modules/Auth.UnitTests/Services/AuthServiceTests.cs
@@ -573,10 +573,5 @@ public class AuthServiceTests : IDisposable
         result.Message.Should().Contain("令牌无效");
     }
 
-    public void Dispose()
-    {
-        throw new NotImplementedException();
-    }
-
     #endregion
 }


### PR DESCRIPTION
## 概述
修复 AuthServiceTests.cs 中的编译错误

## 问题
- AuthServiceTests 类定义了两个 Dispose 方法(第 519 行和第 576 行)
- 导致编译错误: **CS0111: Type 'AuthServiceTests' already defines a member called 'Dispose' with the same parameter types**

## 改动
✅ 删除第 576 行的重复 Dispose 方法(抛出 NotImplementedException)
✅ 保留第 519 行有完整实现的 Dispose 方法

## 验证
- [x] 本地编译通过(0 警告, 0 错误)
- [ ] CI 工作流通过

## 相关 Issue
Fixes #862