### PR TITLE
fix: 修复测试代码中的 Nullability 编译警告

### DIFF
--- a/tests/UnitTests/Server/Modules/LYBT.Module.Patients.Tests/Services/PatientServiceTests.cs
+++ b/tests/UnitTests/Server/Modules/LYBT.Module.Patients.Tests/Services/PatientServiceTests.cs
@@ -74,10 +74,10 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Items.Should().HaveCount(5);
-            result.Data.TotalCount.Should().Be(5);
-            result.Data.CurrentPage.Should().Be(1);
-            result.Data.PageSize.Should().Be(20);
+            result.Data!.Items.Should().HaveCount(5);
+            result.Data!.TotalCount.Should().Be(5);
+            result.Data!.CurrentPage.Should().Be(1);
+            result.Data!.PageSize.Should().Be(20);
 
             _repositoryMock.Verify(x => x.GetPagedAsync(1, 20), Times.Once);
         }
@@ -103,9 +103,9 @@ namespace LYBT.Module.Patients.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("获取患者列表失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("获取患者列表失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -132,8 +132,8 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Items.Should().BeEmpty();
-            result.Data.TotalCount.Should().Be(0);
+            result.Data!.Items.Should().BeEmpty();
+            result.Data!.TotalCount.Should().Be(0);
         }
 
         #endregion
@@ -158,9 +158,9 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Id.Should().Be(patientId);
-            result.Data.Name.Should().Be(patient.Name);
-            result.Data.PhoneNumber.Should().Be(patient.PhoneNumber);
+            result.Data!.Id.Should().Be(patientId);
+            result.Data!.Name.Should().Be(patient.Name);
+            result.Data!.PhoneNumber.Should().Be(patient.PhoneNumber);
 
             _repositoryMock.Verify(x => x.GetByIdAsync(patientId), Times.Once);
         }
@@ -173,7 +173,7 @@ namespace LYBT.Module.Patients.Tests.Services
 
             _repositoryMock
                 .Setup(x => x.GetByIdAsync(patientId))
-                .ReturnsAsync((Patient)null);
+                .ReturnsAsync((Patient?)null);
 
             // Act
             var result = await _patientService.GetByIdAsync(patientId);
@@ -208,9 +208,9 @@ namespace LYBT.Module.Patients.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("获取患者详情失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("获取患者详情失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -259,9 +259,9 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Name.Should().Be(createDto.Name);
-            result.Data.PhoneNumber.Should().Be(createDto.PhoneNumber);
-            result.Data.IdNumber.Should().Be(createDto.IdNumber);
+            result.Data!.Name.Should().Be(createDto.Name);
+            result.Data!.PhoneNumber.Should().Be(createDto.PhoneNumber);
+            result.Data!.IdNumber.Should().Be(createDto.IdNumber);
 
             _repositoryMock.Verify(x => x.AddAsync(It.IsAny<Patient>()), Times.Once);
         }
@@ -295,9 +295,9 @@ namespace LYBT.Module.Patients.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("创建患者失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("创建患者失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -350,9 +350,9 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Id.Should().Be(patientId);
-            result.Data.Name.Should().Be(updateDto.Name);
-            result.Data.PhoneNumber.Should().Be(updateDto.PhoneNumber);
+            result.Data!.Id.Should().Be(patientId);
+            result.Data!.Name.Should().Be(updateDto.Name);
+            result.Data!.PhoneNumber.Should().Be(updateDto.PhoneNumber);
 
             _repositoryMock.Verify(x => x.GetByIdAsync(patientId), Times.Once);
             _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<Patient>()), Times.Once);
@@ -370,7 +370,7 @@ namespace LYBT.Module.Patients.Tests.Services
 
             _repositoryMock
                 .Setup(x => x.GetByIdAsync(patientId))
-                .ReturnsAsync((Patient)null);
+                .ReturnsAsync((Patient?)null);
 
             // Act
             var result = await _patientService.UpdateAsync(patientId, updateDto);
@@ -417,9 +417,9 @@ namespace LYBT.Module.Patients.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("更新患者失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("更新患者失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -448,8 +448,8 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Should().HaveCount(2);
-            result.Data.All(p => p.Name.Contains(keyword)).Should().BeTrue();
+            result.Data!.Should().HaveCount(2);
+            result.Data!.All(p => p.Name.Contains(keyword)).Should().BeTrue();
         }
 
         [Fact]
@@ -465,7 +465,7 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Should().BeEmpty();
+            result.Data!.Should().BeEmpty();
 
             _repositoryMock.Verify(x => x.GetAllAsync(), Times.Never);
         }
@@ -483,7 +483,7 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Should().BeEmpty();
+            result.Data!.Should().BeEmpty();
 
             _repositoryMock.Verify(x => x.GetAllAsync(), Times.Never);
         }
@@ -506,7 +506,7 @@ namespace LYBT.Module.Patients.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Should().BeEmpty();
+            result.Data!.Should().BeEmpty();
         }
 
         [Fact]
@@ -533,10 +533,10 @@ namespace LYBT.Module.Patients.Tests.Services
                     LogLevel.Error,
                     It.IsAny<EventId>(),
                     It.Is<It.IsAnyType>((v, t) => 
-                        v.ToString().Contains("搜索患者时发生错误") && 
-                        v.ToString().Contains(keyword)),
+                        v.ToString()!.Contains("搜索患者时发生错误") && 
+                        v.ToString()!.Contains(keyword)),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -606,9 +606,9 @@ namespace LYBT.Module.Patients.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("删除患者失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("删除患者失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 

--- a/tests/UnitTests/Server/Modules/LYBT.Module.Users.Tests/Services/UserServiceTests.cs
+++ b/tests/UnitTests/Server/Modules/LYBT.Module.Users.Tests/Services/UserServiceTests.cs
@@ -77,10 +77,10 @@ namespace LYBT.Module.Users.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Items.Should().HaveCount(5);
-            result.Data.TotalCount.Should().Be(5);
-            result.Data.CurrentPage.Should().Be(1);
-            result.Data.PageSize.Should().Be(20);
+            result.Data!.Items.Should().HaveCount(5);
+            result.Data!.TotalCount.Should().Be(5);
+            result.Data!.CurrentPage.Should().Be(1);
+            result.Data!.PageSize.Should().Be(20);
 
             _repositoryMock.Verify(x => x.GetPagedAsync(1, 20), Times.Once);
         }
@@ -106,9 +106,9 @@ namespace LYBT.Module.Users.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("获取用户列表失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("获取用户列表失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -135,8 +135,8 @@ namespace LYBT.Module.Users.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Items.Should().BeEmpty();
-            result.Data.TotalCount.Should().Be(0);
+            result.Data!.Items.Should().BeEmpty();
+            result.Data!.TotalCount.Should().Be(0);
         }
 
         #endregion
@@ -161,9 +161,9 @@ namespace LYBT.Module.Users.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Id.Should().Be(userId);
-            result.Data.UserName.Should().Be(user.UserName);
-            result.Data.RealName.Should().Be(user.RealName);
+            result.Data!.Id.Should().Be(userId);
+            result.Data!.UserName.Should().Be(user.UserName);
+            result.Data!.RealName.Should().Be(user.RealName);
 
             _repositoryMock.Verify(x => x.GetByIdAsync(userId), Times.Once);
         }
@@ -176,7 +176,7 @@ namespace LYBT.Module.Users.Tests.Services
 
             _repositoryMock
                 .Setup(x => x.GetByIdAsync(userId))
-                .ReturnsAsync((User)null);
+                .ReturnsAsync((User?)null);
 
             // Act
             var result = await _userService.GetByIdAsync(userId);
@@ -211,9 +211,9 @@ namespace LYBT.Module.Users.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("获取用户详情失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("获取用户详情失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -257,9 +257,9 @@ namespace LYBT.Module.Users.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.UserName.Should().Be(createDto.Username);
-            result.Data.RealName.Should().Be(createDto.RealName);
-            result.Data.Email.Should().Be(createDto.Email);
+            result.Data!.UserName.Should().Be(createDto.Username);
+            result.Data!.RealName.Should().Be(createDto.RealName);
+            result.Data!.Email.Should().Be(createDto.Email);
 
             _repositoryMock.Verify(x => x.AddAsync(It.IsAny<User>()), Times.Once);
         }
@@ -293,9 +293,9 @@ namespace LYBT.Module.Users.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("创建用户失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("创建用户失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -344,9 +344,9 @@ namespace LYBT.Module.Users.Tests.Services
             result.Should().NotBeNull();
             result.IsSuccess.Should().BeTrue();
             result.Data.Should().NotBeNull();
-            result.Data.Id.Should().Be(userId);
-            result.Data.RealName.Should().Be(updateDto.RealName);
-            result.Data.Email.Should().Be(updateDto.Email);
+            result.Data!.Id.Should().Be(userId);
+            result.Data!.RealName.Should().Be(updateDto.RealName);
+            result.Data!.Email.Should().Be(updateDto.Email);
 
             _repositoryMock.Verify(x => x.GetByIdAsync(userId), Times.Once);
             _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<User>()), Times.Once);
@@ -364,7 +364,7 @@ namespace LYBT.Module.Users.Tests.Services
 
             _repositoryMock
                 .Setup(x => x.GetByIdAsync(userId))
-                .ReturnsAsync((User)null);
+                .ReturnsAsync((User?)null);
 
             // Act
             var result = await _userService.UpdateAsync(userId, updateDto);
@@ -411,9 +411,9 @@ namespace LYBT.Module.Users.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("更新用户失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("更新用户失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 
@@ -483,9 +483,9 @@ namespace LYBT.Module.Users.Tests.Services
                 x => x.Log(
                     LogLevel.Error,
                     It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("删除用户失败")),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("删除用户失败")),
                     exception,
-                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
 


### PR DESCRIPTION
## 概述
修复 Issue #1029 中的 nullability 编译警告，通过代码修复而非警告压制。

## 修改内容
### UserServiceTests.cs (24 处警告)
- 在 `result.Data.Should().NotBeNull()` 断言后添加 `!` 操作符
- 将 Mock 的 `(User)null` 改为 `(User?)null`
- 将 Logger 验证中的 `Exception` 改为 `Exception?`
- 在 Lambda 中的 `v.ToString()` 改为 `v.ToString()!`

### PatientServiceTests.cs (30 处警告)
- 采用与 UserServiceTests 相同的修复策略
- 额外修复了 SearchAsync 测试中的多个 `v.ToString()` 调用

## 验证结果
### 编译验证
```bash
dotnet build LYBT.Module.Users.Tests.csproj -c Release --no-restore
# 结果: 0 个警告, 0 个错误

dotnet build LYBT.Module.Patients.Tests.csproj -c Release --no-restore  
# 结果: 0 个警告, 0 个错误
```

### 测试验证
所有测试用例保持绿色状态，nullability 修复不影响测试逻辑。

## 验收标准
- [x] UserServiceTests.cs 编译无警告
- [x] PatientServiceTests.cs 编译无警告
- [x] 所有单元测试通过
- [x] 未使用 NoWarn 压制警告
- [x] 代码逻辑未改变

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>