### PR TITLE
[Issue-1229] 修复 WPF 启动失败 - 注册 IApiHealthCheckService

### DIFF
--- a/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
@@ -125,10 +125,14 @@ namespace LYBT.Desktop.Shell.Extensions
         private static void RegisterFoundationServices(IContainerRegistry containerRegistry)
         {
             // 认证服务 - Foundation/Security
-            containerRegistry.RegisterSingleton<IAuthenticationService, AuthenticationService>();
+        containerRegistry.RegisterSingleton<IAuthenticationService, AuthenticationService>();
 
-            // Token 存储服务 - Foundation/Security
-            containerRegistry.RegisterSingleton<ITokenStorageService, TokenStorageService>();
+        // Token 存储服务 - Foundation/Security
+        containerRegistry.RegisterSingleton<ITokenStorageService, TokenStorageService>();
+
+        // API 健康检查服务 - Foundation/HealthCheck
+        containerRegistry.RegisterSingleton<LYBT.Desktop.Foundation.HealthCheck.IApiHealthCheckService,
+            LYBT.Desktop.Foundation.HealthCheck.ApiHealthCheckService>();
         }
 
         /// <summary>


### PR DESCRIPTION
## 📋 问题描述

Desktop 应用启动时抛出 `ContainerResolutionException`，无法解析 `MainWindowViewModel` 的依赖项。

## 🔍 根因分析

- `MainWindowViewModel` 构造函数需要 `IApiHealthCheckService` 依赖
- 该服务未在 DI 容器中注册
- DryIoc 容器无法解析依赖，导致启动失败

## 🔧 修复内容

在 `ServiceCollectionExtensions.RegisterFoundationServices` 中添加服务注册：

```csharp
// API 健康检查服务 - Foundation/HealthCheck
containerRegistry.RegisterSingleton<LYBT.Desktop.Foundation.HealthCheck.IApiHealthCheckService,
    LYBT.Desktop.Foundation.HealthCheck.ApiHealthCheckService>();
```

## ✅ 验证

- [x] 编译通过（`dotnet build LYBT.Desktop.sln -c Release`）
- [x] 无编译警告和错误
- [x] 符合 ADR-002 架构标准（Foundation 服务由 Shell 统一注册）
- [x] 生命周期：Singleton（健康检查服务需全局唯一）

## 🎯 关联 Issue

Closes #1229

## 📚 架构合规性

✅ **ADR-002 合规**：
- Foundation 层服务由 Shell 统一注册
- 使用 Singleton 生命周期（基础设施服务）
- 命名空间正确（`LYBT.Desktop.Foundation.HealthCheck`）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)