### PR TITLE
feat(prescriptions): 更新PrescriptionSearchResultDto以支持历史查询功能 (Issue #1370 ENTRY-12)

### DIFF
--- a/src/Shared/LYBT.Shared.Models/Contracts/Prescriptions/PrescriptionSearchResultDto.cs
+++ b/src/Shared/LYBT.Shared.Models/Contracts/Prescriptions/PrescriptionSearchResultDto.cs
@@ -1,10 +1,11 @@
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace LYBT.Shared.Models.Contracts.Prescriptions
 {
     /// <summary>
-    /// 处方搜索结果DTO (Issue #1372 ENTRY-14)
-    /// 用于全局处方搜索功能，包含患者和诊断信息
+    /// 处方搜索结果DTO (Issue #1372 ENTRY-14, Issue #1370 ENTRY-12)
+    /// 用于全局处方搜索和历史查询功能，包含患者和诊断信息
     /// </summary>
     public class PrescriptionSearchResultDto
     {
@@ -12,9 +13,25 @@ namespace LYBT.Shared.Models.Contracts.Prescriptions
         [DisplayName("处方ID")]
         public Guid Id { get; set; }
 
+        /// <summary>处方ID（别名，与Id相同）</summary>
+        [DisplayName("处方ID")]
+        public Guid PrescriptionId
+        {
+            get => Id;
+            set => Id = value;
+        }
+
         /// <summary>处方创建日期</summary>
         [DisplayName("创建日期")]
         public DateTime CreatedAt { get; set; }
+
+        /// <summary>处方日期（别名，与CreatedAt相同）</summary>
+        [DisplayName("处方日期")]
+        public DateTime PrescriptionDate
+        {
+            get => CreatedAt;
+            set => CreatedAt = value;
+        }
 
         /// <summary>患者ID</summary>
         [DisplayName("患者ID")]
@@ -22,14 +39,17 @@ namespace LYBT.Shared.Models.Contracts.Prescriptions
 
         /// <summary>患者姓名</summary>
         [DisplayName("患者姓名")]
+        [StringLength(100)]
         public string PatientName { get; set; } = string.Empty;
 
         /// <summary>主治（适应症）</summary>
         [DisplayName("主治")]
+        [StringLength(500)]
         public string? Indication { get; set; }
 
-        /// <summary>中医诊断</summary>
+        /// <summary>中医诊断（从Consultation查询）</summary>
         [DisplayName("中医诊断")]
+        [StringLength(500)]
         public string? TCMDiagnosis { get; set; }
 
         /// <summary>剂数</summary>
@@ -38,14 +58,25 @@ namespace LYBT.Shared.Models.Contracts.Prescriptions
 
         /// <summary>医嘱</summary>
         [DisplayName("医嘱")]
+        [StringLength(500)]
         public string? Advice { get; set; }
 
         /// <summary>验方来源</summary>
         [DisplayName("验方来源")]
+        [StringLength(200)]
         public string? FormulaSource { get; set; }
 
         /// <summary>备注</summary>
         [DisplayName("备注")]
+        [StringLength(500)]
         public string? Remark { get; set; }
+
+        /// <summary>药材数量 (Issue #1370 ENTRY-12)</summary>
+        [DisplayName("药材数量")]
+        public int HerbCount { get; set; }
+
+        /// <summary>处方项目列表 (Issue #1370 ENTRY-12)</summary>
+        [DisplayName("处方项目")]
+        public List<PrescriptionItemDto> Items { get; set; } = new();
     }
 }


### PR DESCRIPTION
## 📋 关联Issue
- Epic: #1343
- Issue: #1370 [ENTRY-12] 创建PrescriptionSearchResultDto
- Closes #1370

## 📝 变更说明

### 新增属性
- ✅ **PrescriptionId**: 处方ID别名（映射到Id，支持ENTRY-12命名规范）
- ✅ **PrescriptionDate**: 处方日期别名（映射到CreatedAt，支持ENTRY-12命名规范）
- ✅ **HerbCount**: 药材数量统计
- ✅ **Items**: 处方项目明细列表（List<PrescriptionItemDto>）

### 增强功能
- 为现有属性添加`StringLength`验证特性
- 更新文档注释，同时标注支持ENTRY-14和ENTRY-12的需求
- 保持与`SearchPrescriptionsAsync` API的兼容性

## 🎯 技术实现

### 1. 属性别名实现向后兼容
```csharp
// 支持ENTRY-14的命名
public Guid Id { get; set; }

// 支持ENTRY-12的命名（别名）
public Guid PrescriptionId 
{
    get => Id;
    set => Id = value;
}
```

### 2. 新增属性满足历史查询需求
```csharp
/// <summary>药材数量 (Issue #1370 ENTRY-12)</summary>
public int HerbCount { get; set; }

/// <summary>处方项目列表 (Issue #1370 ENTRY-12)</summary>
public List<PrescriptionItemDto> Items { get; set; } = new();
```

## ✅ 验收标准

- [x] PrescriptionSearchResultDto 已创建（文件已存在于ENTRY-14）
- [x] 所有必要属性已定义（新增HerbCount和Items）
- [x] 包含诊断信息（来自Consultation）

## 🧪 测试结果

### 编译测试
```
✅ 编译通过
   0 个错误
   7 个警告（预存在）
```

### 代码统计
- **修改文件**: 1个
- **新增代码**: +34行
- **删除代码**: -3行

## 📚 文档影响
无需更新文档（DTO定义，仅Server端使用）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>