### PR TITLE
refactor(api): 统一API路由的单复数命名规范 - Issue #1075

### DIFF
--- a/src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs
@@ -13,7 +13,7 @@ namespace LYBT.WebAPI.Controllers
     /// </summary>
     [ApiController]
     [ApiVersion("1.0")]
-    [Route("api/v{version:apiVersion}/[controller]")]
+    [Route("api/v{version:apiVersion}/consultations")]
     [Authorize]
     public class ConsultationController : ControllerBase
     {


### PR DESCRIPTION
## 摘要
统一ConsultationController的API路由命名，从单数形式改为复数形式，与其他控制器保持一致。

## 修改内容
- **文件**: `src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs`
- **更改**: 将路由从 `[Route("api/v{version:apiVersion}/[controller]")]` 改为 `[Route("api/v{version:apiVersion}/consultations")]`
- **影响**: 路由从 `api/v1/consultation` 变更为 `api/v1/consultations`

## 验证结果
✅ **构建验证**: `dotnet build src/Server/Services/LYBT.WebAPI/LYBT.WebAPI.csproj -c Release --no-restore` - 成功
✅ **测试验证**: `dotnet test tests/UnitTests/Server/Modules/LYBT.Module.Consultation.Tests/ -c Release --no-build` - 全部通过 (23/23)

## 一致性分析
在修改前的现状分析中发现：
- **已使用复数形式的控制器**: FormulasController, HerbsController, PatientsController, PrescriptionsController, UsersController
- **原使用单数形式**: ConsultationController (本次修改)
- **代码中已存在的复数引用**: 
  - `ConsultationRepository.cs` 已使用 "api/v1/consultations"
  - `IConsultationApi.cs` 中所有Refit接口已使用 "api/v1/consultations"
  - 相关文档已记录为复数形式

此次修改实际上是**修复了控制器路由与现有代码的不一致性**，而非破坏性更改。

## 兼容性
由于代码中的API客户端和Repository已经使用复数形式，此次修改：
- ✅ 修复了路由不一致问题
- ✅ 无需更新其他引用代码
- ✅ 符合RESTful API设计规范

Fixes #1075

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>