### PR TITLE
fix(desktop): 添加 UTF-8 BOM 到 5 个 ViewModel 文件 - Issue #925

### DIFF
--- a/scripts/add-utf8-bom-to-cs-files.ps1
+++ b/scripts/add-utf8-bom-to-cs-files.ps1
@@ -1,0 +1,27 @@
+﻿# 添加 UTF-8 BOM 到指定的 C# 文件
+# Issue #925: 修复 5 个 Desktop ViewModel 文件缺少 UTF-8 BOM
+
+$files = @(
+    "src/Client/Desktop/Shell/Dialogs/ViewModels/ConfirmationDialogViewModel.cs",
+    "src/Client/Desktop/Shell/Dialogs/ViewModels/InformationDialogViewModel.cs",
+    "src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginWindowViewModel.cs",
+    "src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionViewModel.cs",
+    "src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserDetailViewModel.cs"
+)
+
+$utf8Bom = New-Object System.Text.UTF8Encoding $true
+$processedCount = 0
+
+foreach ($file in $files) {
+    if (Test-Path $file) {
+        Write-Host "处理文件: $file" -ForegroundColor Cyan
+        $content = Get-Content $file -Raw
+        [System.IO.File]::WriteAllText($file, $content, $utf8Bom)
+        $processedCount++
+        Write-Host "  ✓ 已添加 UTF-8 BOM" -ForegroundColor Green
+    } else {
+        Write-Host "  ✗ 文件不存在: $file" -ForegroundColor Red
+    }
+}
+
+Write-Host "`n完成! 已处理 $processedCount 个文件" -ForegroundColor Green

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginWindowViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginWindowViewModel.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Mvvm;
 

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionViewModel.cs
@@ -1,4 +1,4 @@
-using LYBT.Desktop.Models.ViewModels.Base;
+﻿using LYBT.Desktop.Models.ViewModels.Base;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserDetailViewModel.cs
@@ -1,4 +1,4 @@
-using LYBT.Desktop.Models.ViewModels.Base;
+﻿using LYBT.Desktop.Models.ViewModels.Base;
 using LYBT.Shared.Models.Contracts.Users;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Shell/Dialogs/ViewModels/ConfirmationDialogViewModel.cs
+++ b/src/Client/Desktop/Shell/Dialogs/ViewModels/ConfirmationDialogViewModel.cs
@@ -1,4 +1,4 @@
-using LYBT.Desktop.Models.ViewModels.Base;
+﻿using LYBT.Desktop.Models.ViewModels.Base;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;

--- a/src/Client/Desktop/Shell/Dialogs/ViewModels/InformationDialogViewModel.cs
+++ b/src/Client/Desktop/Shell/Dialogs/ViewModels/InformationDialogViewModel.cs
@@ -1,4 +1,4 @@
-using LYBT.Desktop.Models.ViewModels.Base;
+﻿using LYBT.Desktop.Models.ViewModels.Base;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;


### PR DESCRIPTION
## 📋 问题描述

修复 PR #923 合并后 master 分支 CI 失败问题：5 个 Desktop ViewModel C# 文件缺少 UTF-8 BOM，导致 `dotnet format --verify-no-changes` 检查失败。

## 🐛 错误信息

```
error CHARSET: Fix file encoding.
```

## 📝 修复内容

### 修复的文件（5个）

1. `src/Client/Desktop/Shell/Dialogs/ViewModels/ConfirmationDialogViewModel.cs`
2. `src/Client/Desktop/Shell/Dialogs/ViewModels/InformationDialogViewModel.cs`
3. `src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginWindowViewModel.cs`
4. `src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionViewModel.cs`
5. `src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserDetailViewModel.cs`

### 新增工具

- `scripts/add-utf8-bom-to-cs-files.ps1` - 自动化添加 UTF-8 BOM 的脚本

## ✅ 验收标准

- [x] 所有 5 个文件添加 UTF-8 BOM (EF BB BF)
- [x] 提交包含修复脚本
- [ ] CI `Pass 7 治理基线强制门禁` 通过
- [ ] `dotnet format LYBT.All.sln --verify-no-changes` 通过

## 🔗 相关

- Fixes #925
- 相关 PR: #923（修复了类似的 Markdown 文件编码问题）
- 失败的 CI Run: https://github.com/shouqitao/LYBTZYZS/actions/runs/18242251708

## 📊 影响范围

**优先级**: P0（阻塞 master 分支 CI）
**模块**: Desktop - ViewModels
**风险**: 低（仅编码格式修复，不影响逻辑）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>