### PR TITLE
refactor(desktop): Issue #1151 - 接口位置统一迁移到Interfaces/目录

### DIFF
--- a/docs/architecture/client/unified-design-standard.md
+++ b/docs/architecture/client/unified-design-standard.md
@@ -1,9 +1,9 @@
 # Client 端业务模块统一设计标准
 
-> **版本**: 2.1
-> **制定日期**: 2025-01-11
+> **版本**: 2.2
+> **制定日期**: 2025-10-11
 > **适用范围**: Desktop WPF 客户端所有业务模块
-> **关联 Issue**: #1114, #1119, #1118, #1013
+> **关联 Issue**: #1114, #1119, #1118, #1013, #1151
 
 ---
 
@@ -72,8 +72,10 @@ LYBT.Desktop.{ModuleName}/
 │   ├── {Entity}DetailView.xaml         (+ .xaml.cs)
 │   └── {Action}Dialog.xaml             (+ .xaml.cs)
 │
+├── Interfaces/                  🆕 v2.2 模块接口目录
+│   └── I{Entity}Repository.cs  (Repository接口)
+│
 ├── Repositories/                🆕 模块独立数据访问层
-│   ├── I{Entity}Repository.cs  (Repository接口)
 │   └── {Entity}Repository.cs   (Repository实现)
 │
 ├── {ModuleName}Module.cs        ✅ Prism模块注册
@@ -84,9 +86,12 @@ LYBT.Desktop.{ModuleName}/
 - 🆕 **Repositories/** 目录：每个模块拥有独立的数据访问层
 - ❌ **Services/** 目录：已废弃，不再使用Service层
 
+**v2.2 架构调整**：
+- 🆕 **Interfaces/** 目录：Repository接口独立目录，对齐Server端标准
+- ✅ **Repositories/** 目录：仅包含实现类，不再混合接口
+
 ### 2.2 禁止的目录（已废弃）
 
-- ❌ **Interfaces/** - 接口统一在模块的 `Repositories/` 目录
 - ❌ **Mappings/** - AutoMapper配置已废弃（Repository直接返回DTO）
 - ❌ **Services/** - Service层已移除
 
@@ -198,7 +203,7 @@ public XxxViewModel(
 ```csharp
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.{Module}.Repositories;
+using LYBT.Desktop.{Module}.Interfaces;  // v2.2: Repository接口在独立Interfaces目录
 using LYBT.Shared.Models.Contracts.{Module};
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
@@ -280,12 +285,12 @@ namespace LYBT.Desktop.{Module}.ViewModels
 
 ## 四、Repository 层设计标准（v2.0）
 
-### 4.1 Repository 实现位置
+### 4.1 Repository 实现位置（v2.2修订）
 
-- **位置**: `Desktop.{Module}/Repositories/{Entity}Repository.cs`
-- **接口**: `Desktop.{Module}/Repositories/I{Entity}Repository.cs`
+- **接口位置**: `Desktop.{Module}/Interfaces/I{Entity}Repository.cs` （v2.2新增独立目录）
+- **实现位置**: `Desktop.{Module}/Repositories/{Entity}Repository.cs`
 - **命名**: `{Entity}Repository` (如 PatientRepository, UserRepository)
-- **原则**: 每个模块拥有独立的Repository，不再集中管理
+- **原则**: 每个模块拥有独立的Repository，接口与实现分离，对齐Server端标准
 
 ### 4.2 构造函数依赖（强制顺序）
 
@@ -381,10 +386,11 @@ public async Task<{Entity}Dto> {Method}Async({Request}Dto dto)
    - ❌ 混用 CreateDto/UpdateDto/Dto 场景
    - ❌ 在Repository中使用AutoMapper（已废弃）
 
-### 4.6 Repository 示例模板（v2.1）
+### 4.6 Repository 示例模板（v2.2修订）
 
 ```csharp
 using LYBT.Desktop.Foundation.Api;
+using LYBT.Desktop.{Module}.Interfaces;  // v2.2: 接口在独立Interfaces目录
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.{Module};
 using Microsoft.Extensions.Logging;
@@ -629,10 +635,10 @@ namespace LYBT.Desktop.{Module}.Views
 - [ ] 使用基类的 `ShowErrorMessageAsync` 等方法显示消息
 - [ ] 重写 `OnNavigatedTo` 时调用 `base.OnNavigatedTo()`
 
-### 7.2 Repository 检查清单（v2.1）
+### 7.2 Repository 检查清单（v2.2修订）
 
-- [ ] 接口定义在模块的 `Repositories/I{Entity}Repository.cs`
-- [ ] 实现类在模块的 `Repositories/{Entity}Repository.cs`
+- [ ] ✅ **v2.2**: 接口定义在模块的 `Interfaces/I{Entity}Repository.cs`
+- [ ] ✅ **v2.2**: 实现类在模块的 `Repositories/{Entity}Repository.cs`
 - [ ] 构造函数依赖顺序符合标准（`IApiClientManager`, `ILogger`）
 - [ ] ✅ **所有方法返回裸类型**（如 `Task<T>`, `Task<PagedResult<T>>`, `Task`）
 - [ ] ✅ **GetPagedAsync使用服务端分页**（通过ApiClient传递PagedQueryBaseDto）
@@ -652,12 +658,12 @@ namespace LYBT.Desktop.{Module}.Views
 - [ ] 使用 `{DynamicResource}` 引用主题资源
 - [ ] 代码后置仅包含 `InitializeComponent()`
 
-### 7.4 目录结构检查清单（v2.0）
+### 7.4 目录结构检查清单（v2.2修订）
 
 - [ ] ✅ 有 `Models/`、`ViewModels/`、`Views/`
-- [ ] ✅ 有 `Repositories/`（包含接口和实现）
+- [ ] ✅ **v2.2**: 有 `Interfaces/`（包含Repository接口）
+- [ ] ✅ 有 `Repositories/`（包含Repository实现）
 - [ ] ✅ 有 `{Module}Module.cs` 和 `README.md`
-- [ ] ❌ 无 `Interfaces/` 目录（接口在Repositories/内）
 - [ ] ❌ 无 `Mappings/` 目录（已废弃）
 - [ ] ❌ 无 `Services/` 目录（已废弃）
 
@@ -688,9 +694,10 @@ mkdir src/Client/Desktop/Modules/LYBT.Desktop.Patients/Repositories
 #### Step 2：迁移Repository接口和实现
 ```csharp
 // 旧位置: Desktop.Services/Repositories/Interfaces/IPatientRepository.cs
-// 新位置: Desktop.Patients/Repositories/IPatientRepository.cs
+// v2.0 位置: Desktop.Patients/Repositories/IPatientRepository.cs
+// v2.2 位置: Desktop.Patients/Interfaces/IPatientRepository.cs （对齐Server端标准）
 
-namespace LYBT.Desktop.Patients.Repositories
+namespace LYBT.Desktop.Patients.Interfaces  // v2.2: 接口独立目录
 {
     public interface IPatientRepository
     {
@@ -725,11 +732,11 @@ protected override async Task<IEnumerable<PatientDto>> GetItemsAsync(...)
     }
 }
 
-// ✅ 新代码（v2.1）
-using LYBT.Desktop.Patients.Repositories;  // ✅ 模块内Repository
+// ✅ 新代码（v2.2）
+using LYBT.Desktop.Patients.Interfaces;  // ✅ v2.2: 接口在独立Interfaces目录
 
 public PatientManagementViewModel(
-    IPatientRepository patientRepository,  // 直接注入Repository
+    IPatientRepository patientRepository,  // 直接注入Repository接口
     ...)
 {
     _patientRepository = patientRepository;
@@ -872,6 +879,7 @@ var updated = await _repository.UpdateAsync(updateDto);
 
 | 版本 | 日期 | 修订内容 | 作者 |
 |------|------|---------|------|
+| 2.2 | 2025-10-11 | **接口位置统一迁移** - Issue #1151 Desktop接口位置对齐Server端标准<br/>- ✅ **Interfaces/ 目录**：Repository接口独立目录（7个模块）<br/>- ✅ **Repositories/ 目录**：仅保留实现类，不再混合接口<br/>- ✅ **架构一致性**：Desktop与Server端接口位置统一<br/>- ✅ **命名空间调整**：`LYBT.Desktop.{Module}.Repositories` → `LYBT.Desktop.{Module}.Interfaces`<br/>- 📦 **影响模块**：Patients, Users, MedicalCase, Consultation, Prescriptions, Herbs, Formula | Claude Code |
 | 2.1 | 2025-01-11 | **架构实现修订** - 基于 Issue #1119 Phase 1-4 实际迁移经验修订（Epic #1119）<br/>- ✅ **Repository 返回裸类型**（非 ServiceResult）<br/>- ✅ **UpdateAsync 方法签名调整**（dto 包含 Id，无需额外参数）<br/>- ✅ **IApiClientManager 替代 HttpClient**（Foundation 层统一API客户端）<br/>- ✅ **异常处理模式**：Repository 抛出异常，UnifiedViewModelBase 捕获<br/>- ✅ 更新所有代码示例、检查清单、迁移指南<br/>- ⚠️ 强调禁止使用 `LYBT.Shared.Interfaces.Services.*`（DI 解析失败） | Claude Code |
 | 2.0 | 2025-01-09 | **重大架构变更** - 移除Service层，实现模块化架构 (Issue #1114)<br/>- ❌ 删除Desktop.Services项目<br/>- ✅ Repository下沉到各模块<br/>- ✅ 新增Desktop.Foundation/Presentation<br/>- ✅ 修复P0性能问题（服务端分页）<br/>- ❌ 废弃AutoMapper<br/>- 更新所有代码模板与检查清单 | Claude Code |
 | 1.1 | 2025-01-09 | 添加 DTO 使用规范章节,引用 DTO 设计原则文档 (Issue #1094) | Claude Code |

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ConsultationModule.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ConsultationModule.cs
@@ -1,4 +1,5 @@
-﻿using LYBT.Desktop.Consultation.Repositories;
+﻿using LYBT.Desktop.Consultation.Interfaces;
+using LYBT.Desktop.Consultation.Repositories;
 using Prism.Ioc;
 using Prism.Modularity;
 

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/Interfaces/IConsultationRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/Interfaces/IConsultationRepository.cs
@@ -1,7 +1,7 @@
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Consultation;
 
-namespace LYBT.Desktop.Consultation.Repositories
+namespace LYBT.Desktop.Consultation.Interfaces
 {
     /// <summary>
     /// 诊疗数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/README.md
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/README.md
@@ -47,7 +47,7 @@ dotnet build src\Client\Desktop\Modules\Consultation\LYBT.Desktop.Consultation.c
 
 ```csharp
 // ConsultationManagementViewModel.cs
-using LYBT.Desktop.Consultation.Repositories;
+using LYBT.Desktop.Consultation.Interfaces;
 
 public class ConsultationManagementViewModel : UnifiedViewModelBase
 {

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/Repositories/ConsultationRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/Repositories/ConsultationRepository.cs
@@ -1,3 +1,4 @@
+using LYBT.Desktop.Consultation.Interfaces;
 using LYBT.Desktop.Foundation.Http;
 using LYBT.Desktop.Foundation.Repositories;
 using LYBT.Shared.Models.Contracts.Common;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
@@ -2,7 +2,7 @@
 using System.Windows.Input;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Consultation.Repositories;
+using LYBT.Desktop.Consultation.Interfaces;
 using LYBT.Shared.Models.Contracts.Consultation;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/Interfaces/IFormulaRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/Interfaces/IFormulaRepository.cs
@@ -1,7 +1,7 @@
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Formula;
 
-namespace LYBT.Desktop.Formula.Repositories
+namespace LYBT.Desktop.Formula.Interfaces
 {
     /// <summary>
     /// 验方数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/README.md
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/README.md
@@ -46,7 +46,7 @@ dotnet build src\Client\Desktop\Modules\Formula\LYBT.Desktop.Formula.csproj
 
 ```csharp
 // FormulaManagementViewModel.cs
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 
 public class FormulaManagementViewModel : UnifiedViewModelBase
 {

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/Repositories/FormulaRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/Repositories/FormulaRepository.cs
@@ -1,3 +1,4 @@
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Desktop.Foundation.Http;
 using LYBT.Desktop.Foundation.Repositories;
 using LYBT.Shared.Models.Contracts.Common;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/EditFormulaDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/EditFormulaDialogViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Shared.Models.Contracts.Formula;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/FormulaDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/FormulaDetailViewModel.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Shared.Models.Contracts.Formula;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/FormulaManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/FormulaManagementViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Formula;
 using LYBT.Shared.Models.Enums;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/ViewFormulaDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Formula/ViewModels/ViewFormulaDialogViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Shared.Models.Contracts.Formula;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/Interfaces/IHerbRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/Interfaces/IHerbRepository.cs
@@ -1,7 +1,7 @@
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Herbs;
 
-namespace LYBT.Desktop.Herbs.Repositories
+namespace LYBT.Desktop.Herbs.Interfaces
 {
     /// <summary>
     /// 药材数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/README.md
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/README.md
@@ -46,7 +46,7 @@ dotnet build src\Client\Desktop\Modules\Herbs\LYBT.Desktop.Herbs.csproj
 
 ```csharp
 // HerbManagementViewModel.cs
-using LYBT.Desktop.Herbs.Repositories;
+using LYBT.Desktop.Herbs.Interfaces;
 
 public class HerbManagementViewModel : UnifiedViewModelBase
 {

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/Repositories/HerbRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/Repositories/HerbRepository.cs
@@ -1,5 +1,6 @@
 using LYBT.Desktop.Foundation.Http;
 using LYBT.Desktop.Foundation.Repositories;
+using LYBT.Desktop.Herbs.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Herbs;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbDetailViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Herbs.Repositories;
+using LYBT.Desktop.Herbs.Interfaces;
 using LYBT.Shared.Models.Contracts.Herbs;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbManagementViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Herbs.Repositories;
+using LYBT.Desktop.Herbs.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Herbs;
 using LYBT.Shared.Models.Enums;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Interfaces/IMedicalCaseRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Interfaces/IMedicalCaseRepository.cs
@@ -3,7 +3,7 @@ using LYBT.Shared.Models.Contracts.Consultation;
 using LYBT.Shared.Models.Contracts.MedicalCase;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 
-namespace LYBT.Desktop.MedicalCase.Repositories
+namespace LYBT.Desktop.MedicalCase.Interfaces
 {
     /// <summary>
     /// 医疗案例数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/README.md
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/README.md
@@ -46,7 +46,7 @@ dotnet build src\Client\Desktop\Modules\MedicalCase\LYBT.Desktop.MedicalCase.csp
 
 ```csharp
 // MedicalCaseManagementViewModel.cs
-using LYBT.Desktop.MedicalCase.Repositories;
+using LYBT.Desktop.MedicalCase.Interfaces;
 
 public class MedicalCaseManagementViewModel : UnifiedViewModelBase
 {

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Repositories/MedicalCaseRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Repositories/MedicalCaseRepository.cs
@@ -1,5 +1,6 @@
 using LYBT.Desktop.Foundation.Http;
 using LYBT.Desktop.Foundation.Repositories;
+using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Consultation;
 using LYBT.Shared.Models.Contracts.MedicalCase;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseDetailViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.MedicalCase.Repositories;
+using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Shared.Models.Contracts.MedicalCase;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseListViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseListViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.MedicalCase.Repositories;
+using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Shared.Models.Contracts.MedicalCase;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseManagementViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using LYBT.Desktop.Infrastructure.Events;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.MedicalCase.Repositories;
+using LYBT.Desktop.MedicalCase.Interfaces;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Patients/Interfaces/IPatientRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Patients/Interfaces/IPatientRepository.cs
@@ -1,7 +1,7 @@
 ﻿using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Patients;
 
-namespace LYBT.Desktop.Patients.Repositories
+namespace LYBT.Desktop.Patients.Interfaces
 {
     /// <summary>
     /// 患者数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Patients/PatientsModule.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Patients/PatientsModule.cs
@@ -1,4 +1,5 @@
-﻿using LYBT.Desktop.Patients.Repositories;
+﻿using LYBT.Desktop.Patients.Interfaces;
+using LYBT.Desktop.Patients.Repositories;
 using Prism.Ioc;
 using Prism.Modularity;
 

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Patients/Repositories/PatientRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Patients/Repositories/PatientRepository.cs
@@ -1,4 +1,5 @@
-﻿using LYBT.Desktop.Services.Http;
+﻿using LYBT.Desktop.Patients.Interfaces;
+using LYBT.Desktop.Services.Http;
 using LYBT.Desktop.Services.Repositories;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Patients;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Patients/ViewModels/PatientDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Patients/ViewModels/PatientDetailViewModel.cs
@@ -2,7 +2,7 @@
 using AutoMapper;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Patients.Repositories;
+using LYBT.Desktop.Patients.Interfaces;
 using LYBT.Desktop.Services.Print;
 using LYBT.Shared.Models.Contracts.Patients;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Patients/ViewModels/PatientImportWizardViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Patients/ViewModels/PatientImportWizardViewModel.cs
@@ -5,7 +5,7 @@ using System.Windows;
 using System.Windows.Input;
 using LYBT.Desktop.Infrastructure.Helpers;
 using LYBT.Desktop.Patients.Models;
-using LYBT.Desktop.Patients.Repositories;
+using LYBT.Desktop.Patients.Interfaces;
 using LYBT.Shared.Models.Contracts.Patients;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
@@ -1,7 +1,7 @@
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 
-namespace LYBT.Desktop.Prescriptions.Repositories
+namespace LYBT.Desktop.Prescriptions.Interfaces
 {
     /// <summary>
     /// 处方数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/README.md
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/README.md
@@ -46,7 +46,7 @@ dotnet build src\Client\Desktop\Modules\Prescriptions\LYBT.Desktop.Prescriptions
 
 ```csharp
 // PrescriptionManagementViewModel.cs
-using LYBT.Desktop.Prescriptions.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 
 public class PrescriptionManagementViewModel : UnifiedViewModelBase
 {

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
@@ -1,5 +1,6 @@
 using LYBT.Desktop.Foundation.Http;
 using LYBT.Desktop.Foundation.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionCommandHandler.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionCommandHandler.cs
@@ -1,6 +1,6 @@
 ﻿using System.Windows.Input;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Prescriptions.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionDataManager.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionDataManager.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Prescriptions.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;
 using Prism.Events;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/FormulaTemplateDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/FormulaTemplateDialogViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Shared.Models.Contracts.Formula;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/HerbSelectionDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/HerbSelectionDialogViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Herbs.Repositories;
+using LYBT.Desktop.Herbs.Interfaces;
 using LYBT.Shared.Models.Contracts.Herbs;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
@@ -2,8 +2,8 @@
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
 using LYBT.Desktop.Modules.Prescriptions.ViewModels.Components;
-using LYBT.Desktop.Prescriptions.Repositories;
-using LYBT.Desktop.MedicalCase.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
+using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Shared.Models.Contracts.MedicalCase;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionEditorDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionEditorDialogViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Prescriptions.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionManagementViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Prescriptions.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionsMainViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionsMainViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using LYBT.Desktop.Infrastructure.Events;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Prescriptions.Repositories;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/SelectFormulaDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/SelectFormulaDialogViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Formula.Repositories;
+using LYBT.Desktop.Formula.Interfaces;
 using LYBT.Shared.Models.Contracts.Formula;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/Interfaces/IUserRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/Interfaces/IUserRepository.cs
@@ -1,7 +1,7 @@
 ﻿using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Users;
 
-namespace LYBT.Desktop.Users.Repositories
+namespace LYBT.Desktop.Users.Interfaces
 {
     /// <summary>
     /// 用户数据仓储接口 - Phase 2模块化架构

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/README.md
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/README.md
@@ -46,7 +46,7 @@ dotnet build src\Client\Desktop\Modules\Users\LYBT.Desktop.Users.csproj
 
 ```csharp
 // UserManagementViewModel.cs
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 
 public class UserManagementViewModel : UnifiedViewModelBase
 {

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/Repositories/UserRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/Repositories/UserRepository.cs
@@ -1,5 +1,6 @@
 ﻿using LYBT.Desktop.Foundation.Http;
 using LYBT.Desktop.Foundation.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/UsersModule.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/UsersModule.cs
@@ -1,4 +1,5 @@
-﻿using LYBT.Desktop.Users.Repositories;
+﻿using LYBT.Desktop.Users.Interfaces;
+using LYBT.Desktop.Users.Repositories;
 using LYBT.Desktop.Users.ViewModels;
 using Prism.Ioc;
 using Prism.Modularity;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/ResetPasswordDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/ResetPasswordDialogViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserCreateViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserCreateViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserEditViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserEditViewModel.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserManagementViewModel.cs
@@ -1,6 +1,6 @@
 ﻿using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserProfileDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Users/ViewModels/UserProfileDialogViewModel.cs
@@ -3,7 +3,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 using Prism.Commands;


### PR DESCRIPTION
## 概述

完成Desktop模块接口位置标准化，对齐Server端架构设计标准。

## 关联Issue
Fixes #1151  
Relates to #1138, #1114

## 变更内容

### 📁 目录结构调整
- ✅ 创建7个模块的 `Interfaces/` 目录
- ✅ 使用 `git mv` 移动7个Repository接口文件（保留历史）
- ✅ `Repositories/` 目录仅保留实现类

### 📝 命名空间更新
**接口命名空间调整**：
```
LYBT.Desktop.{Module}.Repositories → LYBT.Desktop.{Module}.Interfaces
```

**影响模块（7个）**：
- Patients
- Users  
- MedicalCase
- Consultation
- Prescriptions
- Herbs
- Formula

### 🔧 代码修复
- ✅ 7个Repository实现类添加 `using LYBT.Desktop.{Module}.Interfaces;`
- ✅ 3个Module注册类添加 `using LYBT.Desktop.{Module}.Repositories;`
- ✅ ~35+文件using引用批量更新（sed自动化）

### 📚 文档更新
- ✅ `unified-design-standard.md`: **v2.1 → v2.2**
- ✅ 添加v2.2版本历史说明
- ✅ 更新目录结构示例
- ✅ 更新Repository实现模板
- ✅ 更新检查清单

## 验收结果

### ✅ 编译验证
```bash
dotnet build LYBT.Desktop.sln -c Release --no-restore
# 已成功生成。
#     0 个警告
#     0 个错误
# 已用时间 00:00:01.89
```

### ✅ 架构一致性
- Desktop与Server端接口位置统一 ✅
- 接口与实现分离清晰 ✅
- 依赖注入正确性 ✅

## Git统计
- 50个文件修改
- 7个接口文件重命名（git mv保留历史）
- 84行插入，66行删除

## 架构收益

### 🎯 标准化
- Desktop模块接口位置对齐Server端标准
- 统一的 `Interfaces/` 目录结构

### 📦 模块化
- 接口与实现职责明确分离
- 便于未来Mock测试

### 🔍 可维护性
- 接口位置一致，降低认知负担
- 符合"单一职责"与"依赖倒置"原则

---

**Phase 4 Day 3** - Desktop架构标准化  
**Issue**: #1151 - Desktop接口位置统一迁移（技术债务 #1114）