### PR TITLE
[FIX] 添加根路径健康检查端点 - Issue #973

### DIFF
--- a/src/Server/Services/LYBT.WebAPI/Controllers/RootHealthController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/RootHealthController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LYBT.WebAPI.Controllers;
+
+/// <summary>
+/// 根路径健康检查控制器 - 用于基础健康检查和外部监控
+/// 提供简单的 /health 端点，符合 Kubernetes/Docker 健康检查标准
+/// </summary>
+[ApiController]
+[Route("health")]
+public class RootHealthController : ControllerBase
+{
+    private static readonly DateTime _startupTime = DateTime.UtcNow;
+
+    /// <summary>
+    /// 基础健康检查端点
+    /// GET /health
+    /// </summary>
+    /// <returns>简单的健康状态响应</returns>
+    [HttpGet]
+    [AllowAnonymous]  // 允许匿名访问，便于外部监控工具
+    public IActionResult Get()
+    {
+        return Ok(new
+        {
+            status = "Healthy",
+            timestamp = DateTime.UtcNow,
+            uptime = (long)(DateTime.UtcNow - _startupTime).TotalSeconds
+        });
+    }
+
+    /// <summary>
+    /// Ping端点 - 最轻量级的存活性检查
+    /// GET /health/ping
+    /// </summary>
+    /// <returns>Pong响应</returns>
+    [HttpGet("ping")]
+    [AllowAnonymous]
+    public IActionResult Ping()
+    {
+        return Ok(new
+        {
+            message = "pong",
+            timestamp = DateTime.UtcNow
+        });
+    }
+}


### PR DESCRIPTION
## 📋 问题描述

Desktop 应用的 API 健康检查持续报告 HTTP 404 错误，虽然 API 实际可用。

**根本原因**:
- 客户端访问: `/health`
- 服务器端点: `/api/v1/health`
- URL 不匹配 → 404 错误

## 🔧 解决方案

新增 **RootHealthController**，提供根路径健康检查端点：

### 新增端点

1. **`GET /health`** - 基础健康检查
   - 匿名访问（`[AllowAnonymous]`）
   - 返回简单状态（status, timestamp, uptime）
   - 符合 Kubernetes/Docker 健康检查标准

2. **`GET /health/ping`** - 轻量级 ping 检查
   - 匿名访问
   - 最简响应（message, timestamp）

### 设计原则

- **职责分离**: 根路径简单检查 vs 版本化详细检查
- **向后兼容**: 保留现有 `/api/v1/health` 端点
- **行业标准**: 符合外部监控工具期望

## 📁 修改文件

```
+ src/Server/Services/LYBT.WebAPI/Controllers/RootHealthController.cs (48行)
```

## ✅ 验证

- [x] dotnet build LYBT.All.sln -c Release - 成功
- [x] 健康检查端点可匿名访问（已配置 AllowAnonymous）
- [ ] Desktop 应用状态显示"已连接"（需集成测试验证）
- [ ] 日志无 404 警告（需集成测试验证）

## 🔗 相关

Fixes #973

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)