### PR TITLE
[CLEANUP] 清理注释代码 - Issue #948

### DIFF
--- a/src/Server/Core/LYBT.Infrastructure/Caching/Adapters/NullCacheService.cs
+++ b/src/Server/Core/LYBT.Infrastructure/Caching/Adapters/NullCacheService.cs
@@ -1,9 +1,4 @@
-﻿// using System; // Moved to GlobalUsings.cs
-// using System.Collections.Generic; // Moved to GlobalUsings.cs
-// using System.Linq; // Moved to GlobalUsings.cs
-// using System.Threading; // Moved to GlobalUsings.cs
-// using System.Threading.Tasks; // Moved to GlobalUsings.cs
-using LYBT.Infrastructure.Caching.Interfaces;
+﻿using LYBT.Infrastructure.Caching.Interfaces;
 using LYBT.Infrastructure.Caching.Models;
 
 namespace LYBT.Infrastructure.Caching.Adapters

--- a/src/Server/Modules/LYBT.Module.Consultation/ConsultationModule.cs
+++ b/src/Server/Modules/LYBT.Module.Consultation/ConsultationModule.cs
@@ -58,7 +58,7 @@ namespace LYBT.Module.Consultation
         /// </summary>
         public static IHealthChecksBuilder AddConsultationModuleHealthCheck(this IHealthChecksBuilder builder)
         {
-            // return builder.AddCheck<ConsultationModuleHealthCheck>("consultation_module");  // 待创建健康检查类
+            // TODO: 待创建健康检查类
             return builder;
         }
     }

--- a/src/Server/Services/LYBT.WebAPI/Extensions/UnifiedApplicationInitialization.cs
+++ b/src/Server/Services/LYBT.WebAPI/Extensions/UnifiedApplicationInitialization.cs
@@ -1,7 +1,4 @@
-﻿// using LYBT.Infrastructure.Configuration; // Removed - SimplifiedConfigurationService eliminated
-
-// using LYBT.WebAPI.Services; // Removed - enterprise services
-namespace LYBT.WebAPI.Extensions;
+﻿namespace LYBT.WebAPI.Extensions;
 
 /// <summary>
 /// 统一应用初始化管理 - UltraThink初始化系统

--- a/tests/TestConfiguration/AutoMapperTestConfiguration.cs
+++ b/tests/TestConfiguration/AutoMapperTestConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using AutoMapper;
-// using LYBT.Module.Auth.Mapping; // 已简化，Auth模块不再使用AutoMapper
 using LYBT.Module.Consultation.Mapping;
 using LYBT.Module.Formula.Mapping;
 using LYBT.Module.Herbs.Mapping;


### PR DESCRIPTION
## 📋 清理摘要

本PR清理了4个文件中的注释代码，共**9行**：

### 清理项
1. **NullCacheService.cs** - 移除5行注释的using语句 (已移至GlobalUsings.cs)
2. **UnifiedApplicationInitialization.cs** - 移除3行注释using
3. **ConsultationModule.cs** - 简化健康检查注释
4. **AutoMapperTestConfiguration.cs** - 移除1行注释using

### ✅ 验证结果
```powershell
dotnet build LYBT.All.sln -c Release --no-restore
# 已成功生成
# 0 个警告
# 0 个错误
```

### 📊 Issue #948 进度
- **本次清理**: 9行
- **累计清理**: 205/500 行 (41%)
- **剩余目标**: 295行

### 🔗 关联
Relates to #948

### 🤖 审查清单
- [x] 仅清理确认无用的注释代码
- [x] 编译通过，0警告0错误
- [x] 遵循Issue #948清理标准