### PR TITLE
[CLEANUP] 移除 ServiceCollectionExtensions 中 5 个空 Layer 方法 - Issue #948

### DIFF
--- a/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
@@ -255,63 +255,11 @@ namespace LYBT.Desktop.Shell.Extensions
 
         /// <summary>
         /// DT-003优化: 分层模块服务注册 - 按依赖层级防止循环依�?
-        /// 基于依赖分析结果�?层注册策略，确保服务解析顺序正确
+        /// 注：Layer 1-5 方法已移除（均为空实现）
         /// </summary>
         private static void RegisterModuleServicesManually(IContainerRegistry containerRegistry)
         {
-            // Layer 1: 基础�?- 无外部依赖的基础模块（优先注册）
-            RegisterLayer1BasicModules(containerRegistry);
-
-            // Layer 2: 认证�?- 依赖基础�?
-            RegisterLayer2AuthModules(containerRegistry);
-
-            // Layer 3: 业务数据�?- 依赖认证�?
-            RegisterLayer3BusinessDataModules(containerRegistry);
-
-            // Layer 4: 流程协调�?- 依赖业务数据�?
-            RegisterLayer4ProcessModules(containerRegistry);
-
-            // Layer 5: 聚合服务�?- 依赖流程协调�?
-            RegisterLayer5AggregationModules(containerRegistry);
-        }
-
-        /// <summary>
-        /// Layer 1: 基础模块注册 - Herbs, Formula (无外部依�?
-        /// 性能优化：改为Scoped注册，避免启动时立即实例�?
-        /// </summary>
-        private static void RegisterLayer1BasicModules(IContainerRegistry containerRegistry)
-        {
-        }
-
-        /// <summary>
-        /// Layer 2: 认证模块注册 - 依赖基础�?
-        /// </summary>
-        private static void RegisterLayer2AuthModules(IContainerRegistry containerRegistry)
-        {
-        }
-
-        /// <summary>
-        /// Layer 3: 业务数据模块注册 - 依赖认证�?
-        /// 性能优化：改为Scoped注册，避免启动时立即实例�?
-        /// </summary>
-        private static void RegisterLayer3BusinessDataModules(IContainerRegistry containerRegistry)
-        {
-        }
-
-        /// <summary>
-        /// Layer 4: 流程协调模块注册 - 依赖业务数据�?
-        /// 性能优化：改为Scoped注册，避免启动时立即实例�?
-        /// </summary>
-        private static void RegisterLayer4ProcessModules(IContainerRegistry containerRegistry)
-        {
-        }
-
-        /// <summary>
-        /// Layer 5: 聚合服务模块注册 - 依赖流程协调�?
-        /// 性能优化：改为Scoped注册，避免启动时立即实例�?
-        /// </summary>
-        private static void RegisterLayer5AggregationModules(IContainerRegistry containerRegistry)
-        {
+            // 当前所有模块服务通过各自的 Module 类注册，无需在此手动注册
         }
 
         /// <summary>


### PR DESCRIPTION
## 概述
本 PR 是 Issue #948 Phase 1 死代码清理的第 3 部分，移除 ServiceCollectionExtensions.cs 中 5 个空的 Layer 注册方法。

## 变更内容
移除以下空方法及其注释（共 54 行）:
- `RegisterLayer1BasicModules` (6 行)
- `RegisterLayer2AuthModules` (5 行)  
- `RegisterLayer3BusinessDataModules` (6 行)
- `RegisterLayer4ProcessModules` (6 行)
- `RegisterLayer5AggregationModules` (6 行)
- 简化 `RegisterModuleServicesManually` (删除 19 行调用代码)

## 清理进度
- 本次清理: **54 行**
- 累计清理: **80 行** (26+54)
- Phase 1 目标: 500 行
- 完成度: **16%**

## 影响分析
✅ **无功能影响**: 这些方法均为空实现，从未包含任何实际注册逻辑
✅ **架构保持**: 所有模块服务继续通过各自的 Module 类注册
✅ **编译验证**: 0 警告 0 错误

## 验收标准
- [x] ✅ 编译通过: `dotnet build LYBT.Desktop.Shell.csproj -c Release`
- [x] ✅ 0 个警告，0 个错误
- [x] ✅ 功能完整: 模块注册机制未受影响
- [x] ✅ 代码简洁: 移除无用的空方法骨架

## 自审清单
- [x] ✅ Claude Code 初审
- [ ] Serena 二审（可选）

## 关联 Issue
Closes #948 (部分完成)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>