### PR TITLE
refactor(desktop): Phase 3 - 迁移 Consultation/Auth 模块并清理 Server 依赖

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Auth/ViewModels/LoginViewModel.cs
@@ -4,7 +4,6 @@ using LYBT.Desktop.Infrastructure.Events;
 using LYBT.Desktop.Models.ViewModels.Base;
 using LYBT.Desktop.Services.Business;
 using LYBT.Desktop.Foundation.HealthCheck;
-using LYBT.Shared.Interfaces.Services;
 using LYBT.Shared.Models.Contracts.Auth;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ConsultationModule.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ConsultationModule.cs
@@ -1,4 +1,5 @@
-﻿using Prism.Ioc;
+﻿using LYBT.Desktop.Consultation.Repositories;
+using Prism.Ioc;
 using Prism.Modularity;
 
 namespace LYBT.Desktop.Consultation
@@ -17,7 +18,8 @@ namespace LYBT.Desktop.Consultation
 
         public void RegisterTypes(IContainerRegistry containerRegistry)
         {
-            // Services由Core_New/Services统一注册，不在Module中注册
+            // Phase 3: 注册 Repository（模块级数据访问）
+            containerRegistry.RegisterSingleton<IConsultationRepository, ConsultationRepository>();
 
             // 注册视图模型 - MVP核心功能
             containerRegistry.Register<ViewModels.MedicalCaseMainViewModel>();

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
@@ -2,7 +2,7 @@
 using System.Windows.Input;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Consultation.Repositories;
 using LYBT.Shared.Models.Contracts.Consultation;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
@@ -21,7 +21,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
 
         #region ��������
 
-        private readonly IConsultationService _consultationService;
+        private readonly IConsultationRepository _consultationRepository;
 
         #endregion ��������
 
@@ -82,7 +82,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
         #region ���캯��
 
         public ConsultationManagementViewModel(
-        IConsultationService consultationService,
+        IConsultationRepository consultationRepository,
         IEventAggregator eventAggregator,
         ILoggerFactory loggerFactory,
         IRegionManager regionManager,
@@ -90,7 +90,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
         IUserNotificationService? userNotificationService = null)
         : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _consultationService = consultationService ?? throw new ArgumentNullException(nameof(consultationService));
+            _consultationRepository = consultationRepository ?? throw new ArgumentNullException(nameof(consultationRepository));
 
             LoadDataCommand = new DelegateCommand(async () => await LoadDataAsync());
             SearchCommand = new DelegateCommand(async () => await SearchAsync());
@@ -147,18 +147,14 @@ namespace LYBT.Desktop.Consultation.ViewModels
                     Keyword = SearchKeyword
                 };
 
-                var result = await _consultationService.GetPagedAsync(query.PageIndex, query.PageSize, query.Keyword);
-                if (result.IsSuccess && result.Data != null)
+                var result = await _consultationRepository.GetPagedAsync(query.PageIndex, query.PageSize, query.Keyword);
+                if (result != null && result.Items != null)
                 {
                     Consultations.Clear();
-                    foreach (var consultation in result.Data.Items)
+                    foreach (var consultation in result.Items)
                     {
                         Consultations.Add(consultation);
                     }
-                }
-                else
-                {
-                    ShowErrorMessage($"��������ʧ��: {result.Message}");
                 }
             }
             catch (Exception ex)

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/MedicalCaseMainViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/MedicalCaseMainViewModel.cs
@@ -2,7 +2,9 @@
 using System.Windows.Input;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Consultation.Repositories;
+using LYBT.Desktop.MedicalCase.Repositories;
+using LYBT.Desktop.Patients.Repositories;
 using LYBT.Shared.Models.Contracts.Consultation;
 using LYBT.Shared.Models.Contracts.Patients;
 using Microsoft.Extensions.Logging;
@@ -22,9 +24,9 @@ namespace LYBT.Desktop.Consultation.ViewModels
 
         #region ��������
 
-        private readonly IConsultationService _consultationService;
-        private readonly IMedicalCaseService _medicalCaseService;
-        private readonly IPatientService _patientService;
+        private readonly IConsultationRepository _consultationRepository;
+        private readonly IMedicalCaseRepository _medicalCaseRepository;
+        private readonly IPatientRepository _patientRepository;
 
         #endregion ��������
 
@@ -134,9 +136,9 @@ namespace LYBT.Desktop.Consultation.ViewModels
         #region ���캯��
 
         public MedicalCaseMainViewModel(
-        IConsultationService consultationService,
-        IMedicalCaseService medicalCaseService,
-        IPatientService patientService,
+        IConsultationRepository consultationRepository,
+        IMedicalCaseRepository medicalCaseRepository,
+        IPatientRepository patientRepository,
         IEventAggregator eventAggregator,
         ILoggerFactory loggerFactory,
         IRegionManager regionManager,
@@ -144,9 +146,9 @@ namespace LYBT.Desktop.Consultation.ViewModels
         IUserNotificationService? userNotificationService = null)
         : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _consultationService = consultationService ?? throw new ArgumentNullException(nameof(consultationService));
-            _medicalCaseService = medicalCaseService ?? throw new ArgumentNullException(nameof(medicalCaseService));
-            _patientService = patientService ?? throw new ArgumentNullException(nameof(patientService));
+            _consultationRepository = consultationRepository ?? throw new ArgumentNullException(nameof(consultationRepository));
+            _medicalCaseRepository = medicalCaseRepository ?? throw new ArgumentNullException(nameof(medicalCaseRepository));
+            _patientRepository = patientRepository ?? throw new ArgumentNullException(nameof(patientRepository));
 
             LoadPatientsCommand = new DelegateCommand(async () => await LoadPatientsAsync());
             SaveConsultationCommand = new DelegateCommand(async () => await SaveConsultationAsync());
@@ -208,11 +210,11 @@ namespace LYBT.Desktop.Consultation.ViewModels
                     Keyword = string.Empty
                 };
 
-                var result = await _patientService.GetPagedAsync(query.PageIndex, query.PageSize, query.Keyword);
-                if (result.IsSuccess && result.Data != null)
+                var result = await _patientRepository.GetPagedAsync(query.PageIndex, query.PageSize, query.Keyword);
+                if (result != null && result.Items != null)
                 {
                     Patients.Clear();
-                    foreach (var patient in result.Data.Items)
+                    foreach (var patient in result.Items)
                     {
                         Patients.Add(patient);
                     }
@@ -256,6 +258,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
                 // 因为 MedicalCase 创建时已自动创建 Consultation
                 var updateDto = new ConsultationUpdateDto
                 {
+                    Id = MedicalCaseId.Value, // Repository 需要在 DTO 中传递 ID
                     ChiefComplaint = Consultation?.ChiefComplaint ?? string.Empty,
                     PresentIllness = Consultation?.PresentIllness,
                     Inspection = Consultation?.Inspection,
@@ -267,15 +270,11 @@ namespace LYBT.Desktop.Consultation.ViewModels
                     Remark = $"患者：{SelectedPatient.Name}，医生：{SessionManager?.CurrentUser?.RealName ?? string.Empty}"
                 };
 
-                var result = await _consultationService.UpdateAsync(MedicalCaseId.Value, updateDto);
-                if (result.IsSuccess && result.Data != null)
+                var updatedConsultation = await _consultationRepository.UpdateAsync(updateDto);
+                if (updatedConsultation != null)
                 {
-                    Consultation = result.Data;
+                    Consultation = updatedConsultation;
                     SetStatus("诊疗记录保存成功");
-                }
-                else
-                {
-                    Logger.LogError("保存失败: {Message}", result.Message);
                 }
             }
             catch (Exception ex)
@@ -337,18 +336,18 @@ namespace LYBT.Desktop.Consultation.ViewModels
                 IsLoading = true;
 
                 // 通过 MedicalCaseId 加载 Consultation（共享主键：Consultation.Id == MedicalCase.Id）
-                var result = await _consultationService.GetByIdAsync(medicalCaseId);
-                
-                if (result.IsSuccess && result.Data != null)
+                var consultation = await _consultationRepository.GetByIdAsync(medicalCaseId);
+
+                if (consultation != null)
                 {
-                    Consultation = result.Data;
+                    Consultation = consultation;
                     Logger.LogInformation("已加载医案 {MedicalCaseId} 的诊疗记录", medicalCaseId);
                 }
                 else
                 {
                     // 如果加载失败，可能是旧数据（MedicalCase 创建时未自动创建 Consultation）
                     Logger.LogWarning("未找到医案 {MedicalCaseId} 的诊疗记录，将创建新记录", medicalCaseId);
-                    
+
                     // 初始化空的 Consultation 对象供用户填写
                     Consultation = new ConsultationDto
                     {
@@ -394,15 +393,15 @@ namespace LYBT.Desktop.Consultation.ViewModels
                 IsLoading = true;
 
                 // ��ȡ���ߵ�����ҽ����ʷ
-                var medicalCasesResult = await _medicalCaseService.GetByPatientIdAsync(SelectedPatient.Id);
+                var medicalCases = await _medicalCaseRepository.GetByPatientIdAsync(SelectedPatient.Id);
 
-                if (!medicalCasesResult.IsSuccess || medicalCasesResult.Data == null || !medicalCasesResult.Data.Any())
+                if (medicalCases == null || !medicalCases.Any())
                 {
                     ShowHistoryDialog(SelectedPatient, null);
                     return;
                 }
 
-                var medicalCases = medicalCasesResult.Data
+                medicalCases = medicalCases
                 .OrderByDescending(mc => mc.CreatedAt)
                 .ToList();
 
@@ -421,16 +420,12 @@ namespace LYBT.Desktop.Consultation.ViewModels
                     // ���Ի�ȡ��ҽ�������Ƽ�¼
                     try
                     {
-                        var consultationResult = await _consultationService.GetByMedicalCaseIdAsync(medicalCase.Id);
-                        if (consultationResult.IsSuccess && consultationResult.Data != null)
+                        var consultations = await _consultationRepository.GetByMedicalCaseIdAsync(medicalCase.Id);
+                        if (consultations != null && consultations.Any())
                         {
                             // �޸���ȡ��һ�����Ƽ�¼
-                            var consultations = consultationResult.Data;
-                            if (consultations.Any())
-                            {
-                                detail.Consultation = consultations.First();
-                                detail.HasConsultation = true;
-                            }
+                            detail.Consultation = consultations.First();
+                            detail.HasConsultation = true;
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
## Epic Issue

#1119 - Desktop ViewModel 依赖迁移 - 从 Server Service 到 Module Repository

## Phase Issue

#1122 - Phase 3: 迁移 Consultation 和 Auth 模块并清理 Server 依赖

## 修改摘要

本 PR 完成 Epic #1119 的 **Phase 3** 任务，迁移 Consultation 和 Auth 模块的 ViewModel 依赖，并清理残留的 Server Service 引用。

**修改范围**：
- 2个 Consultation ViewModel（ConsultationManagementViewModel、MedicalCaseMainViewModel）
- 1个 Auth ViewModel（LoginViewModel - 仅清理未使用 using）
- 1个 Module 注册文件（ConsultationModule.cs）

## 详细修改清单

### ✅ Consultation 模块迁移（2个 ViewModel）

#### 1. ConsultationManagementViewModel.cs
**依赖替换**：
- `IConsultationService` → `IConsultationRepository`

**方法调用调整**：
```csharp
// Before (Service 返回 Result<PagedResult<T>>)
var result = await _consultationService.GetPagedAsync(...);
if (result.IsSuccess && result.Data != null)
{
    foreach (var item in result.Data.Items) { ... }
}

// After (Repository 直接返回 PagedResult<T>)
var result = await _consultationRepository.GetPagedAsync(...);
if (result != null && result.Items != null)
{
    foreach (var item in result.Items) { ... }
}
```

#### 2. MedicalCaseMainViewModel.cs（复杂迁移：3个 Service → 3个 Repository）
**依赖替换**（3个）：
- `IConsultationService` → `IConsultationRepository`
- `IMedicalCaseService` → `IMedicalCaseRepository`
- `IPatientService` → `IPatientRepository`

**构造函数参数**（3个参数全部更新）：
```csharp
public MedicalCaseMainViewModel(
    IConsultationRepository consultationRepository,
    IMedicalCaseRepository medicalCaseRepository,
    IPatientRepository patientRepository,
    ...)
```

**方法调用调整**（5处）：
1. **UpdateAsync** - Repository 需要在 DTO 中传递 Id：
   ```csharp
   // Before
   var result = await _consultationService.UpdateAsync(medicalCaseId, updateDto);
   
   // After
   updateDto.Id = medicalCaseId;
   var consultation = await _consultationRepository.UpdateAsync(updateDto);
   ```

2. **GetByIdAsync** - 直接返回 DTO：
   ```csharp
   // Before
   var result = await _consultationService.GetByIdAsync(id);
   if (result.IsSuccess && result.Data != null) { ... }
   
   // After
   var consultation = await _consultationRepository.GetByIdAsync(id);
   if (consultation != null) { ... }
   ```

3. **GetPagedAsync** - 返回 PagedResult：
   ```csharp
   // Before
   var result = await _patientService.GetPagedAsync(...);
   if (result.IsSuccess) { foreach (var p in result.Data.Items) { ... } }
   
   // After
   var result = await _patientRepository.GetPagedAsync(...);
   if (result != null) { foreach (var p in result.Items) { ... } }
   ```

4. **GetByPatientIdAsync** - 返回 List：
   ```csharp
   // Before
   var result = await _medicalCaseService.GetByPatientIdAsync(patientId);
   var cases = result.Data.OrderByDescending(...);
   
   // After
   var cases = await _medicalCaseRepository.GetByPatientIdAsync(patientId);
   cases = cases.OrderByDescending(...);
   ```

5. **GetByMedicalCaseIdAsync** - 返回 List：
   ```csharp
   // Before
   var result = await _consultationService.GetByMedicalCaseIdAsync(caseId);
   if (result.IsSuccess && result.Data != null) { ... }
   
   // After
   var consultations = await _consultationRepository.GetByMedicalCaseIdAsync(caseId);
   if (consultations != null && consultations.Any()) { ... }
   ```

### ✅ Repository 注册

**ConsultationModule.cs**：
```csharp
public void RegisterTypes(IContainerRegistry containerRegistry)
{
    // Phase 3: 注册 Repository（模块级数据访问）
    containerRegistry.RegisterSingleton<IConsultationRepository, ConsultationRepository>();
    
    // 注册视图模型
    containerRegistry.Register<ViewModels.MedicalCaseMainViewModel>();
    containerRegistry.Register<ViewModels.ConsultationManagementViewModel>();
    ...
}
```

### ✅ Auth 模块清理

**LoginViewModel.cs** - 删除未使用的 `using LYBT.Shared.Interfaces.Services;`
- LoginViewModel 使用的是 `ILocalAuthService`（Desktop 特定服务），不是 Server Service

## 命名空间变更对照

| 旧命名空间 | 新命名空间 | 说明 |
|-----------|-----------|------|
| `LYBT.Shared.Interfaces.Services` | `LYBT.Desktop.Consultation.Repositories` | Consultation Repository |
| - | `LYBT.Desktop.MedicalCase.Repositories` | MedicalCase Repository |
| - | `LYBT.Desktop.Patients.Repositories` | Patient Repository |

## Repository vs Service 关键差异

| 方面 | Server Service | Module Repository |
|------|---------------|-------------------|
| **返回类型** | `Result<T>` | 裸类型 `T` |
| **错误处理** | 返回 `Result.Failure(...)` | 抛出异常 |
| **UpdateAsync** | `UpdateAsync(Guid id, DTO dto)` | `UpdateAsync(DTO dto)` |
| **GetPagedAsync** | `Result<PagedResult<T>>` | `PagedResult<T>` |
| **GetByIdAsync** | `Result<T>` | `T` |
| **成功判断** | `result.IsSuccess && result.Data != null` | `result != null` |

## 编译验证

```powershell
# 清理构建产物
dotnet clean LYBT.Desktop.sln

# 编译验证（Release 模式）
dotnet build LYBT.Desktop.sln -c Release --no-restore
```

**编译结果**：
```
✅ 已成功生成。
   0 个警告
   0 个错误
   已用时间 00:00:04.01
```

## 验收标准

- [x] **Consultation 模块**：2个 ViewModel 已迁移到 Repository
- [x] **Auth 模块**：未使用的 Server Service using 已清理
- [x] **Repository 注册**：ConsultationRepository 已注册到 DI 容器
- [x] **编译成功**：0 错误，0 警告
- [x] **无残留依赖**：Consultation 模块无 Server Service 引用

## 已知问题与后续工作

### ⚠️ Users 模块未完全迁移（超出 Phase 3 范围）

**现状**：
- ✅ Users 模块已有 Repository（在 Phase 1.4 中创建）
- ❌ Users 模块 ViewModel 仍使用 `IUserService`（Phase 2.1 中未迁移）

**影响文件**（5个）：
1. `UserManagementViewModel.cs`
2. `UserCreateViewModel.cs`
3. `UserEditViewModel.cs`
4. `ResetPasswordDialogViewModel.cs`
5. `UserProfileDialogViewModel.cs`

**建议**：
- 创建新 Issue 专门处理 Users 模块的 ViewModel 迁移
- 参考本 PR 的迁移模式完成 Users 模块清理

### ✅ 下一步：Phase 4

- Issue #1123 - 架构测试验证和文档更新
- 验证所有模块的 DI 解析正常
- 运行 DesktopLayerArchTests
- 更新架构文档

## 关联 Issue

Fixes #1122

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>