### PR TITLE
fix: ConsultationServiceTests缺少IMedicalCaseRepository依赖 - Issue #1101

### DIFF
--- a/tests/UnitTests/Server/Modules/LYBT.Module.Consultation.Tests/Services/ConsultationServiceTests.cs
+++ b/tests/UnitTests/Server/Modules/LYBT.Module.Consultation.Tests/Services/ConsultationServiceTests.cs
@@ -5,6 +5,7 @@ using LYBT.Entities.Consultation;
 using LYBT.Entities.MedicalCase;
 using LYBT.Module.Consultation.Interfaces;
 using LYBT.Module.Consultation.Services;
+using LYBT.Module.MedicalCase.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Consultation;
 using Microsoft.Extensions.Logging;
@@ -19,6 +20,7 @@ namespace LYBT.UnitTests.Core.Services
     public class ConsultationServiceTests : IDisposable
     {
         private readonly Mock<IConsultationRepository> _repositoryMock;
+        private readonly Mock<IMedicalCaseRepository> _medicalCaseRepositoryMock;
         private readonly Mock<IMapper> _mapperMock;
         private readonly Mock<ILogger<ConsultationService>> _loggerMock;
         private readonly ConsultationService _service;
@@ -26,11 +28,16 @@ namespace LYBT.UnitTests.Core.Services
         public ConsultationServiceTests()
         {
             _repositoryMock = new Mock<IConsultationRepository>();
+            _medicalCaseRepositoryMock = new Mock<IMedicalCaseRepository>();
             _mapperMock = new Mock<IMapper>();
             _loggerMock = new Mock<ILogger<ConsultationService>>();
 
             // 创建服务实例
-            _service = new ConsultationService(_repositoryMock.Object, _mapperMock.Object, _loggerMock.Object);
+            _service = new ConsultationService(
+                _repositoryMock.Object,
+                _medicalCaseRepositoryMock.Object,
+                _mapperMock.Object,
+                _loggerMock.Object);
         }
 
         #region Get Through MedicalCase Tests


### PR DESCRIPTION
## 📋 关联Issue
Fixes #1101

## 🎯 变更摘要
修复ConsultationServiceTests在创建ConsultationService实例时缺少IMedicalCaseRepository参数导致的编译错误。

## 📝 完成清单
- [x] [TEST-1] 修复ConsultationService实例化参数缺失

## 🔧 技术实现

### 修复测试代码依赖缺失
**文件**: `tests/UnitTests/Server/Modules/LYBT.Module.Consultation.Tests/Services/ConsultationServiceTests.cs`

**问题**：
ConsultationService构造函数需要4个参数：
1. IConsultationRepository
2. IMedicalCaseRepository
3. IMapper
4. ILogger<ConsultationService>

测试代码只传入了3个参数，缺少IMedicalCaseRepository。

**修复内容**：
1. 添加Mock字段：
```csharp
private readonly Mock<IMedicalCaseRepository> _medicalCaseRepositoryMock;
```

2. 在构造函数中初始化：
```csharp
_medicalCaseRepositoryMock = new Mock<IMedicalCaseRepository>();
```

3. 修正服务实例化：
```csharp
_service = new ConsultationService(
    _repositoryMock.Object,
    _medicalCaseRepositoryMock.Object,  // 新增
    _mapperMock.Object,
    _loggerMock.Object);
```

4. 添加using引用：
```csharp
using LYBT.Module.MedicalCase.Interfaces;
```

## ✅ 验收结果

### 编译验证
```bash
dotnet build LYBT.All.sln -c Release
```

**结果**: 
- 成功生成 ✅
- 0警告 0错误 ✅

## 📊 影响范围
- ConsultationService单元测试

## 🔍 根本原因
ConsultationService在重构时添加了IMedicalCaseRepository依赖（用于聚合根模式校验），但测试代码未同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>