### PR TITLE
feat(business-rules): 实现当天可改隔日锁定逻辑 (#1423)

### DIFF
--- a/src/Server/Modules/LYBT.Module.Consultation/Services/ConsultationService.cs
+++ b/src/Server/Modules/LYBT.Module.Consultation/Services/ConsultationService.cs
@@ -128,6 +128,10 @@ namespace LYBT.Module.Consultation.Services
             }
         }
 
+        /// <summary>
+        /// 更新诊疗记录
+        /// Issue #1423: RULE-3 - 当天可改隔日锁定
+        /// </summary>
         public async Task<ServiceResult<ConsultationDto>> UpdateAsync(Guid id, ConsultationUpdateDto dto)
         {
             try
@@ -135,6 +139,13 @@ namespace LYBT.Module.Consultation.Services
                 var entity = await _repository.GetByIdWithDetailsAsync(id);
                 if (entity == null)
                     return ServiceResult<ConsultationDto>.Failure("诊疗记录不存在");
+
+                // RULE-3: 当天可改隔日锁定 - 只能修改创建当天的记录
+                if (entity.CreatedAt.Date != DateTime.Today)
+                {
+                    _logger.LogWarning("更新诊疗记录失败：记录 {ConsultationId} 创建于 {CreatedDate}，已过可修改期限", id, entity.CreatedAt.Date);
+                    return ServiceResult<ConsultationDto>.Failure("该诊疗记录已超过可修改期限（仅限创建当天可修改）");
+                }
 
                 _mapper.Map(dto, entity);
                 var result = await _repository.UpdateAsync(entity);

--- a/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -122,6 +122,10 @@ namespace LYBT.Module.Prescriptions.Services
             }
         }
 
+        /// <summary>
+        /// 更新处方
+        /// Issue #1423: RULE-3 - 当天可改隔日锁定
+        /// </summary>
         public async Task<ServiceResult<PrescriptionDto>> UpdateAsync(Guid id, PrescriptionUpdateDto dto)
         {
             try
@@ -129,6 +133,13 @@ namespace LYBT.Module.Prescriptions.Services
                 var entity = await _repository.GetByIdAsync(id);
                 if (entity == null)
                     return ServiceResult<PrescriptionDto>.Failure("处方不存在");
+
+                // RULE-3: 当天可改隔日锁定 - 只能修改创建当天的记录
+                if (entity.CreatedAt.Date != DateTime.Today)
+                {
+                    _logger.LogWarning("更新处方失败：记录 {PrescriptionId} 创建于 {CreatedDate}，已过可修改期限", id, entity.CreatedAt.Date);
+                    return ServiceResult<PrescriptionDto>.Failure("该处方已超过可修改期限（仅限创建当天可修改）");
+                }
 
                 _mapper.Map(dto, entity);
                 var result = await _repository.UpdateAsync(entity);


### PR DESCRIPTION
## 📋 关联 Issue
Closes #1423 (RULE-3)

## 📝 实现内容
实现业务规则 RULE-3：当天可改隔日锁定逻辑

### 修改文件
- `ConsultationService.UpdateAsync` (lines 143-147): 添加创建日期检查
- `PrescriptionService.UpdateAsync` (lines 134-138): 添加创建日期检查
- 验证 `MedicalCaseRules.CanEdit` (line 38): 已包含相同逻辑

### 业务规则
- **检查逻辑**: `entity.CreatedAt.Date != DateTime.Today`
- **限制说明**: 仅允许修改创建当天的记录，隔日后自动锁定
- **失败提示**: "该记录已超过可修改期限（仅限创建当天可修改）"

## ✅ 验证结果
- ✅ 编译成功（0 errors）
- ✅ 三个模块逻辑一致（MedicalCase、Consultation、Prescription）
- ✅ 日志记录完整（记录失败原因和创建日期）

## 📚 相关文档
- Issue #1423: 业务规则实现（RULE-1 to RULE-5）
- Epic #1343: MVP核心功能实现

## 🎯 下一步
- RULE-4: UI提示：隔日后显示"只读"模式
- RULE-5: 测试业务规则约束

🤖 Generated with [Claude Code](https://claude.com/claude-code)