### PR TITLE
[RULE-2] 实现一诊断一处方业务约束 (#1423)

### DIFF
--- a/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -102,11 +102,24 @@ namespace LYBT.Module.Prescriptions.Services
         /// <summary>
         /// 创建处方 - 仅在独立创建时使用
         /// 注意：推荐通过MedicalCase聚合根创建完整的诊疗流程
+        /// Issue #1423: RULE-2 - 一诊断一处方约束
         /// </summary>
         public async Task<ServiceResult<PrescriptionDto>> CreateAsync(PrescriptionCreateDto dto)
         {
             try
             {
+                // RULE-2: 检查该诊断是否已有处方（一诊断一处方约束）
+                // 注意：Consultation使用共享主键（ConsultationId == MedicalCaseId）
+                if (dto.ConsultationId.HasValue)
+                {
+                    var existingPrescriptions = await _repository.GetByMedicalCaseIdAsync(dto.ConsultationId.Value);
+                    if (existingPrescriptions.Any())
+                    {
+                        _logger.LogWarning("创建处方失败：诊断 {ConsultationId} 已有处方", dto.ConsultationId.Value);
+                        return ServiceResult<PrescriptionDto>.Failure("该诊断已有处方，不可重复创建");
+                    }
+                }
+
                 var entity = _mapper.Map<PrescriptionEntity>(dto);
 
                 // 注意：处方总价在DTO层计算，实体层不存储


### PR DESCRIPTION
## 📋 关联Issue
Closes #1423

## 📝 变更说明
实现业务规则RULE-2：一诊断一处方约束（数据验证层）

**核心逻辑**：
- 在 `PrescriptionService.CreateAsync` 方法中添加约束检查
- 使用 `ConsultationId` 查询现有处方（共享主键模式：ConsultationId == MedicalCaseId）
- 如果该诊断已有处方，返回失败信息，禁止重复创建

**技术实现**：
```csharp
// Consultation使用共享主键（ConsultationId == MedicalCaseId）
if (dto.ConsultationId.HasValue)
{
    var existingPrescriptions = await _repository.GetByMedicalCaseIdAsync(dto.ConsultationId.Value);
    if (existingPrescriptions.Any())
    {
        return ServiceResult<PrescriptionDto>.Failure("该诊断已有处方，不可重复创建");
    }
}
```

## ✅ 测试验证
- [x] 编译通过（Release模式）
- [x] 业务逻辑验证：使用ConsultationId查询

## 📂 影响文件
- `src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs`

## 🔗 关联任务
Epic: #1343 - MVP核心功能实现
- [x] RULE-1: 一病案一诊断约束（已在ConsultationService实现）
- [x] RULE-2: 一诊断一处方约束（本PR）
- [ ] RULE-3: 当天可改隔日锁定
- [ ] RULE-4: UI只读模式提示
- [ ] RULE-5: 业务规则测试

## 📚 文档影响
无需文档更新（业务规则实现，不影响API接口）

🤖 Generated with [Claude Code](https://claude.com/claude-code)