### PR TITLE
fix(desktop): 修复 ILocalAuthService 依赖注入配置缺失

### DIFF
--- a/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
@@ -268,6 +268,11 @@ namespace LYBT.Desktop.Shell.Extensions
             // Issue #835: 注册认证服务(使用 Shared.Interfaces)
             containerRegistry.RegisterSingleton<LYBT.Shared.Interfaces.Services.IAuthService,
                 LYBT.Desktop.Services.Business.AuthService>();
+
+            // Issue #1039: 注册 Desktop 本地认证服务（ILocalAuthService 继承 IAuthService）
+            containerRegistry.RegisterSingleton<LYBT.Desktop.Services.Business.ILocalAuthService,
+                LYBT.Desktop.Services.Business.AuthService>();
+
             containerRegistry.RegisterSingleton<LYBT.Desktop.Services.Business.ITokenStorageService,
                 LYBT.Desktop.Services.Business.TokenStorageService>();
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -23,6 +23,10 @@
 
     <!-- 测试运行设置文件 -->
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)..\.runsettings</RunSettingsFilePath>
+
+    <!-- 解决 Coverlet 并行测试时的文件锁定问题 -->
+    <!-- 为每个测试项目创建依赖程序集的本地副本 -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <!-- 测试框架包版本管理 -->

--- a/tests/TestConfiguration/LYBT.Tests.Configuration.csproj
+++ b/tests/TestConfiguration/LYBT.Tests.Configuration.csproj
@@ -6,6 +6,10 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!-- 生成运行时配置文件，供跨框架引用的测试项目使用 -->
+    <GenerateDependencyFile>true</GenerateDependencyFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 问题描述

修复 Desktop 应用启动时 LoginView 加载失败的问题。

**错误信息**：
```
System.Windows.Markup.XamlParseException: 设置属性"Prism.Mvvm.ViewModelLocator.AutoWireViewModel"时引发了异常。
ContainerException: Unable to resolve LYBT.Desktop.Services.Business.ILocalAuthService
```

## 根本原因

`AuthService` 类已实现 `ILocalAuthService` 接口，但在依赖注入容器中只注册了 `IAuthService`，未注册 `ILocalAuthService`。

**代码分析**：
- ✅ `AuthService` 声明：`public class AuthService : ILocalAuthService`
- ✅ `ILocalAuthService` 继承 `IAuthService` 并添加 Desktop 特定方法
- ❌ `ServiceCollectionExtensions.cs` 只注册了 `IAuthService` → `AuthService`
- ❌ `LoginViewModel` 构造函数需要 `ILocalAuthService` 参数，容器无法解析

## 解决方案

在 `ServiceCollectionExtensions.cs` 的 `RegisterBusinessServices` 方法中添加：

```csharp
// Issue #1039: 注册 Desktop 本地认证服务（ILocalAuthService 继承 IAuthService）
containerRegistry.RegisterSingleton<LYBT.Desktop.Services.Business.ILocalAuthService,
    LYBT.Desktop.Services.Business.AuthService>();
```

## 验收结果

- ✅ `ILocalAuthService` 注册为 Singleton
- ✅ Desktop.Shell 项目编译成功
- ⏳ LoginView 加载测试（待人工验证）
- ⏳ Desktop 应用启动测试（待人工验证）

## 测试说明

**编译验证**：
```powershell
dotnet build src/Client/Desktop/Shell/LYBT.Desktop.Shell.csproj -c Debug
# 结果: 成功，0 个错误
```

**运行验证**（需人工测试）：
1. 运行 Desktop 应用
2. 验证 LoginView 正常加载
3. 验证无 XamlParseException 异常

## 代码审查清单

- [x] Claude Code 初审
- [ ] 满足验收标准
- [ ] 遵守架构规范
- [ ] 符合 DI 标准（构造函数注入）
- [ ] 编译通过

Closes #1039