### PR TITLE
[Issue-1239] 修复 Prism 生命周期违规 - Fail-Fast 错误处理

### DIFF
--- a/src/Client/Desktop/Shell/Services/Bootstrap/ApplicationBootstrapper.cs
+++ b/src/Client/Desktop/Shell/Services/Bootstrap/ApplicationBootstrapper.cs
@@ -76,21 +76,19 @@ namespace LYBT.Desktop.Shell.Services.Bootstrap
         /// <summary>
         /// 初始化错误处理服务
         /// </summary>
+        /// <summary>
+        /// 初始化错误处理服务
+        /// Issue #1239: 移除异常降级处理，让异常向上传播到 Fail-Fast 机制
+        /// </summary>
         public void InitializeErrorHandlingService()
         {
-            try
-            {
-                _logger.LogInformation("注册全局异常处理器");
-                _errorHandlingService.RegisterGlobalExceptionHandlers();
-                _logger.LogInformation("全局异常处理器注册完成");
-            }
-            catch (Exception ex)
-            {
-                // 如果错误处理服务初始化失败，使用基本的错误处理
-                _logger.LogError(ex, "初始化错误处理服务失败");
-                MessageBox.Show($"系统初始化失败 {ex.Message}", "凌隐宝堂 - 系统错误",
-                    MessageBoxButton.OK, MessageBoxImage.Error);
-            }
+            _logger.LogInformation("注册全局异常处理器");
+            
+            // ✅ 不捕获异常，让错误处理服务初始化失败时直接终止应用
+            // 这是关键的基础设施，初始化失败应该触发 Fail-Fast
+            _errorHandlingService.RegisterGlobalExceptionHandlers();
+            
+            _logger.LogInformation("全局异常处理器注册完成");
         }
 
         /// <summary>


### PR DESCRIPTION
## 📋 问题描述

修复 `App.xaml.cs` 和 `ApplicationBootstrapper` 中违反 Prism 生命周期的异步反模式：
1. **OnStartup 已在之前修复**：使用同步调用 `base.OnStartup(e)`，在 `OnInitialized` 中启动异步任务
2. **本次修复**：`ApplicationBootstrapper.InitializeErrorHandlingService` 移除异常降级处理

## 🔧 修复内容

### ApplicationBootstrapper.InitializeErrorHandlingService
**之前（错误）**：
```csharp
public void InitializeErrorHandlingService()
{
    try
    {
        _errorHandlingService.RegisterGlobalExceptionHandlers();
    }
    catch (Exception ex)
    {
        // ❌ 吞掉异常，显示消息框但不终止应用
        MessageBox.Show($"系统初始化失败 {ex.Message}", ...);
    }
}
```

**现在（正确）**：
```csharp
public void InitializeErrorHandlingService()
{
    _logger.LogInformation("注册全局异常处理器");
    
    // ✅ 不捕获异常，让错误处理服务初始化失败时直接终止应用
    // 这是关键的基础设施，初始化失败应该触发 Fail-Fast
    _errorHandlingService.RegisterGlobalExceptionHandlers();
    
    _logger.LogInformation("全局异常处理器注册完成");
}
```

## ✅ 预期效果

### Fail-Fast 机制
- 错误处理服务初始化失败时，异常向上传播到 `App.InitializeApplicationAsync`
- 触发 Fail-Fast 错误对话框，显示清晰的错误信息和可能的解决方案
- 应用终止（`Shutdown(1)`），避免部分初始化状态

### 错误对话框示例
```
应用初始化失败，无法继续运行。

错误类型：ArgumentNullException
错误信息：Value cannot be null. (Parameter 'service')

可能原因：
1. WebAPI服务未启动（检查 http://localhost:5001）
2. 数据库连接失败
3. 配置文件错误

是否查看详细日志？ [是] [否]
```

## 🧪 测试计划

- [ ] 10次正常启动测试（验证无副作用）
- [ ] 异常注入测试（验证 Fail-Fast 对话框）
- [ ] 日志验证（确认异常堆栈完整记录）

## 📦 编译验证

```
dotnet build LYBT.Desktop.sln -c Release --no-restore
已成功生成。
    0 个警告
    0 个错误
```

## 🔗 关联 Issue

Closes #1239

---

**📝 备注**：
- 本次修复专注于移除异常降级处理
- `App.xaml.cs` 的 OnStartup 生命周期已在之前的提交中修复
- 符合 Prism 官方最佳实践和 Fail-Fast 原则