### PR TITLE
[CLEANUP] 移除 MainWindow.xaml 误导性注释 - Issue #948

### DIFF
--- a/src/Client/Desktop/Shell/Views/MainWindow.xaml
+++ b/src/Client/Desktop/Shell/Views/MainWindow.xaml
@@ -11,7 +11,6 @@
         Background="White">
 
     <Window.Resources>
-        <!-- 转换器已在 UnifiedDesignSystem.xaml 全局定义 -->
         <local:ApiHealthStatusToColorConverter x:Key="ApiHealthStatusToColorConverter" xmlns:local="clr-namespace:LYBT.Desktop.Shell.Converters" />
         <local:ApiHealthStatusToTextConverter x:Key="ApiHealthStatusToTextConverter" xmlns:local="clr-namespace:LYBT.Desktop.Shell.Converters" />
     </Window.Resources>


### PR DESCRIPTION
## 概述
本 PR 是 Issue #948 Phase 1 死代码清理的第 6 部分，移除 MainWindow.xaml 中的误导性注释。

## 变更内容
删除 `Window.Resources` 中的错误注释：
```xml
<!-- 转换器已在 UnifiedDesignSystem.xaml 全局定义 -->
```

## 问题说明
- **注释内容错误**: 声称转换器在 UnifiedDesignSystem.xaml 中全局定义
- **实际情况**: `ApiHealthStatusToColorConverter` 和 `ApiHealthStatusToTextConverter` 实际在 MainWindow.xaml 本地定义
- **验证结果**: `grep ApiHealthStatus src/Client/Desktop/Resources/UnifiedDesignSystem.xaml` 无结果

## 清理进度
- 本次清理: **1 行**
- 累计清理: **106 行** (105+1)
- Phase 1 目标: 500 行
- 完成度: **21.2%**

## 影响分析
✅ **无功能影响**: 仅删除误导性注释，不影响转换器定义和使用
✅ **提高代码准确性**: 移除错误的文档说明
✅ **编译验证**: 0 警告 0 错误

## 验收标准
- [x] ✅ 编译通过: `dotnet build LYBT.Desktop.Shell.csproj -c Release`
- [x] ✅ 0 个警告，0 个错误
- [x] ✅ 功能完整: 转换器正常工作
- [x] ✅ 代码准确: 移除误导性文档

## 自审清单
- [x] ✅ Claude Code 初审
- [ ] Serena 二审（可选）

## 关联 Issue
Closes #948 (部分完成)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>