### PR TITLE
[Issue-1207] 修复 Desktop 测试项目编译错误

### DIFF
--- a/tests/Architecture/LYBT.ArchTests.csproj
+++ b/tests/Architecture/LYBT.ArchTests.csproj
@@ -32,7 +32,6 @@
     <ProjectReference Include="..\..\src\Shared\LYBT.Shared.Models\LYBT.Shared.Models.csproj" />
     <ProjectReference Include="..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Client\Desktop\Core\LYBT.Desktop.Models\LYBT.Desktop.Models.csproj" />
-    <ProjectReference Include="..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Auth.Tests/LYBT.Desktop.Auth.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Auth.Tests/LYBT.Desktop.Auth.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Modules\LYBT.Desktop.Auth\LYBT.Desktop.Auth.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
     <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
   </ItemGroup>
 

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Consultation.Tests/LYBT.Desktop.Consultation.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Consultation.Tests/LYBT.Desktop.Consultation.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Modules\LYBT.Desktop.Consultation\LYBT.Desktop.Consultation.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
     <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
   </ItemGroup>
 

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Consultation.Tests/ViewModels/ConsultationManagementViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Consultation.Tests/ViewModels/ConsultationManagementViewModelTests.cs
@@ -1,5 +1,5 @@
 ﻿using FluentAssertions;
-using LYBT.Desktop.Consultation.Repositories;
+using LYBT.Desktop.Consultation.Interfaces;
 using LYBT.Desktop.Consultation.ViewModels;
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Shared.Models.Contracts.Common;

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Patients.Tests/LYBT.Desktop.Patients.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Patients.Tests/LYBT.Desktop.Patients.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Modules\LYBT.Desktop.Patients\LYBT.Desktop.Patients.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
     <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
   </ItemGroup>
 

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Prescriptions.Tests/LYBT.Desktop.Prescriptions.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Prescriptions.Tests/LYBT.Desktop.Prescriptions.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Modules\LYBT.Desktop.Prescriptions\LYBT.Desktop.Prescriptions.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
     <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
   </ItemGroup>
 

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Shell.Tests/LYBT.Desktop.Shell.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Shell.Tests/LYBT.Desktop.Shell.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Shell\LYBT.Desktop.Shell.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
     <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
   </ItemGroup>
 

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/LYBT.Desktop.Users.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/LYBT.Desktop.Users.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Modules\LYBT.Desktop.Users\LYBT.Desktop.Users.csproj" />
     <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
-    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Services\LYBT.Desktop.Services.csproj" />
     <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
   </ItemGroup>
 

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/ChangePasswordDialogViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/ChangePasswordDialogViewModelTests.cs
@@ -1,14 +1,12 @@
 using FluentAssertions;
+using LYBT.Desktop.Foundation.Security;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Services.Business;
 using LYBT.Desktop.Users.ViewModels;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Prism.Events;
 using Prism.Regions;
 using Prism.Services.Dialogs;
-using System.Net.Http;
 using Xunit;
 
 namespace LYBT.Desktop.Users.Tests.ViewModels
@@ -22,14 +20,10 @@ namespace LYBT.Desktop.Users.Tests.ViewModels
         private readonly Mock<IEventAggregator> _mockEventAggregator;
         private readonly Mock<ILoggerFactory> _mockLoggerFactory;
         private readonly Mock<ILogger<ChangePasswordDialogViewModel>> _mockLogger;
-        private readonly Mock<ILogger<AuthService>> _mockAuthServiceLogger;
         private readonly Mock<IRegionManager> _mockRegionManager;
         private readonly Mock<ISessionManager> _mockSessionManager;
         private readonly Mock<IUserNotificationService> _mockNotificationService;
-        private readonly Mock<IHttpClientFactory> _mockHttpClientFactory;
-        private readonly Mock<ITokenStorageService> _mockTokenStorage;
-        private readonly Mock<IConfiguration> _mockConfiguration;
-        private readonly Mock<AuthService> _mockAuthService;
+        private readonly Mock<IAuthenticationService> _mockAuthService;
         private readonly ChangePasswordDialogViewModel _viewModel;
 
         public ChangePasswordDialogViewModelTests()
@@ -38,28 +32,15 @@ namespace LYBT.Desktop.Users.Tests.ViewModels
             _mockEventAggregator = new Mock<IEventAggregator>();
             _mockLoggerFactory = new Mock<ILoggerFactory>();
             _mockLogger = new Mock<ILogger<ChangePasswordDialogViewModel>>();
-            _mockAuthServiceLogger = new Mock<ILogger<AuthService>>();
             _mockRegionManager = new Mock<IRegionManager>();
             _mockSessionManager = new Mock<ISessionManager>();
             _mockNotificationService = new Mock<IUserNotificationService>();
-            _mockHttpClientFactory = new Mock<IHttpClientFactory>();
-            _mockTokenStorage = new Mock<ITokenStorageService>();
-            _mockConfiguration = new Mock<IConfiguration>();
+            _mockAuthService = new Mock<IAuthenticationService>();
 
             // Setup LoggerFactory to return mock logger
             _mockLoggerFactory
                 .Setup(x => x.CreateLogger(It.IsAny<string>()))
                 .Returns(_mockLogger.Object);
-
-            // Mock AuthService with constructor parameters
-            // Note: We don't setup ChangePasswordAsync because it's not virtual
-            // and our tests focus on password validation logic, not the actual API call
-            _mockAuthService = new Mock<AuthService>(
-                _mockAuthServiceLogger.Object,
-                _mockHttpClientFactory.Object,
-                _mockTokenStorage.Object,
-                _mockConfiguration.Object
-            );
 
             // Create ViewModel instance
             _viewModel = new ChangePasswordDialogViewModel(

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/ResetPasswordDialogViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/ResetPasswordDialogViewModelTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Desktop.Users.ViewModels;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserCreateViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserCreateViewModelTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Desktop.Users.ViewModels;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserEditViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserEditViewModelTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Desktop.Users.ViewModels;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserManagementViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserManagementViewModelTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Desktop.Users.ViewModels;
 using LYBT.Shared.Models.Common;
 using LYBT.Shared.Models.Contracts.Common;
@@ -115,8 +115,8 @@ namespace LYBT.Desktop.Users.Tests.ViewModels
             // Act - 调用基类protected方法GetItemsAsync（避免WPF Dispatcher）
             var method = typeof(UserManagementViewModel).BaseType!
                 .GetMethod("GetItemsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            
-            var result = await (Task<IEnumerable<UserDto>>)method!.Invoke(_viewModel, new object[] { 1, 20, (string?)null })!;
+
+            var result = await (Task<IEnumerable<UserDto>>)method!.Invoke(_viewModel, new object?[] { 1, 20, null })!;
 
             // Assert - 验证Repository被调用
             _mockUserRepository.Verify(x => x.GetPagedAsync(1, 20, null), Times.Once);
@@ -169,8 +169,8 @@ namespace LYBT.Desktop.Users.Tests.ViewModels
             // Act - 直接调用GetItemsAsync，避免WPF Dispatcher
             var method = typeof(UserManagementViewModel).BaseType!
                 .GetMethod("GetItemsAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            
-            var result = await (Task<IEnumerable<UserDto>>)method!.Invoke(_viewModel, new object[] { 1, 20, (string?)null })!;
+
+            var result = await (Task<IEnumerable<UserDto>>)method!.Invoke(_viewModel, new object?[] { 1, 20, null })!;
 
             // Assert - 应该返回空列表，而不是抛出异常
             result.Should().BeEmpty();

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserProfileDialogViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Users.Tests/ViewModels/UserProfileDialogViewModelTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
 using LYBT.Desktop.Infrastructure.Interfaces;
-using LYBT.Desktop.Users.Repositories;
+using LYBT.Desktop.Users.Interfaces;
 using LYBT.Desktop.Users.ViewModels;
 using LYBT.Shared.Models.Contracts.Users;
 using LYBT.Shared.Models.Enums;


### PR DESCRIPTION
## 📋 关联 Issue

Closes #1207

## 🎯 问题描述

Issue #1194 移除 Desktop.Services 层后，LYBT.All.sln 编译失败：
- **10个编译错误**: 测试代码使用了已移除的类型（AuthService, IUserRepository, IConsultationRepository）
- **8个警告**: 7个项目引用警告 + 1个可空引用警告

## ✅ 修复方案

### Phase 1: 移除项目引用 (7个测试项目)
- 移除 `Desktop.Services.csproj` 引用
- 影响项目:
  * LYBT.Desktop.Users.Tests
  * LYBT.Desktop.Auth.Tests
  * LYBT.Desktop.Patients.Tests
  * LYBT.Desktop.Prescriptions.Tests
  * LYBT.Desktop.Consultation.Tests
  * LYBT.Desktop.Shell.Tests
  * LYBT.ArchTests

### Phase 2a: 更新 ChangePasswordDialogViewModelTests
**修改前**:
```csharp
using LYBT.Desktop.Services.Business;
Mock<AuthService> _mockAuthService;
Mock<ITokenStorageService> _mockTokenStorage;
// ... 复杂的构造函数
```

**修改后**:
```csharp
using LYBT.Desktop.Foundation.Security;
Mock<IAuthenticationService> _mockAuthService;
// 简化构造，只需 IAuthenticationService
```

### Phase 2b: 修正命名空间引用 (6个测试文件)
**修改前**:
```csharp
using LYBT.Desktop.Users.Repositories;        // ❌ 错误命名空间
using LYBT.Desktop.Consultation.Repositories; // ❌ 错误命名空间
```

**修改后**:
```csharp
using LYBT.Desktop.Users.Interfaces;         // ✅ 正确命名空间
using LYBT.Desktop.Consultation.Interfaces;  // ✅ 正确命名空间
```

### Phase 3: 修复可空引用警告
**修改前**:
```csharp
new object[] { 1, 20, (string?)null }  // ⚠️ CS8625 警告
```

**修改后**:
```csharp
new object?[] { 1, 20, null }          // ✅ 消除警告
```

## 🧪 测试验证

```bash
dotnet build LYBT.All.sln -c Release
```

**结果**:
```
已成功生成。
    0 个警告
    0 个错误
```

## 📊 变更统计

- **14个文件修改**:
  - 7 个 `.csproj` 文件（移除项目引用）
  - 7 个 `.cs` 测试文件（命名空间 + Mock 对象更新）
- **代码变更**: +13 行, -39 行

## 🔍 架构合规性

- ✅ 符合 ADR-002: Desktop 已移除 Service 层
- ✅ 测试现在正确引用 `Interfaces` 命名空间
- ✅ `IAuthenticationService` 来自 `Desktop.Foundation.Security`
- ✅ Repository 接口来自各模块的 `Interfaces` 命名空间

## 📝 Checklist

- [x] Phase 1: 移除 7个测试项目的 Desktop.Services 引用
- [x] Phase 2a: 修复 ChangePasswordDialogViewModelTests (AuthService)
- [x] Phase 2b: 修复 6个测试文件的 using 语句
- [x] Phase 3: 修复可空引用警告
- [x] 验证编译 LYBT.All.sln (0 errors, 0 warnings)
- [x] 提交变更并创建 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)