### PR TITLE
fix(ci): 修复 claude-code-review 工作流 - 使用 ubuntu runner [CI-919]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,8 +17,8 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
-    runs-on: windows-latest
+
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## 变更摘要
修复 Claude Code Review 工作流的 runner 配置，从 `windows-latest` 改为 `ubuntu-latest`。

Claude Code Action (`anthropics/claude-code-action@beta`) 不支持 Windows runner，导致所有 PR 的 claude-review 检查失败并显示 "Windows is not supported" 错误。

## 引用功能清单编号（必须）
Fixes #919 [CI-919]

## 编译验证（必填）
此修改仅涉及 CI 配置文件，无需编译验证。

## 验收验证（按 AC）
- 步骤：
  1. 修改 `.github/workflows/claude-code-review.yml` 的 `runs-on` 为 `ubuntu-latest` ✅
  2. 等待本 PR 的 claude-review 检查运行
  3. 确认 claude-review 检查成功运行并能添加审查评论

- 结果：待 CI 运行完成后验证

## 影响范围
- 代码：无
- 配置：`.github/workflows/claude-code-review.yml` - 修改第 21 行
- 脚本：无
- 文档：无

## 风险与回滚
- 风险：极低。仅改变 CI runner 平台，不影响代码逻辑
- 回滚方案：还原提交 `f59da775`

## 技术细节

**修改前：**
```yaml
runs-on: windows-latest  # ❌ 不支持
```

**修改后：**
```yaml
runs-on: ubuntu-latest   # ✅ 支持
```

这将使所有后续 PR 都能正常运行 Claude Code Review 自动化审查功能。
