### PR TITLE
[CI-7] 修复架构测试 runsettings 文件名错误 - Issue #943

### DIFF
--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -22,7 +22,7 @@
     <RunParallel>true</RunParallel>
 
     <!-- 测试运行设置文件 -->
-    <RunSettingsFilePath>$(MSBuildThisFileDirectory)..\runsettings</RunSettingsFilePath>
+    <RunSettingsFilePath>$(MSBuildThisFileDirectory)..\.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <!-- 测试框架包版本管理 -->


### PR DESCRIPTION
## 📋 问题描述

架构合规测试在 CI 环境中失败，错误信息：
```
The Settings file 'D:\a\LYBTZYZS\LYBTZYZS\tests\..\runsettings' could not be found.
```

## 🔍 根本原因

**tests/Directory.Build.props 第 25 行** 配置的文件名与实际文件名不匹配：
- 配置的文件名: `runsettings`（不带前导点）
- 实际文件名: `.runsettings`（带前导点）

文件名不匹配导致架构测试无法找到配置文件。

## ✅ 解决方案

修改 `tests/Directory.Build.props` 第 25 行：

```xml
<!-- 修改前 -->
<RunSettingsFilePath>$(MSBuildThisFileDirectory)..\runsettings</RunSettingsFilePath>

<!-- 修改后 -->
<RunSettingsFilePath>$(MSBuildThisFileDirectory)..\.runsettings</RunSettingsFilePath>
```

## 📝 实施内容

### [CI-7-1] 修正配置文件路径
- **文件**: `tests/Directory.Build.props` (L25)
- **修改**: 添加前导点 `.` 到文件名
- **影响**: 所有测试项目（通过 Directory.Build.props 继承）

## 🔬 验证结果

- ✅ **编译验证**: `dotnet build tests/Architecture/LYBT.ArchTests.csproj -c Release --no-restore`
  ```
  已成功生成。
      0 个警告
      0 个错误

  已用时间 00:00:07.97
  ```

- ✅ **文件名一致性**: 配置指向的文件名现在与实际文件名 `.runsettings` 匹配

## 📌 验收标准

- ✅ 架构测试项目编译通过（0 警告，0 错误）
- ✅ RunSettingsFilePath 配置正确指向 `.runsettings`
- ✅ 配置文件语法正确

## 🔗 关联 Issue

Closes #943

## 📦 变更文件

- `tests/Directory.Build.props` (L25) - 修正文件名从 `runsettings` 到 `.runsettings`

## 审查清单

- [x] **Claude Code 初审**: 已自审
- [ ] **人工审核**: 待审核
- [x] **编译通过**: Release 配置编译成功
- [x] **配置正确**: 文件名匹配实际文件

## 📋 后续影响

此修复将解除以下 PR 的阻塞：
- PR #941
- PR #937

## 💡 说明

此问题是一个简单的配置错误（文件名拼写），但影响了所有架构测试的运行。修复后，CI 应该能够正确加载 `.runsettings` 文件，并执行所有架构合规检查：
- 治理规则验证
- 层间依赖检查
- API 版本合规检查
- 控制器位置检查
- 命名规范检查
- 禁止框架检查
- Record-Only 功能模式检查

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>