### PR TITLE
[CLEANUP-1] 清理 AppDbContext.cs 多余空行和注释 - Issue #948

### DIFF
--- a/src/Server/Core/LYBT.Infrastructure/Data/AppDbContext.cs
+++ b/src/Server/Core/LYBT.Infrastructure/Data/AppDbContext.cs
@@ -43,10 +43,7 @@ namespace LYBT.Infrastructure.Data
         public DbSet<AuthSession> AuthSessions { get; set; }
         public DbSet<RefreshToken> RefreshTokens { get; set; }
 
-
-        // public DbSet<LoginAttempt> LoginAttempts { get; set; } // UltraThink简化：暂时移除
-        // public DbSet<SecurityLog> SecurityLogs { get; set; } // UltraThink简化：暂时移除
-
+        // UltraThink简化：LoginAttempts、SecurityLogs 已移除
         // 安全审计 - UltraThink重构安全架构 (已移除过度设计的SecurityAuditLog)
 
         // JWT令牌存储 - UltraThink安全优化 P8-01B (已移除过度设计的令牌实体存储)
@@ -442,25 +439,7 @@ namespace LYBT.Infrastructure.Data
         }
 
         // ConfigureCompatibilityNotes方法已删除 - HerbCompatibilityNote实体不再存在
-
         // UltraThink简化：ConfigureTransactions方法已删除（对应实体已清理）
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
         // Sync模块MVP阶段暂不需要
 
         /// <summary>


### PR DESCRIPTION
## 📋 变更概述

本 PR 实施 Issue #948 **阶段 1（低风险清理）** 的第一步：清理 AppDbContext.cs 中的多余空行和冗余注释。

---

## 🔍 清理内容

### 1. 移除多余空行

**位置**: `src/Server/Core/LYBT.Infrastructure/Data/AppDbContext.cs`

**改动前**（行 441-457）:
```csharp
        // ConfigureCompatibilityNotes方法已删除 - HerbCompatibilityNote实体不再存在

        // UltraThink简化：ConfigureTransactions方法已删除（对应实体已清理）




        // （共 18+ 行空行）



        // Sync模块MVP阶段暂不需要
```

**改动后**（行 441-443）:
```csharp
        // ConfigureCompatibilityNotes方法已删除 - HerbCompatibilityNote实体不再存在
        // UltraThink简化：ConfigureTransactions方法已删除（对应实体已清理）
        // Sync模块MVP阶段暂不需要
```

### 2. 简化冗余注释

**改动前**（行 46-51）:
```csharp
        public DbSet<AuthSession> AuthSessions { get; set; }
        public DbSet<RefreshToken> RefreshTokens { get; set; }


        // public DbSet<LoginAttempt> LoginAttempts { get; set; } // UltraThink简化：暂时移除
        // public DbSet<SecurityLog> SecurityLogs { get; set; } // UltraThink简化：暂时移除

        // 安全审计 - UltraThink重构安全架构 (已移除过度设计的SecurityAuditLog)
```

**改动后**（行 43-47）:
```csharp
        public DbSet<AuthSession> AuthSessions { get; set; }
        public DbSet<RefreshToken> RefreshTokens { get; set; }

        // UltraThink简化：LoginAttempts、SecurityLogs 已移除
        // 安全审计 - UltraThink重构安全架构 (已移除过度设计的SecurityAuditLog)
```

---

## 📊 统计

- **删除行数**: 22 行（空行 + 注释）
- **新增行数**: 1 行
- **净减少**: 21 行
- **文件数量**: 1 个

---

## ✅ 验收标准

### 编译验证
```bash
dotnet build LYBT.All.sln -c Release --no-restore
```
**结果**: ✅ 编译通过（0 警告，0 错误）

### 代码质量
- ✅ 代码逻辑无变化
- ✅ 移除多余空白，提升可读性
- ✅ 符合 Issue #948 阶段 1 低风险清理原则

---

## 🎯 与 Issue #948 的关系

本 PR 是 Issue #948 **阶段 1：低风险清理** 的一部分：

- ✅ 移除多余空行
- ✅ 简化冗余注释
- ⏳ 后续阶段：清理更多注释代码、TODO 注释等

**阶段 1 目标**: 移除代码行数 ≥ 500 行  
**当前进度**: 21 行（4.2%）

---

## 🔗 关联资源

- **Issue**: #948
- **分支**: `cleanup/issue-948-phase1-dead-code`
- **相关文件**: `src/Server/Core/LYBT.Infrastructure/Data/AppDbContext.cs`

---

## 🚀 后续计划

1. 继续清理其他文件中的注释代码
2. 移除已完成的 TODO 注释
3. 清理空的接口/类/方法定义

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>