### PR TITLE
feat(api): Issue #1166 - 实现药材和验方导入导出功能

### DIFF
--- a/src/Server/Modules/LYBT.Module.Formula/LYBT.Module.Formula.csproj
+++ b/src/Server/Modules/LYBT.Module.Formula/LYBT.Module.Formula.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" />
+    <PackageReference Include="EPPlus" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
   </ItemGroup>
 

--- a/src/Server/Modules/LYBT.Module.Formula/Services/FormulaService.cs
+++ b/src/Server/Modules/LYBT.Module.Formula/Services/FormulaService.cs
@@ -1,9 +1,12 @@
 ﻿using AutoMapper;
+using LYBT.Entities.Formula;
 using LYBT.Module.Formula.Interfaces;
 using LYBT.Shared.Interfaces.Services;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Formula;
 using Microsoft.Extensions.Logging;
+using LYBT.Shared.Models.Enums;
+using OfficeOpenXml;
 using FormulaEntity = LYBT.Entities.Formula.Formula;
 
 namespace LYBT.Module.Formula.Services
@@ -187,6 +190,257 @@ namespace LYBT.Module.Formula.Services
             {
                 _logger.LogError(ex, "删除验方失败");
                 return ServiceResult.Failure("删除验方失败");
+            }
+        }
+
+
+        /// <summary>
+        /// 从Excel文件导入验方数据 (Issue #1166)
+        /// </summary>
+        public async Task<ServiceResult<ImportResultDto<FormulaDto>>> ImportFromExcelAsync(Stream stream, string? fileName = null)
+        {
+            var result = new ImportResultDto<FormulaDto>
+            {
+                FileName = fileName,
+                ImportTime = DateTime.Now
+            };
+
+            try
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                using var package = new ExcelPackage(stream);
+                var worksheet = package.Workbook.Worksheets.FirstOrDefault();
+
+                if (worksheet == null)
+                {
+                    result.IsSuccess = false;
+                    result.Message = "Excel文件中没有工作表";
+                    return ServiceResult<ImportResultDto<FormulaDto>>.Failure("Excel文件格式错误");
+                }
+
+                var rowCount = worksheet.Dimension?.Rows ?? 0;
+                if (rowCount <= 1)
+                {
+                    result.IsSuccess = false;
+                    result.Message = "Excel文件中没有数据行";
+                    return ServiceResult<ImportResultDto<FormulaDto>>.Success(result);
+                }
+
+                result.TotalCount = rowCount - 1;
+
+                for (int row = 2; row <= rowCount; row++)
+                {
+                    try
+                    {
+                        var name = worksheet.Cells[row, 1].Text?.Trim();
+                        var category = worksheet.Cells[row, 2].Text?.Trim();
+                        var effect = worksheet.Cells[row, 3].Text?.Trim();
+                        var usage = worksheet.Cells[row, 4].Text?.Trim();
+                        var property = worksheet.Cells[row, 5].Text?.Trim();
+                        var formulaTypeText = worksheet.Cells[row, 6].Text?.Trim();
+                        var isSharedText = worksheet.Cells[row, 7].Text?.Trim();
+                        var remark = worksheet.Cells[row, 8].Text?.Trim();
+
+                        if (string.IsNullOrWhiteSpace(name))
+                        {
+                            result.FailureCount++;
+                            result.Errors.Add(new BatchOperationResultDto.ErrorDetail
+                            {
+                                RecordIdentifier = $"第{row}行",
+                                ErrorMessage = "验方名称不能为空"
+                            });
+                            continue;
+                        }
+
+                        // 解析方剂类型（默认为经验方）
+                        var formulaType = FormulaType.Experience;
+                        if (!string.IsNullOrWhiteSpace(formulaTypeText))
+                        {
+                            if (formulaTypeText.Contains("经典", StringComparison.OrdinalIgnoreCase))
+                                formulaType = FormulaType.Classic;
+                        }
+
+                        // 解析是否共享（默认为否）
+                        var isShared = false;
+                        if (!string.IsNullOrWhiteSpace(isSharedText))
+                        {
+                            isShared = isSharedText.Equals("是", StringComparison.OrdinalIgnoreCase) ||
+                                      isSharedText.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                                      isSharedText.Equals("共享", StringComparison.OrdinalIgnoreCase);
+                        }
+
+                        var formula = new FormulaEntity
+                        {
+                            Name = name,
+                            Category = category,
+                            Effect = effect,
+                            Usage = usage,
+                            Property = property,
+                            FormulaType = formulaType,
+                            IsShared = isShared,
+                            Remark = remark,
+                            Status = CommonStatus.Enabled,
+                            CreatedAt = DateTime.Now
+                        };
+
+                        var savedFormula = await _repository.AddAsync(formula);
+                        var formulaDto = _mapper.Map<FormulaDto>(savedFormula);
+
+                        result.SuccessCount++;
+                        result.SuccessfulIds.Add(savedFormula.Id);
+                        result.ImportedData.Add(formulaDto);
+                    }
+                    catch (Exception ex)
+                    {
+                        result.FailureCount++;
+                        result.Errors.Add(new BatchOperationResultDto.ErrorDetail
+                        {
+                            RecordIdentifier = $"第{row}行",
+                            ErrorMessage = $"导入失败：{ex.Message}"
+                        });
+                        _logger.LogError(ex, "导入第{Row}行时发生错误", row);
+                    }
+                }
+
+                result.IsSuccess = true;
+                result.Message = $"导入完成：成功 {result.SuccessCount} 条，失败 {result.FailureCount} 条";
+
+                return ServiceResult<ImportResultDto<FormulaDto>>.Success(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导入验方数据时发生错误");
+                result.IsSuccess = false;
+                result.Message = $"导入失败：{ex.Message}";
+                return ServiceResult<ImportResultDto<FormulaDto>>.Failure($"导入失败：{ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 导出验方数据到Excel (Issue #1166)
+        /// </summary>
+        public async Task<MemoryStream> ExportAsync(string? category = null)
+        {
+            try
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                var formulas = (await _repository.GetAllAsync()).ToList();
+
+                // 应用分类筛选
+                if (!string.IsNullOrWhiteSpace(category))
+                {
+                    formulas = formulas.Where(f =>
+                        !string.IsNullOrEmpty(f.Category) &&
+                        f.Category.Contains(category, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                }
+
+                var stream = new MemoryStream();
+                using (var package = new ExcelPackage(stream))
+                {
+                    var worksheet = package.Workbook.Worksheets.Add("验方列表");
+
+                    // 表头
+                    worksheet.Cells[1, 1].Value = "验方名称";
+                    worksheet.Cells[1, 2].Value = "分类";
+                    worksheet.Cells[1, 3].Value = "功效";
+                    worksheet.Cells[1, 4].Value = "用法";
+                    worksheet.Cells[1, 5].Value = "性味归经";
+                    worksheet.Cells[1, 6].Value = "方剂类型";
+                    worksheet.Cells[1, 7].Value = "是否共享";
+                    worksheet.Cells[1, 8].Value = "备注";
+
+                    using (var range = worksheet.Cells[1, 1, 1, 8])
+                    {
+                        range.Style.Font.Bold = true;
+                        range.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+                        range.Style.Fill.BackgroundColor.SetColor(System.Drawing.Color.LightGray);
+                    }
+
+                    // 数据行
+                    for (int i = 0; i < formulas.Count; i++)
+                    {
+                        var formula = formulas[i];
+                        int row = i + 2;
+
+                        worksheet.Cells[row, 1].Value = formula.Name;
+                        worksheet.Cells[row, 2].Value = formula.Category;
+                        worksheet.Cells[row, 3].Value = formula.Effect;
+                        worksheet.Cells[row, 4].Value = formula.Usage;
+                        worksheet.Cells[row, 5].Value = formula.Property;
+                        worksheet.Cells[row, 6].Value = formula.FormulaType == FormulaType.Classic ? "经典方" : "经验方";
+                        worksheet.Cells[row, 7].Value = formula.IsShared ? "是" : "否";
+                        worksheet.Cells[row, 8].Value = formula.Remark;
+                    }
+
+                    worksheet.Cells.AutoFitColumns();
+                    package.Save();
+                }
+
+                stream.Position = 0;
+                return stream;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导出验方数据时发生错误");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// 生成验方导入模板 (Issue #1166)
+        /// </summary>
+        public MemoryStream GenerateImportTemplate()
+        {
+            try
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                var stream = new MemoryStream();
+                using (var package = new ExcelPackage(stream))
+                {
+                    var worksheet = package.Workbook.Worksheets.Add("验方信息");
+
+                    // 表头
+                    worksheet.Cells[1, 1].Value = "验方名称*";
+                    worksheet.Cells[1, 2].Value = "分类";
+                    worksheet.Cells[1, 3].Value = "功效";
+                    worksheet.Cells[1, 4].Value = "用法";
+                    worksheet.Cells[1, 5].Value = "性味归经";
+                    worksheet.Cells[1, 6].Value = "方剂类型";
+                    worksheet.Cells[1, 7].Value = "是否共享";
+                    worksheet.Cells[1, 8].Value = "备注";
+
+                    using (var range = worksheet.Cells[1, 1, 1, 8])
+                    {
+                        range.Style.Font.Bold = true;
+                        range.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+                        range.Style.Fill.BackgroundColor.SetColor(System.Drawing.Color.LightGray);
+                    }
+
+                    // 示例数据
+                    worksheet.Cells[2, 1].Value = "小柴胡汤";
+                    worksheet.Cells[2, 2].Value = "和解剂";
+                    worksheet.Cells[2, 3].Value = "和解少阳，扶正祛邪";
+                    worksheet.Cells[2, 4].Value = "水煎服，日三次";
+                    worksheet.Cells[2, 5].Value = "性平，归肝、胆经";
+                    worksheet.Cells[2, 6].Value = "经典方";
+                    worksheet.Cells[2, 7].Value = "是";
+                    worksheet.Cells[2, 8].Value = "《伤寒论》经典名方";
+
+                    worksheet.Cells.AutoFitColumns();
+                    package.Save();
+                }
+
+                stream.Position = 0;
+                return stream;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "生成导入模板时发生错误");
+                throw;
             }
         }
     }

--- a/src/Server/Modules/LYBT.Module.Herbs/LYBT.Module.Herbs.csproj
+++ b/src/Server/Modules/LYBT.Module.Herbs/LYBT.Module.Herbs.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" />
+    <PackageReference Include="EPPlus" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/src/Server/Modules/LYBT.Module.Herbs/Services/HerbService.cs
+++ b/src/Server/Modules/LYBT.Module.Herbs/Services/HerbService.cs
@@ -4,7 +4,9 @@ using LYBT.Module.Herbs.Interfaces;
 using LYBT.Shared.Interfaces.Services;
 using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Herbs;
+using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;
+using OfficeOpenXml;
 
 namespace LYBT.Module.Herbs.Services
 {
@@ -142,6 +144,262 @@ namespace LYBT.Module.Herbs.Services
             {
                 _logger.LogError(ex, "搜索药材失败: {Keyword}", keyword);
                 return ServiceResult<List<HerbDto>>.Failure("搜索药材失败");
+            }
+        }
+
+        /// <summary>
+        /// 从Excel文件导入药材数据 (Issue #1166)
+        /// </summary>
+        public async Task<ServiceResult<ImportResultDto<HerbDto>>> ImportFromExcelAsync(Stream stream, string? fileName = null)
+        {
+            var result = new ImportResultDto<HerbDto>
+            {
+                FileName = fileName,
+                ImportTime = DateTime.Now
+            };
+
+            try
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                using var package = new ExcelPackage(stream);
+                var worksheet = package.Workbook.Worksheets.FirstOrDefault();
+
+                if (worksheet == null)
+                {
+                    result.IsSuccess = false;
+                    result.Message = "Excel文件中没有工作表";
+                    return ServiceResult<ImportResultDto<HerbDto>>.Failure("Excel文件格式错误");
+                }
+
+                var rowCount = worksheet.Dimension?.Rows ?? 0;
+                if (rowCount <= 1)
+                {
+                    result.IsSuccess = false;
+                    result.Message = "Excel文件中没有数据行";
+                    return ServiceResult<ImportResultDto<HerbDto>>.Success(result);
+                }
+
+                result.TotalCount = rowCount - 1;
+
+                for (int row = 2; row <= rowCount; row++)
+                {
+                    try
+                    {
+                        var name = worksheet.Cells[row, 1].Text?.Trim();
+                        var unit = worksheet.Cells[row, 2].Text?.Trim();
+                        var priceText = worksheet.Cells[row, 3].Text?.Trim();
+                        var origin = worksheet.Cells[row, 4].Text?.Trim();
+                        var spec = worksheet.Cells[row, 5].Text?.Trim();
+                        var effect = worksheet.Cells[row, 6].Text?.Trim();
+                        var usage = worksheet.Cells[row, 7].Text?.Trim();
+                        var remark = worksheet.Cells[row, 8].Text?.Trim();
+
+                        if (string.IsNullOrWhiteSpace(name))
+                        {
+                            result.FailureCount++;
+                            result.Errors.Add(new BatchOperationResultDto.ErrorDetail
+                            {
+                                RecordIdentifier = $"第{row}行",
+                                ErrorMessage = "药材名称不能为空"
+                            });
+                            continue;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(unit))
+                        {
+                            result.FailureCount++;
+                            result.Errors.Add(new BatchOperationResultDto.ErrorDetail
+                            {
+                                RecordIdentifier = $"第{row}行",
+                                ErrorMessage = "单位不能为空"
+                            });
+                            continue;
+                        }
+
+                        if (!decimal.TryParse(priceText, out var price) || price <= 0)
+                        {
+                            result.FailureCount++;
+                            result.Errors.Add(new BatchOperationResultDto.ErrorDetail
+                            {
+                                RecordIdentifier = $"第{row}行",
+                                ErrorMessage = "单价格式错误或必须大于0"
+                            });
+                            continue;
+                        }
+
+                        var herb = new Herb
+                        {
+                            Name = name,
+                            Unit = unit,
+                            Price = price,
+                            Origin = origin,
+                            Spec = spec,
+                            Effect = effect,
+                            Usage = usage,
+                            Remark = remark,
+                            Status = CommonStatus.Enabled,
+                            CreatedAt = DateTime.Now
+                        };
+
+                        var savedHerb = await _repository.AddAsync(herb);
+                        var herbDto = _mapper.Map<HerbDto>(savedHerb);
+
+                        result.SuccessCount++;
+                        result.SuccessfulIds.Add(savedHerb.Id);
+                        result.ImportedData.Add(herbDto);
+                    }
+                    catch (Exception ex)
+                    {
+                        result.FailureCount++;
+                        result.Errors.Add(new BatchOperationResultDto.ErrorDetail
+                        {
+                            RecordIdentifier = $"第{row}行",
+                            ErrorMessage = $"导入失败：{ex.Message}"
+                        });
+                        _logger.LogError(ex, "导入第{Row}行时发生错误", row);
+                    }
+                }
+
+                result.IsSuccess = true;
+                result.Message = $"导入完成：成功 {result.SuccessCount} 条，失败 {result.FailureCount} 条";
+
+                return ServiceResult<ImportResultDto<HerbDto>>.Success(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导入药材数据时发生错误");
+                result.IsSuccess = false;
+                result.Message = $"导入失败：{ex.Message}";
+                return ServiceResult<ImportResultDto<HerbDto>>.Failure($"导入失败：{ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 导出药材数据到Excel (Issue #1166)
+        /// </summary>
+        public async Task<MemoryStream> ExportAsync(string? category = null)
+        {
+            try
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                var herbs = await _repository.GetAllAsync();
+                var herbDtos = _mapper.Map<List<HerbDto>>(herbs);
+
+                // 应用分类筛选
+                if (!string.IsNullOrWhiteSpace(category))
+                {
+                    herbDtos = herbDtos.Where(h =>
+                        !string.IsNullOrEmpty(h.Category) &&
+                        h.Category.Contains(category, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                }
+
+                var stream = new MemoryStream();
+                using (var package = new ExcelPackage(stream))
+                {
+                    var worksheet = package.Workbook.Worksheets.Add("药材列表");
+
+                    // 表头
+                    worksheet.Cells[1, 1].Value = "药材名称";
+                    worksheet.Cells[1, 2].Value = "单位";
+                    worksheet.Cells[1, 3].Value = "单价";
+                    worksheet.Cells[1, 4].Value = "产地";
+                    worksheet.Cells[1, 5].Value = "规格";
+                    worksheet.Cells[1, 6].Value = "功效";
+                    worksheet.Cells[1, 7].Value = "用法用量";
+                    worksheet.Cells[1, 8].Value = "备注";
+
+                    using (var range = worksheet.Cells[1, 1, 1, 8])
+                    {
+                        range.Style.Font.Bold = true;
+                        range.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+                        range.Style.Fill.BackgroundColor.SetColor(System.Drawing.Color.LightGray);
+                    }
+
+                    // 数据行
+                    for (int i = 0; i < herbDtos.Count; i++)
+                    {
+                        var herb = herbDtos[i];
+                        int row = i + 2;
+
+                        worksheet.Cells[row, 1].Value = herb.Name;
+                        worksheet.Cells[row, 2].Value = herb.Unit;
+                        worksheet.Cells[row, 3].Value = herb.Price;
+                        worksheet.Cells[row, 4].Value = herb.Origin;
+                        worksheet.Cells[row, 5].Value = herb.Spec;
+                        worksheet.Cells[row, 6].Value = herb.Effect;
+                        worksheet.Cells[row, 7].Value = herb.Usage;
+                        worksheet.Cells[row, 8].Value = herb.Remark;
+                    }
+
+                    worksheet.Cells.AutoFitColumns();
+                    package.Save();
+                }
+
+                stream.Position = 0;
+                return stream;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导出药材数据时发生错误");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// 生成药材导入模板 (Issue #1166)
+        /// </summary>
+        public MemoryStream GenerateImportTemplate()
+        {
+            try
+            {
+                ExcelPackage.LicenseContext = LicenseContext.NonCommercial;
+
+                var stream = new MemoryStream();
+                using (var package = new ExcelPackage(stream))
+                {
+                    var worksheet = package.Workbook.Worksheets.Add("药材信息");
+
+                    // 表头
+                    worksheet.Cells[1, 1].Value = "药材名称*";
+                    worksheet.Cells[1, 2].Value = "单位*";
+                    worksheet.Cells[1, 3].Value = "单价*";
+                    worksheet.Cells[1, 4].Value = "产地";
+                    worksheet.Cells[1, 5].Value = "规格";
+                    worksheet.Cells[1, 6].Value = "功效";
+                    worksheet.Cells[1, 7].Value = "用法用量";
+                    worksheet.Cells[1, 8].Value = "备注";
+
+                    using (var range = worksheet.Cells[1, 1, 1, 8])
+                    {
+                        range.Style.Font.Bold = true;
+                        range.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
+                        range.Style.Fill.BackgroundColor.SetColor(System.Drawing.Color.LightGray);
+                    }
+
+                    // 示例数据
+                    worksheet.Cells[2, 1].Value = "人参";
+                    worksheet.Cells[2, 2].Value = "克";
+                    worksheet.Cells[2, 3].Value = 5.0;
+                    worksheet.Cells[2, 4].Value = "吉林";
+                    worksheet.Cells[2, 5].Value = "特级";
+                    worksheet.Cells[2, 6].Value = "大补元气，复脉固脱";
+                    worksheet.Cells[2, 7].Value = "3-9克";
+                    worksheet.Cells[2, 8].Value = "贵重药材";
+
+                    worksheet.Cells.AutoFitColumns();
+                    package.Save();
+                }
+
+                stream.Position = 0;
+                return stream;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "生成导入模板时发生错误");
+                throw;
             }
         }
     }

--- a/src/Server/Services/LYBT.WebAPI/Controllers/FormulasController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/FormulasController.cs
@@ -180,5 +180,113 @@ namespace LYBT.WebAPI.Controllers
                 return HandleException(ex, "删除验方", id);
             }
         }
+
+
+        /// <summary>
+        /// 批量导入验方数据 (Issue #1166)
+        /// </summary>
+        /// <param name="file">Excel文件（.xlsx格式）</param>
+        /// <returns>导入结果，包含成功/失败数量和详细错误信息</returns>
+        [HttpPost("import")]
+        [RequestSizeLimit(10 * 1024 * 1024)] // 限制10MB
+        public async Task<ActionResult<ApiResponse<ImportResultDto<FormulaDto>>>> Import(IFormFile file)
+        {
+            try
+            {
+                // 验证文件
+                if (file == null || file.Length == 0)
+                {
+                    return ValidationFail<ImportResultDto<FormulaDto>>("文件不能为空");
+                }
+
+                // 验证文件扩展名
+                var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+                if (extension != ".xlsx")
+                {
+                    return ValidationFail<ImportResultDto<FormulaDto>>("仅支持.xlsx格式的Excel文件");
+                }
+
+                // 验证文件大小（10MB）
+                if (file.Length > 10 * 1024 * 1024)
+                {
+                    return ValidationFail<ImportResultDto<FormulaDto>>("文件大小不能超过10MB");
+                }
+
+                // 导入数据
+                using var stream = file.OpenReadStream();
+                var result = await _service.ImportFromExcelAsync(stream, file.FileName);
+
+                if (!result.IsSuccess || result.Data == null)
+                {
+                    return BusinessFail<ImportResultDto<FormulaDto>>(
+                        result.ErrorMessage ?? "导入失败",
+                        ApiErrorCodes.DATASAVEFAILED);
+                }
+
+                // 记录操作日志
+                LogOperation("批量导入验方",
+                    new { FileName = file.FileName, TotalCount = result.Data.TotalCount, SuccessCount = result.Data.SuccessCount },
+                    null);
+
+                return Success(result.Data, result.Data.Message);
+            }
+            catch (Exception ex)
+            {
+                return HandleException<ImportResultDto<FormulaDto>>(ex, "批量导入验方", new { FileName = file?.FileName });
+            }
+        }
+
+        /// <summary>
+        /// 导出验方数据到Excel (Issue #1166)
+        /// </summary>
+        /// <param name="category">可选的分类筛选参数</param>
+        /// <returns>包含验方数据的Excel文件</returns>
+        [HttpGet("export")]
+        public async Task<ActionResult> Export([FromQuery] string? category = null)
+        {
+            try
+            {
+                var stream = await _service.ExportAsync(category);
+                var fileName = string.IsNullOrWhiteSpace(category)
+                    ? $"验方数据_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx"
+                    : $"验方数据_{category}_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx";
+
+                // 记录操作日志
+                LogOperation("导出验方数据", new { Category = category, FileName = fileName }, null);
+
+                return File(stream,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导出验方数据失败，分类筛选：{Category}", category);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// 下载验方导入模板 (Issue #1166)
+        /// </summary>
+        /// <returns>包含示例数据的Excel模板文件</returns>
+        [HttpGet("import-template")]
+        [AllowAnonymous] // 模板下载不需要认证
+        public ActionResult ExportTemplate()
+        {
+            try
+            {
+                var stream = _service.GenerateImportTemplate();
+                var fileName = $"验方导入模板_{DateTime.Now:yyyyMMdd}.xlsx";
+
+                return File(stream,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "生成验方导入模板失败");
+                return StatusCode(500);
+            }
+        }
     }
 }

--- a/src/Server/Services/LYBT.WebAPI/Controllers/HerbsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/HerbsController.cs
@@ -172,5 +172,113 @@ namespace LYBT.WebAPI.Controllers
                 return HandleException(ex, "删除药材", id);
             }
         }
+
+
+        /// <summary>
+        /// 批量导入药材数据 (Issue #1166)
+        /// </summary>
+        /// <param name="file">Excel文件（.xlsx格式）</param>
+        /// <returns>导入结果，包含成功/失败数量和详细错误信息</returns>
+        [HttpPost("import")]
+        [RequestSizeLimit(10 * 1024 * 1024)] // 限制10MB
+        public async Task<ActionResult<ApiResponse<ImportResultDto<HerbDto>>>> Import(IFormFile file)
+        {
+            try
+            {
+                // 验证文件
+                if (file == null || file.Length == 0)
+                {
+                    return ValidationFail<ImportResultDto<HerbDto>>("文件不能为空");
+                }
+
+                // 验证文件扩展名
+                var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+                if (extension != ".xlsx")
+                {
+                    return ValidationFail<ImportResultDto<HerbDto>>("仅支持.xlsx格式的Excel文件");
+                }
+
+                // 验证文件大小（10MB）
+                if (file.Length > 10 * 1024 * 1024)
+                {
+                    return ValidationFail<ImportResultDto<HerbDto>>("文件大小不能超过10MB");
+                }
+
+                // 导入数据
+                using var stream = file.OpenReadStream();
+                var result = await _herbService.ImportFromExcelAsync(stream, file.FileName);
+
+                if (!result.IsSuccess || result.Data == null)
+                {
+                    return BusinessFail<ImportResultDto<HerbDto>>(
+                        result.ErrorMessage ?? "导入失败",
+                        ApiErrorCodes.DATASAVEFAILED);
+                }
+
+                // 记录操作日志
+                LogOperation("批量导入药材",
+                    new { FileName = file.FileName, TotalCount = result.Data.TotalCount, SuccessCount = result.Data.SuccessCount },
+                    null);
+
+                return Success(result.Data, result.Data.Message);
+            }
+            catch (Exception ex)
+            {
+                return HandleException<ImportResultDto<HerbDto>>(ex, "批量导入药材", new { FileName = file?.FileName });
+            }
+        }
+
+        /// <summary>
+        /// 导出药材数据到Excel (Issue #1166)
+        /// </summary>
+        /// <param name="category">可选的分类筛选参数</param>
+        /// <returns>包含药材数据的Excel文件</returns>
+        [HttpGet("export")]
+        public async Task<ActionResult> Export([FromQuery] string? category = null)
+        {
+            try
+            {
+                var stream = await _herbService.ExportAsync(category);
+                var fileName = string.IsNullOrWhiteSpace(category)
+                    ? $"药材数据_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx"
+                    : $"药材数据_{category}_{DateTime.Now:yyyyMMdd_HHmmss}.xlsx";
+
+                // 记录操作日志
+                LogOperation("导出药材数据", new { Category = category, FileName = fileName }, null);
+
+                return File(stream,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导出药材数据失败，分类筛选：{Category}", category);
+                return StatusCode(500);
+            }
+        }
+
+        /// <summary>
+        /// 下载药材导入模板 (Issue #1166)
+        /// </summary>
+        /// <returns>包含示例数据的Excel模板文件</returns>
+        [HttpGet("import-template")]
+        [AllowAnonymous] // 模板下载不需要认证
+        public ActionResult ExportTemplate()
+        {
+            try
+            {
+                var stream = _herbService.GenerateImportTemplate();
+                var fileName = $"药材导入模板_{DateTime.Now:yyyyMMdd}.xlsx";
+
+                return File(stream,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "生成药材导入模板失败");
+                return StatusCode(500);
+            }
+        }
     }
 }

--- a/src/Shared/LYBT.Shared.Interfaces/Services/IFormulaService.cs
+++ b/src/Shared/LYBT.Shared.Interfaces/Services/IFormulaService.cs
@@ -46,5 +46,20 @@ namespace LYBT.Shared.Interfaces.Services
         /// 克隆验方 - 复制验方并创建新实例
         /// </summary>
         Task<ServiceResult<FormulaDto>> CloneFormulaAsync(Guid formulaId);
+
+        /// <summary>
+        /// 从Excel文件导入验方数据 (Issue #1166)
+        /// </summary>
+        Task<ServiceResult<ImportResultDto<FormulaDto>>> ImportFromExcelAsync(Stream stream, string? fileName = null);
+
+        /// <summary>
+        /// 导出验方数据到Excel (Issue #1166)
+        /// </summary>
+        Task<MemoryStream> ExportAsync(string? category = null);
+
+        /// <summary>
+        /// 生成验方导入模板 (Issue #1166)
+        /// </summary>
+        MemoryStream GenerateImportTemplate();
     }
 }

--- a/src/Shared/LYBT.Shared.Interfaces/Services/IHerbService.cs
+++ b/src/Shared/LYBT.Shared.Interfaces/Services/IHerbService.cs
@@ -41,5 +41,20 @@ namespace LYBT.Shared.Interfaces.Services
         /// 搜索药材 - 支持多条件搜索
         /// </summary>
         Task<ServiceResult<List<HerbDto>>> SearchAsync(string keyword);
+
+        /// <summary>
+        /// 从Excel文件导入药材数据 (Issue #1166)
+        /// </summary>
+        Task<ServiceResult<ImportResultDto<HerbDto>>> ImportFromExcelAsync(Stream stream, string? fileName = null);
+
+        /// <summary>
+        /// 导出药材数据到Excel (Issue #1166)
+        /// </summary>
+        Task<MemoryStream> ExportAsync(string? category = null);
+
+        /// <summary>
+        /// 生成药材导入模板 (Issue #1166)
+        /// </summary>
+        MemoryStream GenerateImportTemplate();
     }
 }


### PR DESCRIPTION
## 📋 关联Issue

Closes #1166

## ✨ 实现内容

### Herbs模块
- ✅ [HERB-1] 扩展IHerbService接口，添加导入导出方法
- ✅ [HERB-2-4] 实现HerbService导入导出逻辑
  - `ImportFromExcelAsync`: 批量导入药材数据（含行级验证）
  - `ExportAsync`: 导出药材到Excel（支持分类筛选）
  - `GenerateImportTemplate`: 生成导入模板
- ✅ [HERB-5] 实现HerbsController API
  - `POST /api/v1/herbs/import`
  - `GET /api/v1/herbs/export`
  - `GET /api/v1/herbs/import-template`

### Formula模块
- ✅ [FORMULA-1] 扩展IFormulaService接口，添加导入导出方法
- ✅ [FORMULA-2-4] 实现FormulaService导入导出逻辑
  - `ImportFromExcelAsync`: 批量导入验方数据
  - `ExportAsync`: 导出验方到Excel（支持分类筛选）
  - `GenerateImportTemplate`: 生成导入模板
- ✅ [FORMULA-5] 实现FormulasController API
  - `POST /api/v1/formulas/import`
  - `GET /api/v1/formulas/export`
  - `GET /api/v1/formulas/import-template`

## 📊 Excel字段映射

### 药材 (Herbs)
| 列 | 字段 | 必填 | 说明 |
|---|------|------|------|
| 1 | 药材名称 | ✅ | 不能为空 |
| 2 | 单位 | ✅ | 不能为空 |
| 3 | 单价 | ✅ | 必须>0 |
| 4 | 产地 | ❌ | 可选 |
| 5 | 规格 | ❌ | 可选 |
| 6 | 功效 | ❌ | 可选 |
| 7 | 用法用量 | ❌ | 可选 |
| 8 | 备注 | ❌ | 可选 |

### 验方 (Formulas)
| 列 | 字段 | 必填 | 说明 |
|---|------|------|------|
| 1 | 验方名称 | ✅ | 不能为空 |
| 2 | 分类 | ❌ | 可选 |
| 3 | 功效 | ❌ | 可选 |
| 4 | 用法 | ❌ | 可选 |
| 5 | 性味归经 | ❌ | 可选 |
| 6 | 方剂类型 | ❌ | 经典方/经验方 |
| 7 | 是否共享 | ❌ | 是/否 |
| 8 | 备注 | ❌ | 可选 |

## 🔧 技术细节

### 依赖包
- 添加 **EPPlus 7.5.2** 到 Formula 和 Herbs 模块
- 使用 NonCommercial 许可证上下文

### API特性
- **文件格式**: 仅支持 `.xlsx`
- **文件大小**: 限制 10MB
- **行级验证**: 逐行验证并记录错误详情
- **错误追踪**: 使用 `ImportResultDto<T>` 记录成功/失败数量和详细错误信息
- **分类筛选**: 导出时支持可选的 `category` 参数
- **操作日志**: 记录导入/导出操作

### EPPlus vs Stream 技术方案
采用 **EPPlus + MemoryStream** 组合方案：
- EPPlus 提供强类型Excel操作API（自动处理OpenXML格式）
- MemoryStream 用于Web场景的文件传输（避免磁盘I/O）
- Controller 使用 `FileResult` 直接返回 Stream

### 复用设计
- 复用 Issue #1165 的 `ImportResultDto<T>` 通用导入结果类
- 复用 `BatchOperationResultDto.ErrorDetail` 错误详情结构
- 统一的验证和错误处理模式

## ✅ 编译验证

```bash
dotnet build LYBT.Server.sln -c Release --no-restore
# ✅ 已成功生成。0 个警告 0 个错误
```

## 📝 测试建议

### 手动测试步骤
1. **下载模板**: `GET /api/v1/herbs/import-template`
2. **填写数据**: 编辑模板文件
3. **导入测试**: `POST /api/v1/herbs/import`（测试成功/失败场景）
4. **导出验证**: `GET /api/v1/herbs/export`
5. **分类筛选**: `GET /api/v1/herbs/export?category=补益药`

### 测试用例建议
- ✅ 空文件导入
- ✅ 格式错误文件（非.xlsx）
- ✅ 超大文件（>10MB）
- ✅ 必填字段缺失
- ✅ 价格为负数或零
- ✅ 部分成功部分失败场景
- ✅ 分类筛选正确性

## 🔗 相关文档

- [Issue #1166](https://github.com/shouqitao/LYBTZYZS/issues/1166)
- [Issue #1165 - Patient导入功能](https://github.com/shouqitao/LYBTZYZS/issues/1165)（设计参考）
- [Issue #1164 - 分类筛选功能](https://github.com/shouqitao/LYBTZYZS/issues/1164)（依赖）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)