### PR TITLE
feat(prescriptions): 实现验方导入到处方功能 (ENTRY-7 to ENTRY-10)

### DIFF
--- a/src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs
@@ -6,6 +6,9 @@ namespace LYBT.Desktop.Contracts.Api
     /// <summary>
     /// 处方API客户端接口 - 简化版，只包含基础CRUD
     /// </summary>
+    /// <summary>
+    /// 处方API客户端接口 - 简化版，只包含基础CRUD
+    /// </summary>
     public interface IPrescriptionApi
     {
         /// <summary>
@@ -46,5 +49,12 @@ namespace LYBT.Desktop.Contracts.Api
         /// </summary>
         [Refit.Get("/api/v1/prescriptions/medicalcase/{medicalCaseId}")]
         Task<Refit.ApiResponse<List<PrescriptionDto>>> GetPrescriptionsByMedicalCaseIdAsync(Guid medicalCaseId);
+
+        /// <summary>
+        /// 导入验方到处方
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
+        /// </summary>
+        [Refit.Post("/api/v1/prescriptions/{prescriptionId}/import-formula/{formulaId}")]
+        Task<Refit.ApiResponse<ServiceResult>> ImportFormulaAsync(Guid prescriptionId, Guid formulaId);
     }
 }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
@@ -7,6 +7,10 @@ namespace LYBT.Desktop.Prescriptions.Interfaces
     /// 处方数据仓储接口 - Phase 2模块化架构
     /// Issue #1114 - Repository下沉到模块
     /// </summary>
+    /// <summary>
+    /// 处方数据仓储接口 - Phase 2模块化架构
+    /// Issue #1114 - Repository下沉到模块
+    /// </summary>
     public interface IPrescriptionRepository
     {
         Task<PagedResult<PrescriptionDto>> GetPagedAsync(int page = 1, int pageSize = 20, string? keyword = null);
@@ -15,5 +19,13 @@ namespace LYBT.Desktop.Prescriptions.Interfaces
         Task<PrescriptionDto> UpdateAsync(Guid id, PrescriptionUpdateDto dto);
         Task<bool> DeleteAsync(Guid id);
         Task<List<PrescriptionDto>> GetByMedicalCaseIdAsync(Guid medicalCaseId);
+
+        /// <summary>
+        /// 导入验方到处方
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
+        /// </summary>
+        /// <param name="prescriptionId">处方ID</param>
+        /// <param name="formulaId">验方ID</param>
+        Task<ServiceResult> ImportFormulaAsync(Guid prescriptionId, Guid formulaId);
     }
 }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
@@ -62,6 +62,24 @@ namespace LYBT.Desktop.Prescriptions.Repositories
             }
         }
 
+        /// <summary>
+        /// 导入验方到处方
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
+        /// </summary>
+        public async Task<ServiceResult> ImportFormulaAsync(Guid prescriptionId, Guid formulaId)
+        {
+            try
+            {
+                var response = await _api.ImportFormulaAsync(prescriptionId, formulaId);
+                return response.Content ?? ServiceResult.Failure("导入验方失败");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导入验方失败: PrescriptionId={PrescriptionId}, FormulaId={FormulaId}", prescriptionId, formulaId);
+                return ServiceResult.Failure($"导入验方失败：{ex.Message}");
+            }
+        }
+
         #region RepositoryBase抽象方法实现
 
         protected override Task<Refit.ApiResponse<PrescriptionDto>> CallApiGetByIdAsync(Guid id)

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionCommandHandler.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionCommandHandler.cs
@@ -33,6 +33,12 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
         /// 处方清空事件
         /// </summary>
         public event Action? OnPrescriptionCleared;
+
+        /// <summary>
+        /// 导入验方请求事件
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
+        /// </summary>
+        public event Action? OnImportFormulaRequested;
         #endregion
 
         #region 命令定义
@@ -284,10 +290,12 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
 
         /// <summary>
         /// 执行导入验方
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
         /// </summary>
         private void ExecuteImportFormula()
         {
             _logger.LogInformation("执行导入验方");
+            OnImportFormulaRequested?.Invoke();
         }
 
         /// <summary>

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
 using Prism.Regions;
+using Prism.Services.Dialogs;
 
 namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 {
@@ -25,6 +26,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         private readonly IPrescriptionRepository _prescriptionRepository;
         private readonly IMedicalCaseRepository _medicalCaseRepository;
         private readonly IHerbRepository _herbRepository;
+        private readonly IDialogService _dialogService;
 
         #endregion
 
@@ -393,6 +395,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             IPrescriptionRepository prescriptionRepository,
             IMedicalCaseRepository medicalCaseRepository,
             IHerbRepository herbRepository,
+            IDialogService dialogService,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
@@ -408,6 +411,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             _prescriptionRepository = prescriptionRepository ?? throw new ArgumentNullException(nameof(prescriptionRepository));
             _medicalCaseRepository = medicalCaseRepository ?? throw new ArgumentNullException(nameof(medicalCaseRepository));
             _herbRepository = herbRepository ?? throw new ArgumentNullException(nameof(herbRepository));
+            _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
             _dataManager = dataManager ?? throw new ArgumentNullException(nameof(dataManager));
             _calculator = calculator ?? throw new ArgumentNullException(nameof(calculator));
             _validator = validator ?? throw new ArgumentNullException(nameof(validator));
@@ -602,6 +606,9 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             // 订阅清空事件
             _commandHandler.OnPrescriptionCleared += OnPrescriptionCleared;
 
+            // 订阅导入验方请求事件（ENTRY-10）
+            _commandHandler.OnImportFormulaRequested += OnImportFormulaRequested;
+
             // 订阅处方项集合变化事件（Issue #1360）
             PrescriptionItems.CollectionChanged += (s, e) => RefreshItemRows();
         }
@@ -621,6 +628,89 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         {
             // 处方清空后的操作
             RecalculatePrice();
+        }
+
+        /// <summary>
+        /// 处理导入验方请求
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
+        /// </summary>
+        private async void OnImportFormulaRequested()
+        {
+            try
+            {
+                // 显示验方模板选择对话框
+                _dialogService.ShowDialog(
+                    nameof(FormulaTemplateDialogViewModel),
+                    null,
+                    async (result) =>
+                    {
+                        if (result.Result == ButtonResult.OK && result.Parameters.ContainsKey("SelectedFormula"))
+                        {
+                            var selectedFormula = result.Parameters.GetValue<Shared.Models.Contracts.Formula.FormulaDto>("SelectedFormula");
+                            if (selectedFormula != null)
+                            {
+                                await ImportFormulaAsync(selectedFormula.Id);
+                            }
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "显示验方选择对话框时发生异常");
+                await ShowErrorMessageAsync("打开验方选择对话框失败");
+            }
+        }
+
+        /// <summary>
+        /// 导入验方
+        /// ENTRY-10: 集成导入命令到PrescriptionComposerViewModel
+        /// </summary>
+        private async Task ImportFormulaAsync(Guid formulaId)
+        {
+            try
+            {
+                SetIsBusy(true, "正在导入验方...");
+
+                // 获取当前处方ID
+                var prescriptionId = _dataManager.PrescriptionId;
+                if (prescriptionId == Guid.Empty)
+                {
+                    await ShowErrorMessageAsync("当前没有有效的处方，无法导入验方");
+                    return;
+                }
+
+                // 调用Repository导入验方
+                var result = await _prescriptionRepository.ImportFormulaAsync(prescriptionId, formulaId);
+
+                if (result.IsSuccess)
+                {
+                    // 重新加载处方数据（通过重新初始化DataManager）
+                    await _dataManager.InitializeAsync(MedicalCaseId);
+
+                    // 刷新ItemRows
+                    RefreshItemRows();
+
+                    // 重新计算价格
+                    RecalculatePrice();
+
+                    await ShowSuccessMessageAsync(result.ErrorMessage ?? "验方导入成功");
+                    Logger.LogInformation("验方导入成功：FormulaId={FormulaId}, PrescriptionId={PrescriptionId}", formulaId, prescriptionId);
+                }
+                else
+                {
+                    await ShowErrorMessageAsync(result.ErrorMessage ?? "导入验方失败");
+                    Logger.LogWarning("验方导入失败：{ErrorMessage}", result.ErrorMessage);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "导入验方时发生异常：FormulaId={FormulaId}", formulaId);
+                await ShowErrorMessageAsync("导入验方时发生系统错误，请稍后重试");
+            }
+            finally
+            {
+                SetIsBusy(false);
+            }
         }
 
         #endregion
@@ -793,6 +883,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
                     _commandHandler.OnPriceRecalculated -= OnPriceRecalculated;
                     _commandHandler.OnPrescriptionSaved -= OnPrescriptionSaved;
                     _commandHandler.OnPrescriptionCleared -= OnPrescriptionCleared;
+                    _commandHandler.OnImportFormulaRequested -= OnImportFormulaRequested;
                 }
 
                 // 清理事件协调器

--- a/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -508,6 +508,9 @@ namespace LYBT.Module.Prescriptions.Services
         /// <summary>
         /// 导入验方到处方 - 校验验方状态 (Issue #1350)
         /// </summary>
+        /// <summary>
+        /// 导入验方到处方 - 校验验方状态 (Issue #1350, ENTRY-8)
+        /// </summary>
         public async Task<ServiceResult> ImportFormulaIntoPrescriptionAsync(
             Guid prescriptionId,
             Guid formulaId)
@@ -557,6 +560,25 @@ namespace LYBT.Module.Prescriptions.Services
                     };
 
                     prescription.Items.Add(prescriptionItem);
+                }
+
+                // ENTRY-8: 更新 FormulaSource 字段（支持多次导入，逗号分隔）
+                if (string.IsNullOrWhiteSpace(prescription.FormulaSource))
+                {
+                    prescription.FormulaSource = formula.Name;
+                }
+                else
+                {
+                    // 检查是否已经包含该验方名称，避免重复
+                    var existingSources = prescription.FormulaSource
+                        .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(s => s.Trim())
+                        .ToList();
+
+                    if (!existingSources.Contains(formula.Name))
+                    {
+                        prescription.FormulaSource = $"{prescription.FormulaSource},{formula.Name}";
+                    }
                 }
 
                 await _repository.UpdateAsync(prescription);

--- a/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -293,6 +293,50 @@ namespace LYBT.WebAPI.Controllers
             }
         }
 
+
+        /// <summary>
+        /// 导入验方到处方 (ENTRY-10)
+        /// </summary>
+        /// <param name="prescriptionId">处方ID</param>
+        /// <param name="formulaId">验方ID</param>
+        [HttpPost("{prescriptionId}/import-formula/{formulaId}")]
+        [ProducesResponseType(typeof(ApiResponse<ServiceResult>), 200)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ApiResponse<ServiceResult>>> ImportFormula(
+            Guid prescriptionId,
+            Guid formulaId)
+        {
+            try
+            {
+                var prescriptionValidation = ValidateGuid<ServiceResult>(prescriptionId, "处方ID");
+                if (prescriptionValidation != null)
+                {
+                    return prescriptionValidation;
+                }
+
+                var formulaValidation = ValidateGuid<ServiceResult>(formulaId, "验方ID");
+                if (formulaValidation != null)
+                {
+                    return formulaValidation;
+                }
+
+                var result = await _service.ImportFormulaIntoPrescriptionAsync(prescriptionId, formulaId);
+
+                if (!result.IsSuccess)
+                {
+                    return BusinessFail<ServiceResult>(result.ErrorMessage ?? "导入验方失败", ApiErrorCodes.DATASAVEFAILED);
+                }
+
+                LogOperation("导入验方到处方成功", new { prescriptionId, formulaId }, prescriptionId);
+                return Success(result, result.ErrorMessage ?? "导入成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<ServiceResult>(ex, "导入验方", new { prescriptionId, formulaId });
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## 📋 关联 Epic
- Epic: #1343 (MVP功能完成)
- Phase: Phase 2 - Formula Import (验方导入)

## 📝 变更摘要

完成 ENTRY-7 到 ENTRY-10，实现完整的验方导入到处方功能。

### ENTRY-7: 字段验证 ✅
- **结果**: FormulaSource 字段已存在于 PrescriptionModel 和相关 DTOs
- **文件**: `PrescriptionModel.cs`, `PrescriptionDtos.cs`
- **状态**: 无需变更

### ENTRY-8: 服务层增强 ✅
- **增强**: `ImportFormulaIntoPrescriptionAsync` 方法
- **新功能**:
  - FormulaSource 字段自动更新（初次设置 / 追加）
  - 支持多次导入，逗号分隔
  - 重复验方名称检测
- **文件**: `src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs`

### ENTRY-9: 验方过滤验证 ✅
- **结果**: Issue #1354 已实现验证状态过滤
- **功能**: FormulaTemplateDialogViewModel 仅显示已验证验方（ValidationStatus = Validated）
- **状态**: 无需变更

### ENTRY-10: 客户端完整集成 ✅

#### API 层变更
- `IPrescriptionApi.cs`: 添加 ImportFormulaAsync 接口
  - Route: `POST /api/v1/prescriptions/{prescriptionId}/import-formula/{formulaId}`
- `PrescriptionsController.cs`: 添加 ImportFormula 端点
  - 验证处方ID和验方ID
  - 调用服务层导入方法
  - 记录操作日志

#### Repository 层变更
- `IPrescriptionRepository.cs`: 添加 ImportFormulaAsync 方法签名
- `PrescriptionRepository.cs`: 实现导入验方调用逻辑

#### ViewModel 层变更
- `PrescriptionCommandHandler.cs`:
  - 添加 OnImportFormulaRequested 事件
  - ExecuteImportFormula 触发事件
  
- `PrescriptionComposerViewModel.cs`:
  - 添加 IDialogService 依赖注入
  - 添加 using Prism.Services.Dialogs;
  - 订阅 OnImportFormulaRequested 事件
  - 实现 OnImportFormulaRequested 事件处理器（显示验方选择对话框）
  - 实现 ImportFormulaAsync 方法：
    - 调用 Repository 导入验方
    - 导入成功后重新初始化 DataManager
    - 自动刷新 ItemRows
    - 自动重新计算价格
    - 显示成功/失败消息
  - 在 Dispose 中取消事件订阅

## 🏗️ 技术架构

```
用户点击导入按钮
    ↓
PrescriptionCommandHandler.ExecuteImportFormula()
    ↓ (触发事件)
PrescriptionComposerViewModel.OnImportFormulaRequested()
    ↓ (显示对话框)
FormulaTemplateDialogViewModel (仅显示已验证验方)
    ↓ (用户选择)
PrescriptionComposerViewModel.ImportFormulaAsync(formulaId)
    ↓
IPrescriptionRepository.ImportFormulaAsync()
    ↓
IPrescriptionApi.ImportFormulaAsync() (Refit)
    ↓
PrescriptionsController.ImportFormula() (REST API)
    ↓
PrescriptionService.ImportFormulaIntoPrescriptionAsync()
    ↓
更新 Prescription.Items + FormulaSource
    ↓ (返回成功)
PrescriptionComposerViewModel 刷新数据和价格
```

## ✅ 验收标准

### 已完成
- [x] FormulaSource 字段存在且正确配置
- [x] 服务层支持导入验方并更新 FormulaSource
- [x] 验方选择对话框仅显示已验证验方
- [x] Client → API → Service 完整调用链实现
- [x] 导入成功后自动刷新数据
- [x] 导入成功后自动重新计算价格
- [x] 事件驱动架构解耦命令处理
- [x] 所有代码编译通过（0个错误）

### 待测试 (ENTRY-11)
- [ ] 功能测试：启动应用手动测试验方导入流程
- [ ] 验证验方过滤正确（仅显示已验证）
- [ ] 验证导入后处方项自动填充
- [ ] 验证导入后价格自动计算
- [ ] 验证 FormulaSource 字段正确记录
- [ ] 验证多次导入时逗号分隔
- [ ] 验证重复验方名称检测

## 📊 变更统计
- **文件变更**: 7 个文件
- **代码行数**: +205 行
- **涉及层级**: Client (API/Repository/ViewModel) + Server (Service/Controller)

## 🧪 测试计划 (ENTRY-11)

### 环境准备
1. 启动 WebAPI: `dotnet run --project src/Server/Services/LYBT.WebAPI/LYBT.WebAPI.csproj`
2. 启动桌面端: `dotnet run --project src/Client/Desktop/LYBT.Desktop.Main/LYBT.Desktop.Main.csproj`

### 测试步骤
1. 登录桌面端应用
2. 创建或打开一个处方编辑界面（需要关联医案）
3. 点击"导入验方"按钮
4. 验证验方选择对话框只显示已验证验方
5. 选择一个验方，点击确认
6. 验证：
   - 处方项列表自动填充验方药材
   - 价格自动重新计算
   - 显示"验方导入成功"提示
   - 保存处方后 FormulaSource 字段包含验方名称

## 📚 相关文档
- Epic #1343: MVP功能完成
- Issue #1354: 验方模板选择对话框仅显示已验证验方（已完成）
- `.spec-workflow/specs/formula-import/` (如有 Spec 文档)

## 🔗 依赖任务
- Depends on: Issue #1354 (已完成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)