### PR TITLE
refactor(desktop): Users模块ViewModel从IUserService迁移到IUserRepository

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/UsersModule.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/UsersModule.cs
@@ -1,4 +1,5 @@
-﻿using LYBT.Desktop.Users.ViewModels;
+﻿using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.ViewModels;
 using Prism.Ioc;
 using Prism.Modularity;
 
@@ -20,7 +21,8 @@ namespace LYBT.Desktop.Users
         /// <inheritdoc/>
         public void RegisterTypes(IContainerRegistry containerRegistry)
         {
-            // Services由Core_New/Services统一注册，不在Module中注册
+            // Issue #1128: 注册模块内 Repository（覆盖 Shell 层的旧 Repository）
+            containerRegistry.RegisterSingleton<IUserRepository, UserRepository>();
 
             // 注册视图模型 - MVP核心功能
             containerRegistry.Register<UserManagementViewModel>();

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/ResetPasswordDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/ResetPasswordDialogViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Users.Repositories;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
@@ -15,7 +15,7 @@ namespace LYBT.Desktop.Users.ViewModels
     /// </summary>
     public class ResetPasswordDialogViewModel : UnifiedViewModelBase, IDialogAware
     {
-        private readonly IUserService _userService;
+        private readonly IUserRepository _userRepository;
         private Guid _targetUserId;
 
         #region 属性
@@ -158,12 +158,12 @@ namespace LYBT.Desktop.Users.ViewModels
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
-            IUserService userService,
+            IUserRepository userRepository,
             ISessionManager? sessionManager = null,
             IUserNotificationService? userNotificationService = null)
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
 
             GeneratePasswordCommand = new DelegateCommand(GenerateRandomPassword);
 
@@ -187,15 +187,16 @@ namespace LYBT.Desktop.Users.ViewModels
             {
                 SetIsBusy(true, "正在加载用户信息...");
 
-                var result = await _userService.GetByIdAsync(userId);
-                if (result.IsSuccess && result.Data != null)
+                // Repository 模式：直接返回 UserDto?
+                var user = await _userRepository.GetByIdAsync(userId);
+                if (user != null)
                 {
-                    Username = result.Data.UserName; // 注意：UserDto 属性名是 UserName，不是 Username
+                    Username = user.UserName; // 注意：UserDto 属性名是 UserName，不是 Username
                 }
                 else
                 {
                     SetError("无法加载用户信息");
-                    Logger.LogWarning("加载用户信息失败: {ErrorMessage}", result.ErrorMessage);
+                    Logger.LogWarning("加载用户信息失败: Repository 返回 null");
                 }
             }
             catch (Exception ex)

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserCreateViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserCreateViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Users.Repositories;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;
@@ -19,7 +19,7 @@ namespace LYBT.Desktop.Users.ViewModels
     {
         #region 服务依赖
 
-        private readonly IUserService _userService;
+        private readonly IUserRepository _userRepository;
 
         #endregion
 
@@ -189,7 +189,7 @@ namespace LYBT.Desktop.Users.ViewModels
         #region 构造函数
 
         public UserCreateViewModel(
-            IUserService userService,
+            IUserRepository userRepository,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
@@ -197,7 +197,7 @@ namespace LYBT.Desktop.Users.ViewModels
             IUserNotificationService? userNotificationService = null)
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
 
             // 初始化选项
             RoleOptions = Enum.GetValues<UserRole>();
@@ -238,9 +238,9 @@ namespace LYBT.Desktop.Users.ViewModels
                     Status = Status
                 };
 
-                // 调用服务创建用户
-                var result = await _userService.CreateAsync(createDto);
-                if (result.IsSuccess)
+                // 调用 Repository 创建用户
+                var createdUser = await _userRepository.CreateAsync(createDto);
+                if (createdUser != null)
                 {
                     StatusMessage = "用户创建成功";
                     System.Windows.MessageBox.Show("用户创建成功", "成功", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Information);
@@ -250,7 +250,7 @@ namespace LYBT.Desktop.Users.ViewModels
                 }
                 else
                 {
-                    ErrorMessage = $"创建用户失败: {result.ErrorMessage}";
+                    ErrorMessage = "创建用户失败: Repository 返回 null";
                     System.Windows.MessageBox.Show(ErrorMessage, "错误", System.Windows.MessageBoxButton.OK, System.Windows.MessageBoxImage.Error);
                 }
             }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserEditViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserEditViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Users.Repositories;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;
@@ -19,7 +19,7 @@ namespace LYBT.Desktop.Users.ViewModels
     {
         #region 依赖服务
 
-        private readonly IUserService _userService;
+        private readonly IUserRepository _userRepository;
 
         #endregion
 
@@ -195,7 +195,7 @@ namespace LYBT.Desktop.Users.ViewModels
         #region 构造函数
 
         public UserEditViewModel(
-            IUserService userService,
+            IUserRepository userRepository,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
@@ -203,7 +203,7 @@ namespace LYBT.Desktop.Users.ViewModels
             IUserNotificationService? userNotificationService = null)
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
 
             // 初始化选项
             RoleOptions = Enum.GetValues<UserRole>();
@@ -272,11 +272,12 @@ namespace LYBT.Desktop.Users.ViewModels
             {
                 Logger.LogDebug("开始加载用户数据: {UserId}", UserId);
 
-                var result = await _userService.GetByIdAsync(UserId);
+                // Repository 模式：直接返回 UserDto?
+                var user = await _userRepository.GetByIdAsync(UserId);
 
-                if (result.IsSuccess && result.Data != null)
+                if (user != null)
                 {
-                    _originalUser = result.Data;
+                    _originalUser = user;
                     LoadUserData(_originalUser);
                     IsUserLoaded = true;
 
@@ -286,8 +287,8 @@ namespace LYBT.Desktop.Users.ViewModels
                 }
                 else
                 {
-                    Logger.LogWarning("加载用户数据失败: {ErrorMessage}", result.ErrorMessage);
-                    throw new InvalidOperationException($"加载用户数据失败: {result.ErrorMessage}");
+                    Logger.LogWarning("加载用户数据失败: Repository 返回 null");
+                    throw new InvalidOperationException("加载用户数据失败: 用户不存在");
                 }
 
             }, "加载用户数据");
@@ -340,11 +341,12 @@ namespace LYBT.Desktop.Users.ViewModels
                     Status = Status
                 };
 
-                var result = await _userService.UpdateAsync(UserId, updateDto);
+                // Repository 模式：直接返回 UserDto?
+                var updatedUser = await _userRepository.UpdateAsync(updateDto);
 
-                if (result.IsSuccess && result.Data != null)
+                if (updatedUser != null)
                 {
-                    _originalUser = result.Data;
+                    _originalUser = updatedUser;
                     LoadUserData(_originalUser);
 
                     Logger.LogInformation("成功更新用户: {Username} - {RealName}", Username, RealName);
@@ -357,8 +359,8 @@ namespace LYBT.Desktop.Users.ViewModels
                 }
                 else
                 {
-                    Logger.LogWarning("更新用户失败: {ErrorMessage}", result.ErrorMessage);
-                    throw new InvalidOperationException($"更新用户失败: {result.ErrorMessage}");
+                    Logger.LogWarning("更新用户失败: Repository 返回 null");
+                    throw new InvalidOperationException("更新用户失败");
                 }
 
             }, "更新用户");

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserManagementViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Users.Repositories;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;
@@ -16,9 +16,9 @@ namespace LYBT.Desktop.Users.ViewModels
     /// </summary>
     public class UserManagementViewModel : UnifiedListViewModelBase<UserDto>
     {
-        #region ��������
+        #region 服务依赖
 
-        private readonly IUserService _userService;
+        private readonly IUserRepository _userRepository;
 
         #endregion
 
@@ -130,7 +130,7 @@ namespace LYBT.Desktop.Users.ViewModels
         #region ���캯��
 
         public UserManagementViewModel(
-            IUserService userService,
+            IUserRepository userRepository,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
@@ -138,7 +138,7 @@ namespace LYBT.Desktop.Users.ViewModels
             IUserNotificationService? userNotificationService = null)
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
 
             // ��ʼ��ѡ��
             RoleOptions = Enum.GetValues<UserRole>();
@@ -216,15 +216,13 @@ namespace LYBT.Desktop.Users.ViewModels
 
             try
             {
-                // 调用服务获取分页数据
-                var result = await _userService.GetPagedAsync(page, pageSize, searchText);
+                // 调用 Repository 获取分页数据（裸类型返回）
+                var result = await _userRepository.GetPagedAsync(page, pageSize, searchText);
 
-                if (result.IsSuccess && result.Data != null)
+                if (result != null && result.Items != null)
                 {
-                    var pagedData = result.Data;
-
-                    // �����ɸѡ�������ڿͻ��˽�һ�����ˣ�ʵ����Ŀ��Ӧ���ڷ���˴�����
-                    var filteredItems = pagedData.Items.AsEnumerable();
+                    // 应用筛选条件（在客户端进一步筛选，实际项目应该在服务端处理）
+                    var filteredItems = result.Items.AsEnumerable();
 
                     if (SelectedRole.HasValue)
                     {
@@ -241,13 +239,13 @@ namespace LYBT.Desktop.Users.ViewModels
                         filteredItems = filteredItems.Where(u => u.Status == CommonStatus.Enabled);
                     }
 
-                    // ��������
-                    TotalCount = pagedData.TotalCount;
+                    // 更新总数
+                    TotalCount = result.TotalCount;
                     return filteredItems;
                 }
                 else
                 {
-                    Logger.LogWarning("加载用户列表失败: {ErrorMessage}", result.ErrorMessage);
+                    Logger.LogWarning("加载用户列表失败: Repository 返回 null");
                     TotalCount = 0;
                     return new List<UserDto>();
                 }
@@ -284,7 +282,7 @@ namespace LYBT.Desktop.Users.ViewModels
         }
 
         /// <summary>
-        /// ɾ���û�
+        /// 删除用户
         /// </summary>
         protected override async Task OnExecuteDeleteAsync(UserDto user)
         {
@@ -292,12 +290,8 @@ namespace LYBT.Desktop.Users.ViewModels
 
             Logger.LogDebug("删除用户: {UserId} - {UserName}", user.Id, user.UserName);
 
-            var result = await _userService.DeleteAsync(user.Id);
-            if (!result.IsSuccess)
-            {
-                Logger.LogWarning("删除用户失败: {ErrorMessage}", result.ErrorMessage);
-                throw new InvalidOperationException($"删除用户失败: {result.ErrorMessage}");
-            }
+            // Repository 模式：直接调用，异常由 UnifiedViewModelBase 捕获
+            await _userRepository.DeleteAsync(user.Id);
 
             Logger.LogInformation("成功删除用户: {UserName}", user.UserName);
         }
@@ -315,11 +309,8 @@ namespace LYBT.Desktop.Users.ViewModels
             {
                 try
                 {
-                    var result = await _userService.DeleteAsync(user.Id);
-                    if (!result.IsSuccess)
-                    {
-                        failedUsers.Add($"{user.UserName}: {result.ErrorMessage}");
-                    }
+                    // Repository 模式：直接调用，异常表示失败
+                    await _userRepository.DeleteAsync(user.Id);
                 }
                 catch (Exception ex)
                 {
@@ -418,16 +409,12 @@ namespace LYBT.Desktop.Users.ViewModels
                     Status = newStatus
                 };
 
-                var result = await _userService.UpdateAsync(user.Id, updateDto);
-                if (result.IsSuccess)
+                // Repository 模式：直接调用，异常由 UnifiedViewModelBase 捕获
+                var updatedUser = await _userRepository.UpdateAsync(updateDto);
+                if (updatedUser != null)
                 {
                     Logger.LogInformation("成功{Action}用户: {UserName}", action, user.UserName);
-                    await LoadPageAsync(); // ˢ������
-                }
-                else
-                {
-                    Logger.LogWarning("{Action}用户失败: {ErrorMessage}", action, result.ErrorMessage);
-                    throw new InvalidOperationException($"{action}用户失败: {result.ErrorMessage}");
+                    await LoadPageAsync(); // 刷新列表
                 }
 
             }, user.Status == CommonStatus.Enabled ? "禁用用户" : "启用用户");

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserProfileDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserProfileDialogViewModel.cs
@@ -3,7 +3,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Shared.Interfaces.Services;
+using LYBT.Desktop.Users.Repositories;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using Prism.Commands;
@@ -18,7 +18,7 @@ namespace LYBT.Desktop.Users.ViewModels
     /// </summary>
     public class UserProfileDialogViewModel : UnifiedViewModelBase, IDialogAware
     {
-        private readonly IUserService _userService;
+        private readonly IUserRepository _userRepository;
         private readonly ISessionManager _sessionManager;
         private Guid _currentUserId;
         private string? _avatarFilePath;
@@ -193,12 +193,12 @@ namespace LYBT.Desktop.Users.ViewModels
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
-            IUserService userService,
+            IUserRepository userRepository,
             ISessionManager sessionManager,
             IUserNotificationService? userNotificationService = null)
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
-            _userService = userService ?? throw new ArgumentNullException(nameof(userService));
+            _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
             _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
 
             SelectAvatarCommand = new DelegateCommand(SelectAvatar);
@@ -225,12 +225,11 @@ namespace LYBT.Desktop.Users.ViewModels
             {
                 SetIsBusy(true, "正在加载个人资料...");
 
-                var result = await _userService.GetByIdAsync(_currentUserId);
+                // Repository 模式：直接返回 UserDto?
+                var user = await _userRepository.GetByIdAsync(_currentUserId);
 
-                if (result.IsSuccess && result.Data != null)
+                if (user != null)
                 {
-                    var user = result.Data;
-
                     Username = user.UserName; // 注意：UserDto 属性名是 UserName，不是 Username
                     RealName = user.RealName ?? string.Empty;
                     Email = user.Email ?? string.Empty;
@@ -246,8 +245,8 @@ namespace LYBT.Desktop.Users.ViewModels
                 }
                 else
                 {
-                    SetError(result.ErrorMessage ?? "加载个人资料失败");
-                    Logger.LogWarning("加载用户资料失败: {ErrorMessage}", result.ErrorMessage);
+                    SetError("加载个人资料失败");
+                    Logger.LogWarning("加载用户资料失败: Repository 返回 null");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## 关联 Issue
Fixes #1128

## 变更概述
将 Users 模块的 5 个 ViewModel 从 Server Service 模式（`IUserService`）迁移到 Module Repository 模式（`IUserRepository`），与 Epic #1119 Phase 1-3 保持一致。

## 修改文件清单

### [USR-1] UsersModule.cs - 注册 UserRepository
- ✅ 添加 `using LYBT.Desktop.Users.Repositories;`
- ✅ 注册 `containerRegistry.RegisterSingleton<IUserRepository, UserRepository>()` 覆盖 Shell 层

### [USR-2] UserManagementViewModel.cs - 迁移主列表 ViewModel
- ✅ 字段：`IUserService _userService` → `IUserRepository _userRepository`
- ✅ GetItemsAsync：Service 模式 `result.IsSuccess && result.Data` → Repository 模式 `result != null && result.Items`
- ✅ DeleteAsync：移除 `result.IsSuccess` 检查，异常由 `UnifiedViewModelBase` 捕获
- ✅ BatchDeleteAsync：移除 `result.IsSuccess` 检查，异常处理逻辑不变
- ✅ ExecuteToggleUserStatusAsync：签名变更 `UpdateAsync(userId, dto)` → `UpdateAsync(dto)`

### [USR-3] UserCreateViewModel.cs - 迁移创建 ViewModel
- ✅ 字段：`IUserService _userService` → `IUserRepository _userRepository`
- ✅ CreateAsync：Service 模式 `result.IsSuccess && result.Data` → Repository 模式 `createdUser != null`
- ✅ 错误处理：`result.ErrorMessage` → `Repository 返回 null`

### [USR-4] UserEditViewModel.cs - 迁移编辑 ViewModel
- ✅ 字段：`IUserService _userService` → `IUserRepository _userRepository`
- ✅ LoadUserAsync：Service 模式 `result.IsSuccess && result.Data` → Repository 模式 `user != null`
- ✅ ExecuteSaveAsync：签名变更 `UpdateAsync(userId, dto)` → `UpdateAsync(dto)`

### [USR-5] ResetPasswordDialogViewModel.cs - 迁移密码重置对话框
- ✅ 字段：`IUserService _userService` → `IUserRepository _userRepository`
- ✅ LoadUserInfoAsync：Service 模式 `result.IsSuccess && result.Data` → Repository 模式 `user != null`

### [USR-6] UserProfileDialogViewModel.cs - 迁移个人资料对话框
- ✅ 字段：`IUserService _userService` → `IUserRepository _userRepository`
- ✅ LoadUserProfileAsync：Service 模式 `result.IsSuccess && result.Data` → Repository 模式 `user != null`

## 验收标准

### 代码层面
- ✅ 所有 ViewModel 构造函数使用 `IUserRepository` 而非 `IUserService`
- ✅ GetPagedAsync 返回值检查：`result != null && result.Items != null`（而非 `result.IsSuccess`）
- ✅ GetByIdAsync/CreateAsync/UpdateAsync 返回值检查：`entity != null`（而非 `result.IsSuccess && result.Data != null`）
- ✅ UpdateAsync 方法签名：Repository 使用 `UpdateAsync(dto)` 而非 Service 的 `UpdateAsync(id, dto)`
- ✅ 删除操作无需检查 `result.IsSuccess`，异常由基类 `UnifiedViewModelBase` 捕获

### 编译验证
```powershell
dotnet build LYBT.Desktop.sln -c Release --no-restore
```

**结果**：
- ✅ 编译成功
- ✅ 0 个错误
- ⚠️ 8 个警告（已存在警告，与本次迁移无关，来自 SessionManager.cs）

### 架构一致性
- ✅ 遵循 Epic #1119 Phase 1-3 迁移模式
- ✅ 参考 ConsultationManagementViewModelTests.cs 的 Repository Mock 模式
- ✅ 符合 `docs/architecture/client/unified-design-standard.md` 三层架构要求

## 影响范围
- **仅限 Users 模块**：5 个 ViewModel + 1 个模块注册文件
- **无破坏性变更**：Repository 接口签名与之前已迁移模块保持一致
- **无需修改 View**：ViewModel 公共接口未变更

## 参考文档
- 实现模式：Epic #1119 Phase 1-3（Consultation、Patients 模块迁移）
- 测试模式：`ConsultationManagementViewModelTests.cs`（PR #1129）
- 架构标准：`docs/architecture/client/unified-design-standard.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>