### PR TITLE
[CI-2] 修复 WebAPI 集成测试 AppDbContext DI 问题 - Issue #924

### DIFF
--- a/tests/IntegrationTests/WebAPI.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/tests/IntegrationTests/WebAPI.IntegrationTests/CustomWebApplicationFactory.cs
@@ -25,20 +25,27 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
 
         builder.ConfigureServices(services =>
         {
-            // 移除现有的 DbContext 配置
-            var descriptor = services.SingleOrDefault(
-                d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+            // 移除所有与 AppDbContext 相关的服务描述符
+            var descriptorsToRemove = services
+                .Where(d => d.ServiceType == typeof(DbContextOptions<AppDbContext>) ||
+                           d.ServiceType == typeof(AppDbContext) ||
+                           d.ServiceType == typeof(DbContextOptions) ||
+                           (d.ServiceType.IsGenericType && 
+                            d.ServiceType.GetGenericTypeDefinition() == typeof(DbContextOptions<>)))
+                .ToList();
 
-            if (descriptor != null)
+            foreach (var descriptor in descriptorsToRemove)
             {
                 services.Remove(descriptor);
             }
 
-            // 添加内存数据库
+            // 添加内存数据库 - 使用唯一的数据库名称
+            var databaseName = $"TestDatabase_{Guid.NewGuid()}";
             services.AddDbContext<AppDbContext>(options =>
             {
-                options.UseInMemoryDatabase("TestDatabase");
+                options.UseInMemoryDatabase(databaseName);
                 options.EnableSensitiveDataLogging();
+                options.EnableDetailedErrors();
             });
 
             // 确保数据库已创建


### PR DESCRIPTION
## 问题

WebAPI 集成测试失败，错误信息：
```
Unable to resolve service for type 'LYBT.Core.Infrastructure.Data.AppDbContext' 
while attempting to activate 'LYBT.WebAPI.Controllers.HealthController'.
```

## 根本原因

CustomWebApplicationFactory 未能正确覆盖 Program.cs 中注册的 AppDbContext 服务。Program.cs 使用 UseSqlServer 注册 DbContext，而测试环境需要使用 UseInMemoryDatabase。

## 解决方案

1. **彻底移除所有 DbContextOptions 相关的服务描述符**
   - `DbContextOptions<AppDbContext>`
   - `AppDbContext`
   - `DbContextOptions`
   - 所有泛型 `DbContextOptions<>` 实例

2. **重新注册 InMemory 数据库**
   - 使用 `UseInMemoryDatabase` 替代 `UseSqlServer`
   - 为每个测试实例生成唯一的数据库名称（避免并发冲突）
   - 启用 SensitiveDataLogging 和 DetailedErrors 便于调试

3. **确保数据库初始化**
   - 在配置服务后立即调用 `EnsureCreated()`

## 测试验证

将通过 CI 运行所有集成测试进行验证。

## 关联 Issue

Closes #924

---

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>