### PR TITLE
[Issue-1211] 修正 Infrastructure 和 Shell 服务命名空间污染

### DIFF
--- a/src/Client/Desktop/Core/LYBT.Desktop.Infrastructure/Services/Navigation/EnhancedNavigationService.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Infrastructure/Services/Navigation/EnhancedNavigationService.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Prism.Regions;
 
-namespace LYBT.Desktop.Services.Navigation
+namespace LYBT.Desktop.Infrastructure.Services
 {
     /// <summary>
     /// 增强导航服务接口

--- a/src/Client/Desktop/Shell/Services/INavigationService.cs
+++ b/src/Client/Desktop/Shell/Services/INavigationService.cs
@@ -1,4 +1,4 @@
-﻿namespace LYBT.Desktop.Services.Navigation
+﻿namespace LYBT.Desktop.Shell.Services
 {
     /// <summary>
     /// 导航服务接口 - 简化版本

--- a/src/Client/Desktop/Shell/Services/INotificationService.cs
+++ b/src/Client/Desktop/Shell/Services/INotificationService.cs
@@ -1,4 +1,4 @@
-﻿namespace LYBT.Desktop.Services.Notifications
+﻿namespace LYBT.Desktop.Shell.Services
 {
     /// <summary>
     /// 通知服务接口 - 简化版本

--- a/src/Client/Desktop/Shell/Services/NotificationService.cs
+++ b/src/Client/Desktop/Shell/Services/NotificationService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Windows;
 using Microsoft.Extensions.Logging;
 
-namespace LYBT.Desktop.Services.Notifications
+namespace LYBT.Desktop.Shell.Services
 {
     /// <summary>
     /// 通知服务实现 - 简化版本

--- a/src/Client/Desktop/Shell/Services/ThemeService.cs
+++ b/src/Client/Desktop/Shell/Services/ThemeService.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 
-namespace LYBT.Desktop.Services.Theming
+namespace LYBT.Desktop.Shell.Services
 {
     /// <summary>
     /// 主题服务接口


### PR DESCRIPTION
## 问题描述

修复 Infrastructure 和 Shell 层服务使用错误的 `Desktop.Services.*` 命名空间的问题。

根据 ADR-002 架构标准，服务应该使用正确的分层命名空间：
- Infrastructure 层服务：`LYBT.Desktop.Infrastructure.*`
- Shell 层服务：`LYBT.Desktop.Shell.*`

## 修改内容

修复了 5 个文件的命名空间：

### Infrastructure 层
1. **EnhancedNavigationService.cs**
   - ❌ `LYBT.Desktop.Services.Navigation`
   - ✅ `LYBT.Desktop.Infrastructure.Services`

### Shell 层
2. **ThemeService.cs**
   - ❌ `LYBT.Desktop.Services.Theming`
   - ✅ `LYBT.Desktop.Shell.Services`

3. **INavigationService.cs**
   - ❌ `LYBT.Desktop.Services.Navigation`
   - ✅ `LYBT.Desktop.Shell.Services`

4. **NotificationService.cs**
   - ❌ `LYBT.Desktop.Services.Notifications`
   - ✅ `LYBT.Desktop.Shell.Services`

5. **INotificationService.cs**
   - ❌ `LYBT.Desktop.Services.Notifications`
   - ✅ `LYBT.Desktop.Shell.Services`

## 验证结果

- ✅ 编译通过：0 错误，0 警告
- ✅ 无引用更新需要（这些接口未被外部 using 语句引用）
- ✅ 符合架构分层标准

## 关联 Issue

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)