### PR TITLE
feat(prescriptions): 调整ClonePrescriptionAsync支持跨诊疗记录克隆 (#1373)

### DIFF
--- a/src/Server/Core/LYBT.Server.Interfaces/Services/IPrescriptionService.cs
+++ b/src/Server/Core/LYBT.Server.Interfaces/Services/IPrescriptionService.cs
@@ -55,9 +55,22 @@ namespace LYBT.Server.Interfaces.Services
         Task<ServiceResult<string>> GeneratePrescriptionNoAsync();
 
         /// <summary>
-        /// 克隆处方 - 复制处方并创建新实例 (Issue #1167)
+        /// 克隆处方（旧版） - 复制处方到同一病历 (Issue #1167)
+        /// 已弃用，请使用 ClonePrescriptionAsync
         /// </summary>
+        [Obsolete("请使用 ClonePrescriptionAsync(Guid sourcePrescriptionId, Guid targetConsultationId) 替代")]
         Task<ServiceResult<PrescriptionDto>> CloneAsync(Guid prescriptionId);
+
+        /// <summary>
+        /// 克隆处方 - 复制处方到指定诊疗记录 (Issue #1373 ENTRY-15)
+        /// 支持从历史处方复制到新的诊疗记录/病历
+        /// </summary>
+        /// <param name="sourcePrescriptionId">源处方ID</param>
+        /// <param name="targetConsultationId">目标诊疗记录ID（与MedicalCase共享主键）</param>
+        /// <returns>新创建的处方DTO</returns>
+        Task<ServiceResult<PrescriptionDto>> ClonePrescriptionAsync(
+            Guid sourcePrescriptionId,
+            Guid targetConsultationId);
 
         /// <summary>
         /// 获取处方统计数据 (Issue #1163)

--- a/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -446,49 +446,65 @@ namespace LYBT.Module.Prescriptions.Services
 
 
         /// <summary>
-        /// 克隆处方 - 复制处方并创建新实例 (Issue #1167)
+        /// 克隆处方 - 复制处方到指定诊疗记录 (Issue #1373 ENTRY-15)
+        /// 支持从历史处方复制到新的诊疗记录/病历
         /// </summary>
-        public async Task<ServiceResult<PrescriptionDto>> CloneAsync(Guid prescriptionId)
+        /// <param name="sourcePrescriptionId">源处方ID</param>
+        /// <param name="targetConsultationId">目标诊疗记录ID（与MedicalCase共享主键）</param>
+        /// <returns>新创建的处方DTO</returns>
+        public async Task<ServiceResult<PrescriptionDto>> ClonePrescriptionAsync(
+            Guid sourcePrescriptionId,
+            Guid targetConsultationId)
         {
             try
             {
-                // 获取原始处方（包含药材项）
-                var originalPrescription = await _repository.GetByIdWithItemsAsync(prescriptionId);
-                if (originalPrescription == null)
+                // 获取源处方（包含药材项）
+                var sourcePrescription = await _repository.GetByIdWithItemsAsync(sourcePrescriptionId);
+                if (sourcePrescription == null)
                 {
                     return ServiceResult<PrescriptionDto>.Failure("未找到要克隆的处方");
                 }
 
-                // 创建克隆处方
+                // 根据targetConsultationId找到目标MedicalCase（Consultation与MedicalCase共享主键）
+                var targetMedicalCase = await _medicalCaseRepository.GetByIdAsync(targetConsultationId);
+                if (targetMedicalCase == null)
+                {
+                    return ServiceResult<PrescriptionDto>.Failure($"未找到目标诊疗记录对应的病历（ID: {targetConsultationId}）");
+                }
+
+                // 创建克隆处方，关联到目标病历
                 var clonedPrescription = new PrescriptionEntity
                 {
                     Id = Guid.NewGuid(),
-                    MedicalCaseId = originalPrescription.MedicalCaseId,
-                    PatientId = originalPrescription.PatientId,
-                    UserId = originalPrescription.UserId,
-                    Indication = originalPrescription.Indication,
-                    DosageCount = originalPrescription.DosageCount,
-                    Discount = originalPrescription.Discount,
-                    Advice = originalPrescription.Advice,
-                    FormulaSource = originalPrescription.FormulaSource,
+                    MedicalCaseId = targetMedicalCase.Id, // 关联到目标病历
+                    PatientId = targetMedicalCase.PatientId, // 使用目标病历的患者
+                    UserId = sourcePrescription.UserId, // 保留原开方医生
+                    Indication = sourcePrescription.Indication, // 保留适应症
+                    DosageCount = sourcePrescription.DosageCount,
+                    Discount = sourcePrescription.Discount,
+                    Advice = sourcePrescription.Advice,
+
+                    // TODO: ENTRY-7完成后，这里改为ReferencedFormulas字段
+                    FormulaSource = sourcePrescription.FormulaSource, // 保留验方来源
+
                     Status = PrescriptionStatus.Draft, // 克隆的处方默认为草稿状态
-                    Remark = originalPrescription.Remark,
+                    Remark = sourcePrescription.Remark,
                     PrintVersion = 1, // 重置打印版本
                     LastPrintedAt = null, // 清空打印时间
                     PrintCount = 0, // 重置打印次数
+                    IsPrinted = false, // 重置打印状态
                     CreatedAt = DateTime.Now,
                     UpdatedAt = DateTime.Now,
-                    
-                    // 复制药材项（稍后设置PrescriptionId）
+
                     Items = new List<PrescriptionItemEntity>()
                 };
 
                 var savedPrescription = await _repository.AddAsync(clonedPrescription);
-                
-                // 复制药材项
-                if (originalPrescription.Items != null && originalPrescription.Items.Any())
+
+                // 克隆所有药材项
+                if (sourcePrescription.Items != null && sourcePrescription.Items.Any())
                 {
-                    foreach (var item in originalPrescription.Items)
+                    foreach (var item in sourcePrescription.Items)
                     {
                         savedPrescription.Items.Add(new PrescriptionItemEntity
                         {
@@ -504,11 +520,41 @@ namespace LYBT.Module.Prescriptions.Services
                         });
                     }
                 }
-                
+
                 await _repository.SaveChangesAsync();
+
+                _logger.LogInformation("处方克隆成功，源处方ID：{SourceId}，目标诊疗ID：{TargetConsultationId}，新处方ID：{NewId}，药材数量：{ItemCount}",
+                    sourcePrescriptionId, targetConsultationId, savedPrescription.Id, savedPrescription.Items.Count);
 
                 var prescriptionDto = _mapper.Map<PrescriptionDto>(savedPrescription);
                 return ServiceResult<PrescriptionDto>.Success(prescriptionDto);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "克隆处方时发生错误，源处方ID：{SourceId}，目标诊疗ID：{TargetConsultationId}",
+                    sourcePrescriptionId, targetConsultationId);
+                return ServiceResult<PrescriptionDto>.Failure($"克隆处方失败：{ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 克隆处方（旧版） - 复制处方到同一病历 (Issue #1167)
+        /// 已弃用，请使用 ClonePrescriptionAsync
+        /// </summary>
+        [Obsolete("请使用 ClonePrescriptionAsync(Guid sourcePrescriptionId, Guid targetConsultationId) 替代")]
+        public async Task<ServiceResult<PrescriptionDto>> CloneAsync(Guid prescriptionId)
+        {
+            try
+            {
+                // 获取原始处方
+                var originalPrescription = await _repository.GetByIdWithItemsAsync(prescriptionId);
+                if (originalPrescription == null)
+                {
+                    return ServiceResult<PrescriptionDto>.Failure("未找到要克隆的处方");
+                }
+
+                // 调用新版克隆方法，克隆到同一MedicalCase
+                return await ClonePrescriptionAsync(prescriptionId, originalPrescription.MedicalCaseId);
             }
             catch (Exception ex)
             {

--- a/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -254,13 +254,15 @@ namespace LYBT.WebAPI.Controllers
 
 
         /// <summary>
-        /// 克隆处方 - 复制处方作为新处方 (Issue #1167)
+        /// 克隆处方（旧版） - 复制处方到同一病历 (Issue #1167)
+        /// 已弃用，请使用 ClonePrescriptionTo
         /// </summary>
         /// <param name="id">原处方ID</param>
         /// <returns>新创建的处方副本</returns>
         [HttpPost("{id}/copy")]
         [ProducesResponseType(typeof(ApiResponse<PrescriptionDto>), 200)]
         [ProducesResponseType(404)]
+        [Obsolete("请使用 POST /prescriptions/{id}/clone-to/{targetConsultationId} 替代")]
         public async Task<ActionResult<ApiResponse<PrescriptionDto>>> CopyPrescription(Guid id)
         {
             try
@@ -271,18 +273,20 @@ namespace LYBT.WebAPI.Controllers
                     return validation;
                 }
 
+                #pragma warning disable CS0618 // 类型或成员已过时
                 var result = await _service.CloneAsync(id);
-                
+                #pragma warning restore CS0618
+
                 if (!result.IsSuccess || result.Data == null)
                 {
                     return NotFound<PrescriptionDto>(
-                        result.ErrorMessage ?? "处方不存在", 
+                        result.ErrorMessage ?? "处方不存在",
                         ApiErrorCodes.PRESCRIPTIONNOTFOUND);
                 }
 
                 // 记录操作日志
-                LogOperation("克隆处方", 
-                    new { OriginalId = id, NewId = result.Data.Id }, 
+                LogOperation("克隆处方（同一病历）",
+                    new { OriginalId = id, NewId = result.Data.Id },
                     result.Data.Id);
 
                 return Success(result.Data, "处方克隆成功");
@@ -290,6 +294,56 @@ namespace LYBT.WebAPI.Controllers
             catch (Exception ex)
             {
                 return HandleException<PrescriptionDto>(ex, "克隆处方", id);
+            }
+        }
+
+        /// <summary>
+        /// 克隆处方到指定诊疗记录 - 支持从历史处方复制 (Issue #1373 ENTRY-15)
+        /// </summary>
+        /// <param name="sourcePrescriptionId">源处方ID</param>
+        /// <param name="targetConsultationId">目标诊疗记录ID</param>
+        /// <returns>新创建的处方副本</returns>
+        [HttpPost("{sourcePrescriptionId}/clone-to/{targetConsultationId}")]
+        [ProducesResponseType(typeof(ApiResponse<PrescriptionDto>), 200)]
+        [ProducesResponseType(404)]
+        [ProducesResponseType(400)]
+        public async Task<ActionResult<ApiResponse<PrescriptionDto>>> ClonePrescriptionTo(
+            Guid sourcePrescriptionId,
+            Guid targetConsultationId)
+        {
+            try
+            {
+                var sourceValidation = ValidateGuid<PrescriptionDto>(sourcePrescriptionId, "源处方ID");
+                if (sourceValidation != null)
+                {
+                    return sourceValidation;
+                }
+
+                var targetValidation = ValidateGuid<PrescriptionDto>(targetConsultationId, "目标诊疗记录ID");
+                if (targetValidation != null)
+                {
+                    return targetValidation;
+                }
+
+                var result = await _service.ClonePrescriptionAsync(sourcePrescriptionId, targetConsultationId);
+
+                if (!result.IsSuccess || result.Data == null)
+                {
+                    return NotFound<PrescriptionDto>(
+                        result.ErrorMessage ?? "克隆处方失败",
+                        ApiErrorCodes.PRESCRIPTIONNOTFOUND);
+                }
+
+                // 记录操作日志
+                LogOperation("克隆处方到新诊疗",
+                    new { SourcePrescriptionId = sourcePrescriptionId, TargetConsultationId = targetConsultationId, NewPrescriptionId = result.Data.Id },
+                    result.Data.Id);
+
+                return Success(result.Data, "处方克隆成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<PrescriptionDto>(ex, "克隆处方到新诊疗", new { sourcePrescriptionId, targetConsultationId });
             }
         }
 


### PR DESCRIPTION
## 📋 关联 Issue

Closes #1373

## 📝 变更说明

实现ENTRY-15需求，支持从历史处方复制到不同的诊疗记录/病历。

### 主要功能

1. **新增ClonePrescriptionAsync方法**
   - 参数: `sourcePrescriptionId` + `targetConsultationId`
   - 根据targetConsultationId找到对应MedicalCase并创建新处方
   - 支持跨病历/跨患者的处方克隆

2. **完整克隆逻辑**
   - ✅ 克隆所有药材项（HerbId, Quantity, Unit, UnitPrice等）
   - ✅ 保留验方来源（FormulaSource字段）
   - ✅ 重置打印状态（PrintVersion=1, PrintCount=0）
   - ✅ 新处方默认状态为Draft

3. **API端点**
   - 新增: `POST /api/v1/prescriptions/{sourcePrescriptionId}/clone-to/{targetConsultationId}`
   - 保留旧端点向后兼容（标记为Obsolete）

### 技术实现细节

- **关键关系**: Consultation与MedicalCase共享主键（1:1关系）
- **数据关联**: Prescription → MedicalCase → Patient
- **字段说明**: 临时使用FormulaSource字段，待ENTRY-7完成后改为ReferencedFormulas

### 代码变更

#### src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
- 新增 `ClonePrescriptionAsync(Guid, Guid)` 方法
- 旧版 `CloneAsync(Guid)` 标记为Obsolete并委托给新方法

#### src/Server/Core/LYBT.Server.Interfaces/Services/IPrescriptionService.cs  
- 添加 `ClonePrescriptionAsync` 接口定义
- 标记 `CloneAsync` 为Obsolete

#### src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
- 新增 `ClonePrescriptionTo` API端点
- 保留 `CopyPrescription` 端点（Obsolete）

## ✅ 测试验证

### 编译验证
```
dotnet build LYBT.All.sln -c Release --no-restore
已成功生成 (4个警告，0个错误)
```

### 单元测试
```
dotnet test --filter "FullyQualifiedName~PrescriptionService"
测试总数: 16
通过数: 16
总时间: 11.6754秒
```

## 📚 验收标准

- [x] ClonePrescriptionAsync 方法已实现
- [x] 药材项完整克隆
- [x] FormulaSource字段保留（临时替代ReferencedFormulas）
- [x] 关联到新的诊疗记录
- [x] 所有单元测试通过
- [x] API端点已添加

## 🔗 相关任务

Epic: #1343 MVP "能看诊" 功能实现
依赖: #1372 (ENTRY-14) ✅ 已完成

## 💡 后续优化

- [ ] ENTRY-7完成后，将FormulaSource改为ReferencedFormulas字段
- [ ] 考虑添加ClonePrescriptionAsync的单元测试

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)