### PR TITLE
feat(formula): 实现GetPendingValidationFormulasAsync获取待验证验方列表 (#1349)

### DIFF
--- a/src/Server/Core/LYBT.Server.Interfaces/Services/IFormulaService.cs
+++ b/src/Server/Core/LYBT.Server.Interfaces/Services/IFormulaService.cs
@@ -75,5 +75,11 @@ namespace LYBT.Server.Interfaces.Services
         /// <param name="herbItemId">待验证的药材项ID</param>
         /// <param name="selectedHerbId">选中的系统药材ID</param>
         Task<ServiceResult> ValidateFormulaHerbAsync(Guid formulaId, Guid herbItemId, Guid selectedHerbId);
+
+        /// <summary>
+        /// 获取待验证的验方列表 (Issue #1349)
+        /// 查询所有 ValidationStatus = Draft 的验方，包含未验证的药材项
+        /// </summary>
+        Task<ServiceResult<List<FormulaDto>>> GetPendingValidationFormulasAsync();
     }
 }

--- a/src/Server/Modules/LYBT.Module.Formula/Services/FormulaService.cs
+++ b/src/Server/Modules/LYBT.Module.Formula/Services/FormulaService.cs
@@ -256,6 +256,36 @@ namespace LYBT.Module.Formula.Services
 
 
         /// <summary>
+        /// 获取待验证的验方列表 (Issue #1349)
+        /// 查询所有 ValidationStatus = Draft 的验方，包含未验证的药材项
+        /// </summary>
+        public async Task<ServiceResult<List<FormulaDto>>> GetPendingValidationFormulasAsync()
+        {
+            try
+            {
+                // 查询所有Draft状态的验方（使用GetAllAsync预加载Herbs避免N+1查询）
+                var allFormulas = await _repository.GetAllAsync();
+                
+                // 过滤出Draft状态的验方
+                var pendingFormulas = allFormulas
+                    .Where(f => f.ValidationStatus == FormulaValidationStatus.Draft)
+                    .ToList();
+
+                // 映射为DTO
+                var formulaDtos = _mapper.Map<List<FormulaDto>>(pendingFormulas);
+
+                _logger.LogInformation("查询到 {Count} 个待验证验方", formulaDtos.Count);
+                return ServiceResult<List<FormulaDto>>.Success(formulaDtos);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "获取待验证验方列表失败");
+                return ServiceResult<List<FormulaDto>>.Failure("获取待验证验方列表失败");
+            }
+        }
+
+
+        /// <summary>
         /// 批量删除验方（软删除）(Issue #1169)
         /// </summary>
         public async Task<ServiceResult<BatchOperationResultDto>> BatchDeleteAsync(List<Guid> ids)


### PR DESCRIPTION
## 📋 关联 Issue
Closes #1349

## 📝 变更概述

实现获取待验证验方列表的功能，查询所有 `ValidationStatus = Draft` 的验方，供验证UI使用。

## ✨ 功能实现

### 1. 新增接口定义
- `IFormulaService.GetPendingValidationFormulasAsync` 方法定义
- 返回类型：`ServiceResult<List<FormulaDto>>`

### 2. 实现查询逻辑
- **查询条件**：`ValidationStatus = Draft`
- **数据加载**：使用 `GetAllAsync()` 预加载关联数据
- **内存过滤**：在内存中过滤出Draft状态的验方
- **DTO映射**：使用AutoMapper映射为 `FormulaDto` 列表

### 3. 关键特性
- ✅ **性能优化**：使用 `GetAllAsync` 避免N+1查询问题
- ✅ **状态过滤**：只返回Draft状态的验方
- ✅ **完整数据**：FormulaDto包含药材项列表（Herbs属性）
- ✅ **日志记录**：记录查询到的待验证验方数量
- ✅ **异常处理**：完善的错误处理和日志

## 🔧 修改的文件

### 接口定义
- `IFormulaService.cs`: 添加 `GetPendingValidationFormulasAsync` 方法声明

### 服务实现
- `FormulaService.cs` (262-285行):
```csharp
public async Task<ServiceResult<List<FormulaDto>>> GetPendingValidationFormulasAsync()
{
    try
    {
        // 查询所有Draft状态的验方（使用GetAllAsync预加载Herbs避免N+1查询）
        var allFormulas = await _repository.GetAllAsync();
        
        // 过滤出Draft状态的验方
        var pendingFormulas = allFormulas
            .Where(f => f.ValidationStatus == FormulaValidationStatus.Draft)
            .ToList();

        // 映射为DTO
        var formulaDtos = _mapper.Map<List<FormulaDto>>(pendingFormulas);

        _logger.LogInformation("查询到 {Count} 个待验证验方", formulaDtos.Count);
        return ServiceResult<List<FormulaDto>>.Success(formulaDtos);
    }
    catch (Exception ex)
    {
        _logger.LogError(ex, "获取待验证验方列表失败");
        return ServiceResult<List<FormulaDto>>.Failure("获取待验证验方列表失败");
    }
}
```

## ✅ 验收标准检查

- [x] GetPendingValidationFormulasAsync 方法已实现
- [x] 查询逻辑正确（只返回Draft状态的验方）
- [x] 包含药材项列表（通过FormulaDto的Herbs属性）
- [x] 性能优化（使用GetAllAsync避免N+1查询）
- [x] 编译成功（0错误，2个已知警告）

## 🏗️ 技术说明

### 查询策略
1. **预加载优化**：使用 `GetAllAsync()` 一次性加载所有验方及其关联的Herbs集合
2. **内存过滤**：在内存中使用LINQ过滤Draft状态验方（验方数量通常不大）
3. **DTO映射**：使用AutoMapper自动映射Entity到DTO

### 数据结构
- **FormulaDto** 包含：
  - 验方基础信息（Name、Category、Effect等）
  - `ValidationStatus` 状态字段
  - `Herbs` 药材项集合（包含 `IsValidated` 标记）

### 使用场景
- 验证UI界面加载待验证验方列表
- 显示每个验方的未验证药材项（`IsValidated = false`）
- 医生选择验方进行药材验证操作

## 📊 编译结果

```
生成成功。
    2 个警告（已知Infrastructure项目警告）
    0 个错误
```

## 🔗 相关文档

- Issue #1349: [FORMULA-6] 实现GetPendingValidationFormulasAsync方法
- Issue #1348: [FORMULA-5] 实现ValidateFormulaHerbAsync方法
- Epic #1343: 验方模块Phase 1完整实现

## 🔄 依赖关系

**前置任务（已完成）**：
- ✅ Issue #1348: ValidateFormulaHerbAsync方法实现

**后续任务（可继续）**：
- ⏭️ Issue #1350-1355: 验证UI功能（ViewModel + View）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>