### PR TITLE
feat(prescriptions): API补充：处方模块核心功能补充 (Issue #1163)

### DIFF
--- a/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -29,18 +29,41 @@ namespace LYBT.Module.Prescriptions.Services
             _logger = logger;
         }
 
-        public async Task<ServiceResult<PagedResult<PrescriptionDto>>> GetPagedAsync(int page = 1, int pageSize = 20, string? keyword = null)
+        public async Task<ServiceResult<PagedResult<PrescriptionDto>>> GetPagedAsync(
+            int page = 1,
+            int pageSize = 20,
+            string? keyword = null,
+            DateTime? startDate = null,
+            DateTime? endDate = null)
         {
             try
             {
                 // 使用优化后的查询方法，包含Items集合
                 var pagedResult = await _repository.GetPagedWithDetailsAsync(page, pageSize, keyword);
+
+                // Issue #1163: 应用日期范围筛选（MVP阶段内存过滤）
+                var filteredItems = pagedResult.Items.AsEnumerable();
+
+                if (startDate.HasValue)
+                {
+                    filteredItems = filteredItems.Where(p => p.CreatedAt >= startDate.Value);
+                }
+
+                if (endDate.HasValue)
+                {
+                    // 结束日期包含当天全部（到23:59:59）
+                    var endOfDay = endDate.Value.Date.AddDays(1).AddTicks(-1);
+                    filteredItems = filteredItems.Where(p => p.CreatedAt <= endOfDay);
+                }
+
+                var filteredList = filteredItems.ToList();
+
                 var dto = new PagedResult<PrescriptionDto>
                 {
-                    Items = _mapper.Map<List<PrescriptionDto>>(pagedResult.Items),
-                    TotalCount = pagedResult.TotalCount,
-                    CurrentPage = pagedResult.CurrentPage,
-                    PageSize = pagedResult.PageSize
+                    Items = _mapper.Map<List<PrescriptionDto>>(filteredList),
+                    TotalCount = startDate.HasValue || endDate.HasValue ? filteredList.Count : pagedResult.TotalCount,
+                    CurrentPage = page,
+                    PageSize = pageSize
                 };
                 return ServiceResult<PagedResult<PrescriptionDto>>.Success(dto);
             }
@@ -275,5 +298,134 @@ namespace LYBT.Module.Prescriptions.Services
 
             return sb.ToString();
         }
+
+        #region Issue #1163: 新增功能
+
+        /// <summary>
+        /// 生成处方编号 (Issue #1163)
+        /// 格式：RX + YYYYMMDD + 4位序号
+        /// </summary>
+        public async Task<ServiceResult<string>> GeneratePrescriptionNoAsync()
+        {
+            try
+            {
+                var today = DateTime.Now.ToString("yyyyMMdd");
+                var prefix = "RX";
+
+                // MVP阶段：简单数据库计数方案
+                // 注意：高并发场景需要使用 Redis 计数器或数据库序列
+                var allPrescriptions = await _repository.GetAllAsync();
+                var todayPrescriptions = allPrescriptions
+                    .Where(p => p.CreatedAt.Date == DateTime.Today)
+                    .ToList();
+
+                var sequence = todayPrescriptions.Count + 1;
+                var prescriptionNo = $"{prefix}{today}{sequence:D4}";
+
+                _logger.LogInformation("生成处方编号: {PrescriptionNo}", prescriptionNo);
+                return ServiceResult<string>.Success(prescriptionNo);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "生成处方编号失败");
+                return ServiceResult<string>.Failure("生成处方编号失败");
+            }
+        }
+
+        /// <summary>
+        /// 获取处方统计数据 (Issue #1163)
+        /// </summary>
+        public async Task<ServiceResult<PrescriptionMainStatisticsDto>> GetStatisticsAsync()
+        {
+            try
+            {
+                var allPrescriptions = await _repository.GetAllAsync();
+                var today = DateTime.Today;
+
+                // 包含处方项以计算金额
+                var todayPrescriptionsWithItems = new List<PrescriptionEntity>();
+                foreach (var p in allPrescriptions.Where(p => p.CreatedAt.Date == today))
+                {
+                    var withItems = await _repository.GetByIdWithItemsAsync(p.Id);
+                    if (withItems != null)
+                        todayPrescriptionsWithItems.Add(withItems);
+                }
+
+                // 计算今日总金额
+                decimal todayTotalAmount = 0;
+                foreach (var prescription in todayPrescriptionsWithItems)
+                {
+                    var itemsTotal = (prescription.Items ?? [])
+                        .Sum(item => item.UnitPrice * item.Quantity * prescription.DosageCount);
+                    todayTotalAmount += itemsTotal * prescription.Discount;
+                }
+
+                var statistics = new PrescriptionMainStatisticsDto
+                {
+                    TotalCount = allPrescriptions.Count(),
+                    TodayCount = todayPrescriptionsWithItems.Count,
+                    TodayTotalAmount = todayTotalAmount
+                };
+
+                return ServiceResult<PrescriptionMainStatisticsDto>.Success(statistics);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "获取处方统计失败");
+                return ServiceResult<PrescriptionMainStatisticsDto>.Failure("获取处方统计失败");
+            }
+        }
+
+        /// <summary>
+        /// 获取日期范围统计 (Issue #1163)
+        /// </summary>
+        public async Task<ServiceResult<PrescriptionRangeStatisticsDto>> GetRangeStatisticsAsync(DateTime startDate, DateTime endDate)
+        {
+            try
+            {
+                var allPrescriptions = await _repository.GetAllAsync();
+
+                // 结束日期包含当天全部
+                var endOfDay = endDate.Date.AddDays(1).AddTicks(-1);
+
+                var rangePrescriptions = allPrescriptions
+                    .Where(p => p.CreatedAt >= startDate && p.CreatedAt <= endOfDay)
+                    .ToList();
+
+                // 包含处方项以计算金额
+                var prescriptionsWithItems = new List<PrescriptionEntity>();
+                foreach (var p in rangePrescriptions)
+                {
+                    var withItems = await _repository.GetByIdWithItemsAsync(p.Id);
+                    if (withItems != null)
+                        prescriptionsWithItems.Add(withItems);
+                }
+
+                // 计算总金额
+                decimal totalAmount = 0;
+                foreach (var prescription in prescriptionsWithItems)
+                {
+                    var itemsTotal = (prescription.Items ?? [])
+                        .Sum(item => item.UnitPrice * item.Quantity * prescription.DosageCount);
+                    totalAmount += itemsTotal * prescription.Discount;
+                }
+
+                var statistics = new PrescriptionRangeStatisticsDto
+                {
+                    Count = prescriptionsWithItems.Count,
+                    TotalAmount = totalAmount,
+                    AvgAmount = prescriptionsWithItems.Count > 0 ? totalAmount / prescriptionsWithItems.Count : 0
+                };
+
+                return ServiceResult<PrescriptionRangeStatisticsDto>.Success(statistics);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "获取日期范围统计失败");
+                return ServiceResult<PrescriptionRangeStatisticsDto>.Failure("获取日期范围统计失败");
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -28,15 +28,22 @@ namespace LYBT.WebAPI.Controllers
         }
 
         /// <summary>
-        /// 获取处方列表 - 支持分页和查询
+        /// 获取处方列表 - 支持分页和查询（Issue #1163: 扩展日期范围筛选）
         /// </summary>
+        /// <param name="page">页码</param>
+        /// <param name="pageSize">每页数量</param>
+        /// <param name="keyword">搜索关键字</param>
+        /// <param name="startDate">开始日期</param>
+        /// <param name="endDate">结束日期</param>
         [HttpGet]
         [ResponseCache(Duration = 600, Location = ResponseCacheLocation.Any)]
         [OutputCache(PolicyName = "PrescriptionsCache")]
         public async Task<ActionResult<ApiResponse<PagedResult<PrescriptionDto>>>> GetList(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 20,
-            [FromQuery] string? keyword = null)
+            [FromQuery] string? keyword = null,
+            [FromQuery] DateTime? startDate = null,
+            [FromQuery] DateTime? endDate = null)
         {
             try
             {
@@ -45,12 +52,12 @@ namespace LYBT.WebAPI.Controllers
                     return ValidationFailPaged<PrescriptionDto>("页码和页大小参数无效（页码>0，页大小1-100）");
                 }
 
-                var pagedResult = await _service.GetPagedAsync(page, pageSize, keyword);
+                var pagedResult = await _service.GetPagedAsync(page, pageSize, keyword, startDate, endDate);
                 return HandlePagedServiceResult(pagedResult, "查询成功");
             }
             catch (Exception ex)
             {
-                return HandleExceptionPaged<PrescriptionDto>(ex, "获取处方列表", new { page, pageSize, keyword });
+                return HandleExceptionPaged<PrescriptionDto>(ex, "获取处方列表", new { page, pageSize, keyword, startDate, endDate });
             }
         }
 
@@ -176,5 +183,75 @@ namespace LYBT.WebAPI.Controllers
                 return HandleException(ex, "删除处方", id);
             }
         }
+
+        #region Issue #1163: 新增功能
+
+        /// <summary>
+        /// 生成处方编号 (Issue #1163)
+        /// </summary>
+        [HttpGet("generate-no")]
+        [ProducesResponseType(typeof(ApiResponse<string>), 200)]
+        public async Task<ActionResult<ApiResponse<string>>> GeneratePrescriptionNo()
+        {
+            try
+            {
+                var result = await _service.GeneratePrescriptionNoAsync();
+                return HandleServiceResult(result, "生成成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<string>(ex, "生成处方编号");
+            }
+        }
+
+        /// <summary>
+        /// 获取处方统计数据 (Issue #1163)
+        /// </summary>
+        [HttpGet("statistics")]
+        [ResponseCache(Duration = 300, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(ApiResponse<PrescriptionMainStatisticsDto>), 200)]
+        public async Task<ActionResult<ApiResponse<PrescriptionMainStatisticsDto>>> GetStatistics()
+        {
+            try
+            {
+                var result = await _service.GetStatisticsAsync();
+                return HandleServiceResult(result, "查询成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<PrescriptionMainStatisticsDto>(ex, "获取处方统计");
+            }
+        }
+
+        /// <summary>
+        /// 获取日期范围统计 (Issue #1163)
+        /// </summary>
+        /// <param name="startDate">开始日期</param>
+        /// <param name="endDate">结束日期</param>
+        [HttpGet("statistics/range")]
+        [ResponseCache(Duration = 300, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(ApiResponse<PrescriptionRangeStatisticsDto>), 200)]
+        [ProducesResponseType(400)]
+        public async Task<ActionResult<ApiResponse<PrescriptionRangeStatisticsDto>>> GetRangeStatistics(
+            [FromQuery] DateTime startDate,
+            [FromQuery] DateTime endDate)
+        {
+            try
+            {
+                if (startDate > endDate)
+                {
+                    return ValidationFail<PrescriptionRangeStatisticsDto>("开始日期不能晚于结束日期");
+                }
+
+                var result = await _service.GetRangeStatisticsAsync(startDate, endDate);
+                return HandleServiceResult(result, "查询成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<PrescriptionRangeStatisticsDto>(ex, "获取日期范围统计", new { startDate, endDate });
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/Shared/LYBT.Shared.Interfaces/Services/IPrescriptionService.cs
+++ b/src/Shared/LYBT.Shared.Interfaces/Services/IPrescriptionService.cs
@@ -4,14 +4,24 @@ using LYBT.Shared.Models.Contracts.Prescriptions;
 namespace LYBT.Shared.Interfaces.Services
 {
     /// <summary>
-    /// 处方服务接口 - 简化版，只包含基础CRUD
+    /// 处方服务接口 - 简化版，包含基础CRUD和统计功能
     /// </summary>
     public interface IPrescriptionService
     {
         /// <summary>
-        /// 分页查询处方
+        /// 分页查询处方（Issue #1163: 扩展支持日期范围筛选）
         /// </summary>
-        Task<ServiceResult<PagedResult<PrescriptionDto>>> GetPagedAsync(int page = 1, int pageSize = 20, string? keyword = null);
+        /// <param name="page">页码</param>
+        /// <param name="pageSize">每页数量</param>
+        /// <param name="keyword">搜索关键字</param>
+        /// <param name="startDate">开始日期（可选）</param>
+        /// <param name="endDate">结束日期（可选）</param>
+        Task<ServiceResult<PagedResult<PrescriptionDto>>> GetPagedAsync(
+            int page = 1,
+            int pageSize = 20,
+            string? keyword = null,
+            DateTime? startDate = null,
+            DateTime? endDate = null);
 
         /// <summary>
         /// 根据ID获取处方详情
@@ -37,5 +47,25 @@ namespace LYBT.Shared.Interfaces.Services
         /// 根据病例ID获取处方列表
         /// </summary>
         Task<ServiceResult<List<PrescriptionDto>>> GetByMedicalCaseIdAsync(Guid medicalCaseId);
+
+        /// <summary>
+        /// 生成处方编号 (Issue #1163)
+        /// 格式：RX + YYYYMMDD + 4位序号
+        /// </summary>
+        Task<ServiceResult<string>> GeneratePrescriptionNoAsync();
+
+        /// <summary>
+        /// 获取处方统计数据 (Issue #1163)
+        /// 包含总数、今日数量和今日金额
+        /// </summary>
+        Task<ServiceResult<PrescriptionMainStatisticsDto>> GetStatisticsAsync();
+
+        /// <summary>
+        /// 获取日期范围统计 (Issue #1163)
+        /// 包含数量、总金额和平均金额
+        /// </summary>
+        /// <param name="startDate">开始日期</param>
+        /// <param name="endDate">结束日期</param>
+        Task<ServiceResult<PrescriptionRangeStatisticsDto>> GetRangeStatisticsAsync(DateTime startDate, DateTime endDate);
     }
 }

--- a/src/Shared/LYBT.Shared.Models/Contracts/Prescriptions/PrescriptionDtos.cs
+++ b/src/Shared/LYBT.Shared.Models/Contracts/Prescriptions/PrescriptionDtos.cs
@@ -507,4 +507,42 @@ namespace LYBT.Shared.Models.Contracts.Prescriptions
         [DisplayName("完成数")]
         public int CompletedCount { get; set; }
     }
+
+    /// <summary>
+    /// 处方主页统计DTO (Issue #1163)
+    /// 为Desktop端PrescriptionsMainViewModel提供统计数据
+    /// </summary>
+    public class PrescriptionMainStatisticsDto
+    {
+        /// <summary>总处方数</summary>
+        [DisplayName("总处方数")]
+        public int TotalCount { get; set; }
+
+        /// <summary>今日处方数</summary>
+        [DisplayName("今日处方数")]
+        public int TodayCount { get; set; }
+
+        /// <summary>今日总金额</summary>
+        [DisplayName("今日总金额")]
+        public decimal TodayTotalAmount { get; set; }
+    }
+
+    /// <summary>
+    /// 处方日期范围统计DTO (Issue #1163)
+    /// 为Desktop端提供日期范围统计数据
+    /// </summary>
+    public class PrescriptionRangeStatisticsDto
+    {
+        /// <summary>处方数量</summary>
+        [DisplayName("处方数量")]
+        public int Count { get; set; }
+
+        /// <summary>总金额</summary>
+        [DisplayName("总金额")]
+        public decimal TotalAmount { get; set; }
+
+        /// <summary>平均金额</summary>
+        [DisplayName("平均金额")]
+        public decimal AvgAmount { get; set; }
+    }
 }


### PR DESCRIPTION
## 概述
实现处方模块的核心功能补充，包括日期范围筛选、处方编号生成和统计功能。

关联：Closes #1163  
Epic: #1161 (API补充计划)

## 变更清单

### 新增 API 端点
- ✅ `GET /api/prescriptions?startDate=xxx&endDate=xxx` - 按日期范围筛选处方列表
- ✅ `GET /api/prescriptions/generate-no` - 生成处方编号（格式：RX + YYYYMMDD + 4位序号）
- ✅ `GET /api/prescriptions/statistics` - 获取处方统计数据（总数、今日数量、今日金额）
- ✅ `GET /api/prescriptions/statistics/range?startDate=xxx&endDate=xxx` - 获取日期范围统计

### 代码变更
- ✅ [SRV-1] 扩展 `GET /api/prescriptions` 端点，添加日期范围筛选参数
- ✅ [SRV-2] 实现 `GET /api/prescriptions/generate-no` 端点
- ✅ [SRV-3] 实现 `GET /api/prescriptions/statistics` 端点
- ✅ [SRV-4] 实现 `GET /api/prescriptions/statistics/range` 端点

### DTO 类
- ✅ 创建 `PrescriptionMainStatisticsDto`（主页统计）
- ✅ 创建 `PrescriptionRangeStatisticsDto`（范围统计）

### 技术实现细节
- 内存过滤（MVP阶段，适用于中小规模数据）
- 处方编号格式：RX + YYYYMMDD + 4位序号（例如：RX202501120001）
- 编号生成采用数据库计数（高并发场景需升级为 Redis 或数据库序列）
- 统计数据包含响应缓存（5分钟）
- 向后兼容现有 API（新参数全部可选）

## 验收标准
- [x] 编译通过（无警告无错误）
- [ ] API 端点可正常调用
- [ ] 日期范围筛选返回正确结果
- [ ] 处方编号生成格式正确且唯一
- [ ] 统计数据准确（总数、今日、金额）
- [ ] 范围统计计算正确

## 测试建议
```bash
# 测试日期范围筛选
GET /api/prescriptions?startDate=2025-01-01&endDate=2025-01-31

# 测试生成处方编号
GET /api/prescriptions/generate-no

# 测试统计数据
GET /api/prescriptions/statistics

# 测试范围统计
GET /api/prescriptions/statistics/range?startDate=2025-01-01&endDate=2025-01-12
```

## 文件变更
- `src/Shared/LYBT.Shared.Models/Contracts/Prescriptions/PrescriptionDtos.cs`
- `src/Shared/LYBT.Shared.Interfaces/Services/IPrescriptionService.cs`
- `src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs`
- `src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs`

## 依赖 Desktop 端模块
- `PrescriptionsMainViewModel`（需要统计数据）
- `PrescriptionManagementViewModel`（需要日期筛选）
- `PrescriptionComposerViewModel`（需要编号生成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)