### PR TITLE
[HOTFIX] 修复 Splash Screen 导致的 MainWindowViewModel 初始化失败

### DIFF
--- a/src/Client/Desktop/Shell/App.xaml.cs
+++ b/src/Client/Desktop/Shell/App.xaml.cs
@@ -88,13 +88,16 @@ public partial class App : PrismApplication
 
     /// <summary>
     /// 初始化主窗口
-    /// Issue #1221: 重写以阻止 Prism 自动显示主窗口
+    /// Issue #1221: 调用 base 初始化，但先不显示窗口
     /// </summary>
     protected override void InitializeShell(Window shell)
     {
-        // 不调用 base.InitializeShell(shell)，因为它会自动显示窗口
-        // 将 shell 设置为 MainWindow 属性，但不显示
-        MainWindow = shell;
+        // 调用 base 以完成 Prism 的初始化（包括 DataContext 设置）
+        base.InitializeShell(shell);
+
+        // 但立即隐藏窗口，让 Splash Screen 先显示
+        // 主窗口将在 OnInitialized 的异步任务完成后显示
+        shell.Hide();
     }
 
     /// <summary>


### PR DESCRIPTION
## 问题描述

合并 PR #1231 后，应用程序启动失败，抛出 `XamlParseException`：

```
System.Windows.Markup.XamlParseException
Message="设置属性'Prism.Mvvm.ViewModelLocator.AutoWireViewModel'时引发了异常。"
Inner Exception: ContainerResolutionException: Unable to resolve resolution root LYBT.Desktop.Shell.ViewModels.MainWindowViewModel
```

## 根本原因

在 `App.xaml.cs` 的 `InitializeShell(Window shell)` 方法中，我们没有调用 `base.InitializeShell(shell)`。

Prism 框架的 `PrismApplication.InitializeShell()` 负责：
1. 设置主窗口的 DataContext
2. 初始化 ViewModelLocator 的自动绑定机制

因为缺少这个调用，MainWindow 的 DataContext 未被设置，导致 Prism 的 AutoWireViewModel 无法正确连接 MainWindowViewModel。

## 解决方案

修改 `InitializeShell()` 方法：

```csharp
protected override void InitializeShell(Window shell)
{
    // ✅ 调用 base 以完成 Prism 的初始化（包括 DataContext 设置）
    base.InitializeShell(shell);

    // 但立即隐藏窗口，让 Splash Screen 先显示
    // 主窗口将在 OnInitialized 的异步任务完成后显示
    shell.Hide();
}
```

## 测试验证

- ✅ 编译通过（无错误）
- ⏳ 等待 CI/CD 检查

## 影响范围

- 仅修改 `App.xaml.cs` 的 `InitializeShell()` 方法
- 不影响其他功能
- 修复 Splash Screen 实现中的致命错误

## 关联 Issue

- 修复了 #1221 实现中的关键缺陷

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>