### PR TITLE
[FORMULA-8] 实现按名称或拼音码查询药材方法 (Issue #1351)

### DIFF
--- a/src/Server/Modules/LYBT.Module.Herbs/Interfaces/IHerbRepository.cs
+++ b/src/Server/Modules/LYBT.Module.Herbs/Interfaces/IHerbRepository.cs
@@ -12,5 +12,12 @@ namespace LYBT.Module.Herbs.Interfaces
         /// 根据名称获取药材
         /// </summary>
         Task<Herb?> GetByNameAsync(string name);
+
+        /// <summary>
+        /// 按名称或拼音码查询药材 (Issue #1351)
+        /// 优先精确匹配名称，其次模糊匹配拼音码
+        /// </summary>
+        /// <param name="searchTerm">搜索词（药材名称或拼音码）</param>
+        Task<Herb?> GetByNameOrPinyinAsync(string searchTerm);
     }
 }

--- a/src/Server/Modules/LYBT.Module.Herbs/Repositories/HerbRepository.cs
+++ b/src/Server/Modules/LYBT.Module.Herbs/Repositories/HerbRepository.cs
@@ -24,5 +24,29 @@ namespace LYBT.Module.Herbs.Repositories
                 .AsNoTracking()
                 .FirstOrDefaultAsync(h => h.Name == name && !h.IsDeleted);
         }
+
+        /// <summary>
+        /// 按名称或拼音码查询药材 (Issue #1351)
+        /// 优先精确匹配名称，其次模糊匹配拼音码
+        /// </summary>
+        public async Task<Herb?> GetByNameOrPinyinAsync(string searchTerm)
+        {
+            // 1. 优先精确匹配名称
+            var exactMatch = await _dbSet
+                .AsNoTracking()
+                .FirstOrDefaultAsync(h => h.Name == searchTerm && !h.IsDeleted);
+
+            if (exactMatch != null)
+                return exactMatch;
+
+            // 2. 模糊匹配拼音码
+            var pinyinMatch = await _dbSet
+                .AsNoTracking()
+                .FirstOrDefaultAsync(h => h.PinYinCode != null
+                    && h.PinYinCode.Contains(searchTerm)
+                    && !h.IsDeleted);
+
+            return pinyinMatch;
+        }
     }
 }


### PR DESCRIPTION
## 📋 关联Issue
Closes #1351

## 📝 实施内容
实现 GetByNameOrPinyinAsync 方法，支持按药材名称或拼音码进行智能查询，用于验方导入时的药材匹配。

## ✅ 核心变更
1. **IHerbRepository接口扩展**
   - 新增 `GetByNameOrPinyinAsync(string searchTerm)` 方法

2. **HerbRepository实现**
   - 优先精确匹配药材名称
   - 未匹配则模糊匹配拼音码
   - 使用AsNoTracking优化查询性能

## 🎯 查询策略
```csharp
public async Task<Herb?> GetByNameOrPinyinAsync(string searchTerm)
{
    // 1. 优先精确匹配名称
    var exactMatch = await _dbSet
        .AsNoTracking()
        .FirstOrDefaultAsync(h => h.Name == searchTerm && !h.IsDeleted);
    
    if (exactMatch != null)
        return exactMatch;
    
    // 2. 模糊匹配拼音码
    var pinyinMatch = await _dbSet
        .AsNoTracking()
        .FirstOrDefaultAsync(h => h.PinYinCode != null
            && h.PinYinCode.Contains(searchTerm)
            && !h.IsDeleted);
    
    return pinyinMatch;
}
```

## ✅ 验收标准
- [x] GetByNameOrPinyinAsync 方法已实现
- [x] 精确匹配逻辑正确（Name字段）
- [x] 拼音码模糊匹配逻辑正确（PinYinCode字段Contains）
- [x] 使用AsNoTracking优化查询性能
- [x] 编译通过，无警告无错误

## 🔧 技术细节
- **两级查询策略**: 先精确后模糊
- **性能优化**: AsNoTracking() 避免实体跟踪开销
- **软删除过滤**: 所有查询都过滤 IsDeleted 标记

## 📦 影响范围
- Server/Modules/LYBT.Module.Herbs/Interfaces
- Server/Modules/LYBT.Module.Herbs/Repositories

## 💡 使用场景
该方法将用于验方导入功能，当Excel中的药材名称无法精确匹配时，通过拼音码进行模糊匹配，提高导入成功率。

🤖 Generated with [Claude Code](https://claude.com/claude-code)