### PR TITLE
feat(prescriptions): 设计8列DataGrid XAML布局 (#1361)

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionComposerView.xaml
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionComposerView.xaml
@@ -142,45 +142,94 @@
                     </StackPanel>
                 </Border>
 
-                <!-- 药材列表 -->
-                <DataGrid Grid.Row="1" ItemsSource="{Binding PrescriptionItems}"
+                <!-- 药材列表 (8列表格布局) -->
+                <!-- Issue #1361: [ENTRY-3] 设计8列DataGrid XAML布局 -->
+                <DataGrid Grid.Row="1" ItemsSource="{Binding ItemRows}"
                          AutoGenerateColumns="False" CanUserAddRows="False"
-                         GridLinesVisibility="Horizontal" HeadersVisibility="Column"
+                         GridLinesVisibility="All" HeadersVisibility="Column"
                          Background="White" AlternatingRowBackground="#F8F9FA">
 
                     <DataGrid.Columns>
-                        <DataGridTextColumn Header="序号" Width="60" IsReadOnly="True"
-                                           Binding="{Binding Id}" />
-
-                        <DataGridTextColumn Header="药材名称" Binding="{Binding HerbName}" Width="150" IsReadOnly="True" />
-
-                        <DataGridTextColumn Header="用量" Binding="{Binding Quantity, UpdateSourceTrigger=PropertyChanged}"
-                                           Width="100" />
-
-                        <DataGridTextColumn Header="单位" Binding="{Binding Unit}" Width="60" IsReadOnly="True" />
-
-                        <DataGridTextColumn Header="单价" Binding="{Binding UnitPrice, StringFormat=C}"
-                                           Width="100" IsReadOnly="True" />
-
-                        <DataGridTextColumn Header="小计" Width="100" IsReadOnly="True">
-                            <DataGridTextColumn.Binding>
-                                <Binding Path="Subtotal" StringFormat="C" />
-                            </DataGridTextColumn.Binding>
-                        </DataGridTextColumn>
-
-                        <DataGridTextColumn Header="用法说明" Binding="{Binding Usage}" Width="*" />
-
-                        <DataGridTemplateColumn Header="操作" Width="120">
+                        <!-- 药材1 -->
+                        <DataGridTemplateColumn Header="药材1" Width="2*">
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
-                                    <StackPanel Orientation="Horizontal">
-                                        <Button Content="编辑" Padding="8,2" Margin="0,0,5,0"
-                                               Command="{Binding DataContext.EditHerbCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                               CommandParameter="{Binding}" />
-                                        <Button Content="删除" Padding="8,2" Background="#E74C3C"
-                                               Command="{Binding DataContext.RemoveHerbCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                               CommandParameter="{Binding}" />
-                                    </StackPanel>
+                                    <ComboBox IsEditable="True"
+                                             Text="{Binding Item1.HerbName, UpdateSourceTrigger=PropertyChanged}"
+                                             BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 用量1 -->
+                        <DataGridTemplateColumn Header="用量1" Width="1*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBox Text="{Binding Item1.Quantity, UpdateSourceTrigger=PropertyChanged}"
+                                            BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 药材2 -->
+                        <DataGridTemplateColumn Header="药材2" Width="2*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ComboBox IsEditable="True"
+                                             Text="{Binding Item2.HerbName, UpdateSourceTrigger=PropertyChanged}"
+                                             BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 用量2 -->
+                        <DataGridTemplateColumn Header="用量2" Width="1*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBox Text="{Binding Item2.Quantity, UpdateSourceTrigger=PropertyChanged}"
+                                            BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 药材3 -->
+                        <DataGridTemplateColumn Header="药材3" Width="2*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ComboBox IsEditable="True"
+                                             Text="{Binding Item3.HerbName, UpdateSourceTrigger=PropertyChanged}"
+                                             BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 用量3 -->
+                        <DataGridTemplateColumn Header="用量3" Width="1*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBox Text="{Binding Item3.Quantity, UpdateSourceTrigger=PropertyChanged}"
+                                            BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 药材4 -->
+                        <DataGridTemplateColumn Header="药材4" Width="2*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <ComboBox IsEditable="True"
+                                             Text="{Binding Item4.HerbName, UpdateSourceTrigger=PropertyChanged}"
+                                             BorderThickness="0" Background="Transparent" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+
+                        <!-- 用量4 -->
+                        <DataGridTemplateColumn Header="用量4" Width="1*">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBox Text="{Binding Item4.Quantity, UpdateSourceTrigger=PropertyChanged}"
+                                            BorderThickness="0" Background="Transparent" />
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>


### PR DESCRIPTION
## 📋 关联Issue

Closes #1361 - [ENTRY-3] 设计8列DataGrid XAML布局

Epic: #1343 - MVP "能看诊"
Related: #1360 (ENTRY-2), #1359 (ENTRY-1)

---

## 📝 变更说明

### 修改的文件
- `src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionComposerView.xaml`

### 主要变更
1. **DataGrid布局改造**：将原来的垂直列表布局改为8列水平表格布局
2. **数据绑定切换**：`ItemsSource` 从 `PrescriptionItems` 改为 `ItemRows`
3. **8列结构设计**：
   - 列1：药材1（ComboBox，IsEditable=True）
   - 列2：用量1（TextBox）
   - 列3：药材2（ComboBox，IsEditable=True）
   - 列4：用量2（TextBox）
   - 列5：药材3（ComboBox，IsEditable=True）
   - 列6：用量3（TextBox）
   - 列7：药材4（ComboBox，IsEditable=True）
   - 列8：用量4（TextBox）
4. **列宽比例**：药材列2*，用量列1*（总比例2:1:2:1:2:1:2:1）
5. **实时数据绑定**：所有输入控件使用 `UpdateSourceTrigger=PropertyChanged`

---

## ✅ 验收标准完成情况

- [x] **8列布局已创建**：完成8列DataGrid设计，列结构符合需求
- [x] **列宽比例合理**：药材列2*，用量列1*，显示比例合理
- [x] **绑定到ItemRows正确**：ItemsSource绑定到ItemRows集合，数据路径正确

---

## 🔧 技术细节

### XAML布局特点
```xml
<DataGrid ItemsSource="{Binding ItemRows}" 
         AutoGenerateColumns="False" 
         CanUserAddRows="False"
         GridLinesVisibility="All">
    <DataGrid.Columns>
        <!-- 8列DataGridTemplateColumn -->
        <!-- 药材列：ComboBox (IsEditable=True) -->
        <!-- 用量列：TextBox -->
    </DataGrid.Columns>
</DataGrid>
```

### 数据绑定路径
- `Item1.HerbName`, `Item1.Quantity`
- `Item2.HerbName`, `Item2.Quantity`
- `Item3.HerbName`, `Item3.Quantity`
- `Item4.HerbName`, `Item4.Quantity`

### 控件配置
- ComboBox：`IsEditable=True`, `BorderThickness=0`, `Background=Transparent`
- TextBox：`BorderThickness=0`, `Background=Transparent`
- 数据绑定：`UpdateSourceTrigger=PropertyChanged`

---

## 🏗️ 编译结果

✅ **编译成功**：`LYBT.Desktop.Prescriptions` 模块
- 错误：0个
- 警告：13个（预存在的nullability警告，非本次变更导致）

---

## 📚 参考文档

- [处方录入详细设计](docs/reports/prescription-entry-requirements-2025-10-16.md) - 第1节：表格结构设计

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>