### PR TITLE
docs(commands): 修复命令数量不一致问题

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -4,7 +4,7 @@
 **创建日期**: 2025-10-09
 **灵感来源**: [SuperClaude Framework](https://github.com/SuperClaude-Org/SuperClaude_Framework)
 
-本目录包含27个专业化的slash命令，用于提升LYBTZYZS项目的AI辅助开发效率。
+本目录包含25个专业化的slash命令，用于提升LYBTZYZS项目的AI辅助开发效率。
 
 ---
 
@@ -18,6 +18,7 @@
 | `/code-review` | 代码质量审查 | 代码审查、质量检查 |
 | `/analyze-complexity` | 复杂度分析 | 识别需要简化的代码 |
 | `/analyze-dependencies` | 依赖关系分析 | 检测循环依赖、违规依赖 |
+| `/code-rabbit` | CodeRabbit评审处理 | 处理CodeRabbit评审意见 |
 
 ### ⚡ 性能与安全（Performance & Security）
 
@@ -65,12 +66,14 @@
 | `/create-issue` | 创建Issue | 标准化Issue创建 |
 | `/generate-pr` | 生成PR描述 | 自动生成PR描述 |
 | `/sprint-summary` | Sprint总结 | 生成周期总结报告 |
+| `/re-init` | 更新项目规范 | 同步CLAUDE.md规范到项目 |
 
 ### 💡 通用助手（General Assistant）
 
 | 命令 | 描述 | 使用场景 |
 |------|------|---------|
 | `/ask` | 智能问答 | 项目相关问题解答 |
+| `/prompt` | 复杂提示处理 | 处理带@引用的复杂提示 |
 
 ---
 
@@ -135,7 +138,7 @@
 
 | 特性 | SuperClaude | LYBTZYZS |
 |------|-------------|----------|
-| **Slash命令数** | 25个 | 27个 ✅ |
+| **Slash命令数** | 25个 | 25个 ✅ |
 | **行为模式** | 7种 | 7种 ✅ |
 | **MCP服务器** | 8个 | 8个 ✅ |
 | **AI代理** | 15个 | 通过命令实现 ✅ |


### PR DESCRIPTION
## 关联Issue
Fixes #1116

## 变更摘要
修复  中命令数量不一致问题，采用**方案A**：更新文档以反映实际25个命令。

## 修改内容
1. ✅ 更新命令总数：27个→25个（第7行）
2. ✅ 在架构与代码质量分类添加 `/code-rabbit` 命令
3. ✅ 在通用助手分类添加 `/prompt` 命令
4. ✅ 在项目管理分类添加 `/re-init` 命令
5. ✅ 更新SuperClaude对比表格：27个→25个

## 验收标准
- ✅ 命令总数与实际文件数一致（25个 .md 文件）
- ✅ 所有命令在README分类表格中可见
- ✅ SuperClaude对比达到100%对齐（25个 = 25个）

## 差异摘要
```diff
-本目录包含27个专业化的slash命令
+本目录包含25个专业化的slash命令

 # 架构与代码质量分类
+| /code-rabbit | CodeRabbit评审处理 | 处理CodeRabbit评审意见 |

 # 项目管理分类
+| /re-init | 更新项目规范 | 同步CLAUDE.md规范到项目 |

 # 通用助手分类
+| /prompt | 复杂提示处理 | 处理带@引用的复杂提示 |

 # SuperClaude对比表格
-| **Slash命令数** | 25个 | 27个 ✅ |
+| **Slash命令数** | 25个 | 25个 ✅ |
```

## 编译验证
```bash
# 文档修改，无需编译验证
# 已通过Issue #1116验证：
# - 实际命令文件数：25个
# - README声明命令数：25个（已修复）
```

## AI审查清单
- ✅ 符合文档规范（`docs/development/documentation-guidelines.md`）
- ✅ UTF-8 with BOM编码
- ✅ 与Issue #1116验收标准一致
- ✅ SuperClaude对比数据准确
- ✅ 所有缺失命令已添加到分类表格

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>