### PR TITLE
feat(prescriptions): 为SearchPrescriptionsAsync添加API端点 (Issue #1372 ENTRY-14)

### DIFF
--- a/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -347,6 +347,37 @@ namespace LYBT.WebAPI.Controllers
             }
         }
 
+        /// <summary>
+        /// 搜索处方 - 按患者姓名或症状/诊断关键字 (Issue #1372 ENTRY-14)
+        /// </summary>
+        /// <param name="patientName">患者姓名关键字（可空）</param>
+        /// <param name="symptomKeyword">症状/诊断关键字（可空）</param>
+        /// <returns>处方搜索结果列表</returns>
+        [HttpGet("search")]
+        [ResponseCache(Duration = 300, Location = ResponseCacheLocation.Any)]
+        [ProducesResponseType(typeof(ApiResponse<List<PrescriptionSearchResultDto>>), 200)]
+        [ProducesResponseType(400)]
+        public async Task<ActionResult<ApiResponse<List<PrescriptionSearchResultDto>>>> Search(
+            [FromQuery] string? patientName = null,
+            [FromQuery] string? symptomKeyword = null)
+        {
+            try
+            {
+                // 至少需要一个搜索条件
+                if (string.IsNullOrWhiteSpace(patientName) && string.IsNullOrWhiteSpace(symptomKeyword))
+                {
+                    return ValidationFail<List<PrescriptionSearchResultDto>>("请至少提供一个搜索条件（患者姓名或症状关键字）");
+                }
+
+                var result = await _service.SearchPrescriptionsAsync(patientName, symptomKeyword);
+                return HandleServiceResult(result, "查询成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<List<PrescriptionSearchResultDto>>(ex, "搜索处方", new { patientName, symptomKeyword });
+            }
+        }
+
         #endregion
     }
 }

--- a/tests/UnitTests/Server/Modules/LYBT.Module.Prescriptions.Tests/Services/PrescriptionServiceTests.cs
+++ b/tests/UnitTests/Server/Modules/LYBT.Module.Prescriptions.Tests/Services/PrescriptionServiceTests.cs
@@ -589,6 +589,45 @@ namespace LYBT.Module.Prescriptions.Tests.Services
 
         #endregion
 
+        #region SearchPrescriptionsAsync Tests
+
+        [Fact]
+        public async Task SearchPrescriptionsAsync_WithNoParameters_ShouldReturnEmptyList()
+        {
+            // Arrange - 无需参数
+
+            // Act
+            var result = await _prescriptionService.SearchPrescriptionsAsync(null, null);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            result.Data.Should().NotBeNull();
+            result.Data.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task SearchPrescriptionsAsync_WithEmptyStrings_ShouldReturnEmptyList()
+        {
+            // Arrange
+            var emptyPatientName = "   ";
+            var emptySymptomKeyword = "";
+
+            // Act
+            var result = await _prescriptionService.SearchPrescriptionsAsync(emptyPatientName, emptySymptomKeyword);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            result.Data.Should().NotBeNull();
+            result.Data.Should().BeEmpty();
+        }
+
+        // Note: 完整的集成测试将在IntegrationTests项目中进行
+        // 这里的单元测试仅验证基本逻辑和边界条件
+
+        #endregion
+
         public override void Dispose()
         {
             base.Dispose();


### PR DESCRIPTION
## 📋 关联 Issue
- Closes #1372

## 📝 变更说明
完成处方搜索功能的API层实现，补充Controller端点和单元测试。

### 核心变更
1. **新增API端点** (`PrescriptionsController.cs:350-380`)
   - 路由：`GET /api/v1/prescriptions/search`
   - 参数：`patientName`（可选）、`symptomKeyword`（可选）
   - 验证：至少需要一个搜索参数
   - 缓存：300秒响应缓存

2. **新增单元测试** (`PrescriptionServiceTests.cs:592-629`)
   - 测试无参数情况：返回空列表
   - 测试空字符串参数：返回空列表
   - 注释说明：完整集成测试应在IntegrationTests项目中进行

### 技术背景
SearchPrescriptionsAsync 服务层方法已在 ENTRY-14 中实现（`PrescriptionService.cs:637-735`），本PR补充缺失的Controller API端点，完成从服务层到API层的完整闭环。

## ✅ 测试验证
- ✅ 编译通过：`dotnet build LYBT.WebAPI.csproj -c Release` (0 errors, 0 warnings)
- ✅ 单元测试：31/31 passed in `LYBT.Module.Prescriptions.Tests`
- ✅ 代码规范：符合项目编码规范

## 📊 变更统计
- 新增代码：70 lines
  - PrescriptionsController.cs: +31 lines
  - PrescriptionServiceTests.cs: +39 lines

## 🔍 审查重点
- [ ] API参数验证逻辑
- [ ] 响应缓存配置
- [ ] 异常处理完整性
- [ ] 单元测试覆盖率

🤖 Generated with Claude Code