### PR TITLE
feat(consultation): 实现会诊统计API功能 (Issue #1168)

### DIFF
--- a/src/Server/Modules/LYBT.Module.Consultation/Services/ConsultationService.cs
+++ b/src/Server/Modules/LYBT.Module.Consultation/Services/ConsultationService.cs
@@ -231,5 +231,65 @@ namespace LYBT.Module.Consultation.Services
                 return ServiceResult<List<ConsultationDto>>.Failure("搜索诊疗记录失败");
             }
         }
+
+
+        /// <summary>
+        /// 获取诊疗统计数据 (Issue #1168)
+        /// </summary>
+        public async Task<ServiceResult<ConsultationStatisticsDto>> GetStatisticsAsync(DateTime? startDate = null, DateTime? endDate = null)
+        {
+            try
+            {
+                // 获取所有诊疗记录
+                var allConsultations = (await _repository.GetAllAsync()).ToList();
+                
+                // 日期范围筛选
+                var filteredConsultations = allConsultations.AsQueryable();
+                if (startDate.HasValue)
+                {
+                    filteredConsultations = filteredConsultations.Where(c => c.CreatedAt >= startDate.Value);
+                }
+                if (endDate.HasValue)
+                {
+                    var endOfDay = endDate.Value.Date.AddDays(1).AddSeconds(-1);
+                    filteredConsultations = filteredConsultations.Where(c => c.CreatedAt <= endOfDay);
+                }
+
+                var consultations = filteredConsultations.ToList();
+                var today = DateTime.Today;
+
+                // 统计今日诊疗数
+                var todayConsultations = consultations.Where(c => c.CreatedAt.Date == today).ToList();
+
+                // 按状态统计
+                var byStatus = consultations
+                    .GroupBy(c => c.Status.ToString())
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                // 按医生统计
+                var byDoctor = consultations
+                    .Where(c => c.MedicalCase != null)
+                    .GroupBy(c => c.MedicalCase!.DoctorName)
+                    .ToDictionary(g => g.Key, g => g.Count());
+
+                // 注意：Consultation 实体中没有 StartTime/EndTime 字段
+                // 平均诊疗时长暂时设为 0，未来需要在实体中添加这些字段
+                var statistics = new ConsultationStatisticsDto
+                {
+                    TotalCount = consultations.Count,
+                    TodayCount = todayConsultations.Count,
+                    AvgDuration = 0, // 实体中暂无时间字段
+                    ByStatus = byStatus,
+                    ByDoctor = byDoctor
+                };
+
+                return ServiceResult<ConsultationStatisticsDto>.Success(statistics);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "获取诊疗统计失败");
+                return ServiceResult<ConsultationStatisticsDto>.Failure("获取诊疗统计失败");
+            }
+        }
     }
 }

--- a/src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs
@@ -225,5 +225,34 @@ namespace LYBT.WebAPI.Controllers
                 return HandleException<List<ConsultationDto>>(ex, "搜索诊疗记录", new { Keyword = keyword });
             }
         }
+
+
+        /// <summary>
+        /// 获取诊疗统计数据 (Issue #1168)
+        /// </summary>
+        /// <param name="startDate">开始日期（可选）</param>
+        /// <param name="endDate">结束日期（可选）</param>
+        [HttpGet("statistics")]
+        [ProducesResponseType(typeof(ApiResponse<ConsultationStatisticsDto>), 200)]
+        public async Task<ActionResult<ApiResponse<ConsultationStatisticsDto>>> GetStatistics(
+            [FromQuery] DateTime? startDate = null,
+            [FromQuery] DateTime? endDate = null)
+        {
+            try
+            {
+                // 日期范围验证
+                if (startDate.HasValue && endDate.HasValue && startDate > endDate)
+                {
+                    return ValidationFail<ConsultationStatisticsDto>("开始日期不能晚于结束日期");
+                }
+
+                var result = await _consultationService.GetStatisticsAsync(startDate, endDate);
+                return HandleServiceResult(result, "查询成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<ConsultationStatisticsDto>(ex, "获取诊疗统计", new { startDate, endDate });
+            }
+        }
     }
 }

--- a/src/Shared/LYBT.Shared.Interfaces/Services/IConsultationService.cs
+++ b/src/Shared/LYBT.Shared.Interfaces/Services/IConsultationService.cs
@@ -49,5 +49,12 @@ namespace LYBT.Shared.Interfaces.Services
         /// <param name="patientId">患者ID</param>
         /// <returns>新创建的诊疗记录</returns>
         Task<ServiceResult<ConsultationDto>> StartAsync(Guid patientId);
+
+        /// <summary>
+        /// 获取诊疗统计数据 (Issue #1168)
+        /// </summary>
+        /// <param name="startDate">开始日期（可选）</param>
+        /// <param name="endDate">结束日期（可选）</param>
+        Task<ServiceResult<ConsultationStatisticsDto>> GetStatisticsAsync(DateTime? startDate = null, DateTime? endDate = null);
     }
 }

--- a/src/Shared/LYBT.Shared.Models/Contracts/Consultation/ConsultationDtos.cs
+++ b/src/Shared/LYBT.Shared.Models/Contracts/Consultation/ConsultationDtos.cs
@@ -299,4 +299,32 @@ namespace LYBT.Shared.Models.Contracts.Consultation
         /// <summary>错误消息</summary>
         public List<string> ErrorMessages { get; set; } = new();
     }
+
+
+    /// <summary>
+    /// 诊疗统计DTO (Issue #1168)
+    /// 为Desktop端ConsultationsMainViewModel提供统计数据
+    /// </summary>
+    public class ConsultationStatisticsDto
+    {
+        /// <summary>总诊疗数</summary>
+        [DisplayName("总诊疗数")]
+        public int TotalCount { get; set; }
+
+        /// <summary>今日诊疗数</summary>
+        [DisplayName("今日诊疗数")]
+        public int TodayCount { get; set; }
+
+        /// <summary>平均诊疗时长(分钟)</summary>
+        [DisplayName("平均诊疗时长")]
+        public double AvgDuration { get; set; }
+
+        /// <summary>按状态统计</summary>
+        [DisplayName("按状态统计")]
+        public Dictionary<string, int> ByStatus { get; set; } = new();
+
+        /// <summary>按医生统计</summary>
+        [DisplayName("按医生统计")]
+        public Dictionary<string, int> ByDoctor { get; set; } = new();
+    }
 }


### PR DESCRIPTION
## 📋 需求概述

实现会诊统计API功能，为Desktop端提供统计数据展示。

关联 Issue: #1168

## ✅ 实现内容

### [DTO-1] 创建ConsultationStatisticsDto
- ✅ 新增 `ConsultationStatisticsDto`（`src/Shared/LYBT.Shared.Models/Contracts/Consultation/ConsultationDtos.cs:308-329`）
- ✅ 包含字段：
  - `TotalCount`：总诊疗数
  - `TodayCount`：今日诊疗数
  - `AvgDuration`：平均诊疗时长（分钟）
  - `ByStatus`：按状态统计（Dictionary）
  - `ByDoctor`：按医生统计（Dictionary）

### [SRV-1] 扩展IConsultationService接口
- ✅ 新增 `GetStatisticsAsync` 方法签名（`src/Shared/LYBT.Shared.Interfaces/Services/IConsultationService.cs:53-58`）
- ✅ 支持可选参数：`startDate`、`endDate`

### [SRV-2] 实现ConsultationService.GetStatisticsAsync
- ✅ 实现统计逻辑（`src/Server/Modules/LYBT.Module.Consultation/Services/ConsultationService.cs:236-293`）
- ✅ 日期范围筛选
- ✅ 今日诊疗数量统计
- ✅ 按状态分组统计
- ✅ 按医生分组统计
- ⚠️ 注意：`AvgDuration` 暂时返回 0（Consultation 实体中无 `StartTime/EndTime` 字段）

### [API-1] 实现ConsultationController.GetStatistics
- ✅ 新增 `GET /api/v1/consultations/statistics` 端点（`src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs:230-256`）
- ✅ 查询参数：`startDate`、`endDate`（可选）
- ✅ 日期范围验证（开始日期不能晚于结束日期）
- ✅ 返回 `ConsultationStatisticsDto`

## 🔧 技术实现

### API 端点
```
GET /api/v1/consultations/statistics?startDate=2025-01-01&endDate=2025-01-31
```

### 响应示例
```json
{
  "code": 0,
  "message": "查询成功",
  "data": {
    "totalCount": 150,
    "todayCount": 8,
    "avgDuration": 0,
    "byStatus": {
      "Enabled": 140,
      "Disabled": 10
    },
    "byDoctor": {
      "张医生": 80,
      "李医生": 70
    }
  }
}
```

### 统计逻辑
- 从 Repository 获取所有诊疗记录
- 根据 `startDate` 和 `endDate` 筛选记录
- 统计今日诊疗数（`CreatedAt.Date == DateTime.Today`）
- 按 `Status` 字段分组统计
- 按 `MedicalCase.DoctorName` 分组统计

## 📝 已知限制

⚠️ **平均诊疗时长功能待完善**
- `Consultation` 实体中缺少 `StartTime` 和 `EndTime` 字段
- 当前 `AvgDuration` 返回固定值 0
- 需要在 Epic P0-03（后续迭代）中添加时间字段

## ✅ 编译验证

```bash
✅ dotnet build LYBT.Module.Consultation.csproj --no-restore
✅ dotnet build LYBT.WebAPI.csproj --no-restore
```

## 📦 影响范围

### 新增文件
无

### 修改文件
- `src/Shared/LYBT.Shared.Models/Contracts/Consultation/ConsultationDtos.cs` (+31 行)
- `src/Shared/LYBT.Shared.Interfaces/Services/IConsultationService.cs` (+8 行)
- `src/Server/Modules/LYBT.Module.Consultation/Services/ConsultationService.cs` (+58 行)
- `src/Server/Services/LYBT.WebAPI/Controllers/ConsultationController.cs` (+27 行)

**总计：+124 行**

## 🔍 测试建议

### 单元测试
- [ ] `GetStatisticsAsync` 无日期范围
- [ ] `GetStatisticsAsync` 指定日期范围
- [ ] 日期范围边界测试（startDate > endDate）
- [ ] 空数据场景

### 集成测试
- [ ] API 端点正常响应
- [ ] 日期参数验证
- [ ] 统计数据准确性

## 📚 后续改进

1. **完善平均时长统计** (待 Epic P0-03)
   - 在 `Consultation` 实体中添加 `StartTime`/`EndTime` 字段
   - 修改 `GetStatisticsAsync` 计算真实平均时长

2. **性能优化** (可选)
   - 考虑缓存统计数据
   - 使用数据库聚合查询替代内存统计

Closes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>