### PR TITLE
feat(server): 补全ConsultationController缺失的API端点

### DIFF
--- a/src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs
@@ -157,17 +157,66 @@ namespace LYBT.WebAPI.Controllers
                 if (validationResult != null) return validationResult;
 
                 var result = await _consultationService.DeleteAsync(id);
-                
+
                 if (result.IsSuccess)
                 {
                     LogOperation("删除诊疗记录", null, id);
                 }
-                
+
                 return HandleServiceResult(result, "诊疗记录删除成功");
             }
             catch (Exception ex)
             {
                 return HandleException(ex, "删除诊疗记录", new { ConsultationId = id });
+            }
+        }
+
+        /// <summary>
+        /// 根据医案ID获取诊疗记录列表
+        /// </summary>
+        /// <param name="medicalCaseId">医案ID</param>
+        /// <returns>诊疗记录列表</returns>
+        [HttpGet("medicalcase/{medicalCaseId}")]
+        [ProducesResponseType(typeof(ApiResponse<List<ConsultationDto>>), 200)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ApiResponse<List<ConsultationDto>>>> GetByMedicalCaseId(Guid medicalCaseId)
+        {
+            try
+            {
+                var validationResult = ValidateGuid<List<ConsultationDto>>(medicalCaseId, "医案ID");
+                if (validationResult != null) return validationResult;
+
+                var result = await _consultationService.GetByMedicalCaseIdAsync(medicalCaseId);
+                return HandleServiceResult(result);
+            }
+            catch (Exception ex)
+            {
+                return HandleException<List<ConsultationDto>>(ex, "根据医案ID获取诊疗记录", new { MedicalCaseId = medicalCaseId });
+            }
+        }
+
+        /// <summary>
+        /// 搜索诊疗记录
+        /// </summary>
+        /// <param name="keyword">搜索关键词</param>
+        /// <returns>匹配的诊疗记录列表</returns>
+        [HttpGet("search")]
+        [ProducesResponseType(typeof(ApiResponse<List<ConsultationDto>>), 200)]
+        public async Task<ActionResult<ApiResponse<List<ConsultationDto>>>> Search([FromQuery] string keyword)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(keyword))
+                {
+                    return BadRequest(ApiResponse<List<ConsultationDto>>.CreateFail("搜索关键词不能为空"));
+                }
+
+                var result = await _consultationService.SearchAsync(keyword);
+                return HandleServiceResult(result);
+            }
+            catch (Exception ex)
+            {
+                return HandleException<List<ConsultationDto>>(ex, "搜索诊疗记录", new { Keyword = keyword });
             }
         }
     }


### PR DESCRIPTION
## 关联 Issue
Fixes #1092

## 改动说明
补全 ConsultationController 中缺失的 API 端点，避免 Desktop Repository 使用低效的 GetAll+内存过滤。

### 新增端点

#### 1. GET api/v1/consultations/medicalcase/{medicalCaseId}
**功能**：根据医案ID获取诊疗记录列表

**参数**：
- `medicalCaseId` (Guid): 医案ID

**返回**：`ApiResponse<List<ConsultationDto>>`

**用途**：Desktop Repository 的 GetByMedicalCaseIdAsync 可以直接调用此端点，而非 GetAll+过滤

#### 2. GET api/v1/consultations/search?keyword={keyword}
**功能**：关键词搜索诊疗记录

**参数**：
- `keyword` (string, required): 搜索关键词

**搜索字段**：
- 主诉 (ChiefComplaint)
- 中医诊断 (TCMDiagnosis)  
- 现病史 (PresentIllness)

**返回**：`ApiResponse<List<ConsultationDto>>`

**验证**：关键词不能为空，否则返回 400 BadRequest

## 验收结果
- [x] Service层方法已实现（GetByMedicalCaseIdAsync、SearchAsync）
- [x] 新增2个Controller端点（GetByMedicalCaseId、Search）
- [x] dotnet build LYBT.Server.sln -c Release 编译通过（0警告0错误）
- [x] dotnet build LYBT.All.sln -c Release 编译通过（0警告0错误）

## 编译命令和结果
```bash
dotnet build LYBT.Server.sln -c Release --no-restore
dotnet build LYBT.All.sln -c Release --no-restore
```

**结果**：
```
已成功生成。
    0 个警告
    0 个错误
```

## 影响范围
- 修改文件：1个（ConsultationController.cs）
- 新增代码：51行
- 影响模块：Server.WebAPI
- 破坏性变更：无（纯新增端点）

## 后续任务
依赖Issue #1094更新Desktop Repository调用新端点

## AI 审查清单
请 GitHub Copilot 和 Claude Code 审查以下方面：
- [ ] 端点路由设计是否符合RESTful规范
- [ ] 参数验证是否充分
- [ ] 异常处理是否完整
- [ ] XML文档注释是否清晰
- [ ] 是否符合 docs/architecture/server-module-design-standard.md 规范

🤖 Generated with [Claude Code](https://claude.com/claude-code)