### PR TITLE
fix(desktop): 修复 HerbManagementViewModel 中的 CS8618 可空引用警告 [CLI-917]

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbManagementViewModel.cs
@@ -259,32 +259,32 @@ namespace LYBT.Desktop.Herbs.ViewModels
         /// <summary>
         /// 切换状态命令
         /// </summary>
-        public DelegateCommand<HerbDto> ToggleStatusCommand { get; private set; }
+        public DelegateCommand<HerbDto> ToggleStatusCommand { get; private set; } = null!;
 
         /// <summary>
         /// 导入药材命令
         /// </summary>
-        public DelegateCommand ImportHerbsCommand { get; private set; }
+        public DelegateCommand ImportHerbsCommand { get; private set; } = null!;
 
         /// <summary>
         /// 导出模板命令
         /// </summary>
-        public DelegateCommand ExportTemplateCommand { get; private set; }
+        public DelegateCommand ExportTemplateCommand { get; private set; } = null!;
 
         /// <summary>
         /// 导出药材命令
         /// </summary>
-        public DelegateCommand ExportHerbsCommand { get; private set; }
+        public DelegateCommand ExportHerbsCommand { get; private set; } = null!;
 
         /// <summary>
         /// 首页命令
         /// </summary>
-        public DelegateCommand FirstPageCommand { get; private set; }
+        public DelegateCommand FirstPageCommand { get; private set; } = null!;
 
         /// <summary>
         /// 末页命令
         /// </summary>
-        public DelegateCommand LastPageCommand { get; private set; }
+        public DelegateCommand LastPageCommand { get; private set; } = null!;
 
         #endregion
 


### PR DESCRIPTION
## 变更摘要
修复 HerbManagementViewModel 中的 6 个 CS8618 可空引用警告。

为以下命令属性添加 `= null!` 初始化器：
- ToggleStatusCommand
- ImportHerbsCommand
- ExportTemplateCommand
- ExportHerbsCommand
- FirstPageCommand
- LastPageCommand

这些属性在构造函数调用的 `InitializeCustomCommands()` 方法中初始化，但 C# 编译器的流分析无法检测到这种初始化模式。使用空容许运算符是处理这种情况的标准做法。

## 引用功能清单编号（必须）
Fixes #917 [CLI-917]

## 编译验证（必填）
```bash
dotnet build LYBT.All.sln -c Release --no-restore
```

**编译结果：**
```
已成功生成。
    0 个警告
    0 个错误

已用时间 00:00:14.88
```

## 验收验证（按 AC）
- 步骤：
  1. 为所有 6 个命令属性添加 `= null!` 初始化器 ✅
  2. 编译 `LYBT.Desktop.Herbs.csproj` 零警告零错误 ✅
  3. 编译 `LYBT.All.sln -c Release` 成功 ✅

- 结果：所有验收条件满足

## 影响范围
- 代码：仅修改 `HerbManagementViewModel.cs` 文件中 6 个属性声明的初始化器
- 配置：无
- 脚本：无
- 文档：无（代码质量修复，不影响功能）

## 风险与回滚
- 风险：无。仅添加编译器提示，不改变运行时行为
- 回滚方案：还原提交 `3932bef3`
