### PR TITLE
feat(prescriptions): 实现Items→ItemRows转换逻辑 (#1360)

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
@@ -93,6 +93,18 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         /// </summary>
         public ObservableCollection<PrescriptionItemViewModel> PrescriptionItems => _dataManager.PrescriptionItems;
 
+        private ObservableCollection<PrescriptionItemRow> _itemRows = new();
+
+        /// <summary>
+        /// 处方项行集合（用于8列表格布局）
+        /// Issue #1360: [ENTRY-2] 实现Items→ItemRows转换逻辑
+        /// </summary>
+        public ObservableCollection<PrescriptionItemRow> ItemRows
+        {
+            get => _itemRows;
+            set => SetProperty(ref _itemRows, value);
+        }
+
         /// <summary>
         /// 选中的处方项
         /// </summary>
@@ -449,6 +461,9 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
                 // 初始计算
                 RecalculatePrice();
 
+                // 初始化ItemRows（Issue #1360）
+                RefreshItemRows();
+
                 Logger.LogInformation("处方编写器初始化完成");
             }
             catch (Exception ex)
@@ -495,6 +510,9 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 
             // 订阅清空事件
             _commandHandler.OnPrescriptionCleared += OnPrescriptionCleared;
+
+            // 订阅处方项集合变化事件（Issue #1360）
+            PrescriptionItems.CollectionChanged += (s, e) => RefreshItemRows();
         }
 
         private void OnPriceRecalculated()
@@ -635,6 +653,36 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         {
             // 命令状态由各自的CanExecute方法控制
             // 这里可以添加额外的状态更新逻辑
+        }
+
+        /// <summary>
+        /// 刷新处方项行集合（Items → ItemRows转换）
+        /// Issue #1360: [ENTRY-2] 实现Items→ItemRows转换逻辑
+        /// </summary>
+        private void RefreshItemRows()
+        {
+            ItemRows.Clear();
+
+            var items = PrescriptionItems;
+            if (items == null || items.Count == 0)
+            {
+                return;
+            }
+
+            // 每4个项目组成一行
+            for (int i = 0; i < items.Count; i += 4)
+            {
+                var row = new PrescriptionItemRow
+                {
+                    Item1 = i < items.Count ? items[i] : null,
+                    Item2 = i + 1 < items.Count ? items[i + 1] : null,
+                    Item3 = i + 2 < items.Count ? items[i + 2] : null,
+                    Item4 = i + 3 < items.Count ? items[i + 3] : null
+                };
+                ItemRows.Add(row);
+            }
+
+            Logger.LogDebug($"已刷新处方项行集合，共 {items.Count} 个项目，{ItemRows.Count} 行");
         }
 
         #endregion


### PR DESCRIPTION
## 📋 关联 Issue
- Closes #1360

## 📝 任务描述
实现处方项集合Items到ItemRows的转换逻辑，支持8列表格布局显示。

## ✅ 变更内容

### 1. 添加ItemRows属性
- 在 `PrescriptionComposerViewModel` 中添加 `ItemRows` 属性
- 类型：`ObservableCollection<PrescriptionItemRow>`
- 用于8列表格布局的数据绑定

### 2. 实现转换逻辑
- 添加 `RefreshItemRows()` 方法
- 每4个处方项组成一行（Item1-Item4）
- 自动处理不足4个项目的情况

### 3. 自动更新机制
- 在 `SubscribeToEvents()` 中订阅 `PrescriptionItems.CollectionChanged` 事件
- 集合变化时自动调用 `RefreshItemRows()`
- 在 `LoadPrescriptionDataAsync()` 初始化时调用 `RefreshItemRows()`

## 🧪 验收标准
- [x] ItemRows 属性已添加
- [x] 转换逻辑正确（每4个项目一行）
- [x] Items 变化时自动更新 ItemRows
- [x] 编译通过无错误
- [x] 代码遵循项目规范

## 📊 编译结果
```
LYBT.Desktop.Prescriptions 模块编译成功
0 个错误，0 个新增警告
```

## 📚 相关文档
- 遵循 MVVM 架构规范
- 使用 WPF 数据绑定模式
- 符合项目代码风格

🤖 Generated with [Claude Code](https://claude.com/claude-code)