### PR TITLE
feat(prescriptions): 实现GetPatientRecentPrescriptionsAsync方法 (Issue #1371 ENTRY-13)

### DIFF
--- a/src/Server/Core/LYBT.Server.Interfaces/Services/IPrescriptionService.cs
+++ b/src/Server/Core/LYBT.Server.Interfaces/Services/IPrescriptionService.cs
@@ -102,5 +102,16 @@ namespace LYBT.Server.Interfaces.Services
         Task<ServiceResult<List<PrescriptionSearchResultDto>>> SearchPrescriptionsAsync(
             string? patientName = null,
             string? symptomKeyword = null);
+
+        /// <summary>
+        /// 获取患者最近处方列表 (Issue #1371 ENTRY-13)
+        /// 按日期倒序排列，包含诊断信息
+        /// </summary>
+        /// <param name="patientId">患者ID</param>
+        /// <param name="count">返回数量（默认5条）</param>
+        /// <returns>患者最近处方列表</returns>
+        Task<ServiceResult<List<PrescriptionSearchResultDto>>> GetPatientRecentPrescriptionsAsync(
+            Guid patientId,
+            int count = 5);
     }
 }

--- a/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
+++ b/src/Server/Modules/LYBT.Module.Prescriptions/Services/PrescriptionService.cs
@@ -735,6 +735,101 @@ namespace LYBT.Module.Prescriptions.Services
             }
         }
 
+        /// <summary>
+        /// 获取患者最近处方列表 (Issue #1371 ENTRY-13)
+        /// MVP实现：内存过滤，适用于小数据量（<1000条处方）
+        /// </summary>
+        /// <param name="patientId">患者ID</param>
+        /// <param name="count">返回数量（默认5条）</param>
+        /// <returns>患者最近处方列表（按日期倒序）</returns>
+        public async Task<ServiceResult<List<PrescriptionSearchResultDto>>> GetPatientRecentPrescriptionsAsync(
+            Guid patientId,
+            int count = 5)
+        {
+            try
+            {
+                // 获取所有处方
+                var allPrescriptions = await _repository.GetAllAsync();
+
+                // 获取所有病历（用于关联患者）
+                var allMedicalCases = await _medicalCaseRepository.GetAllAsync();
+                var medicalCaseDict = allMedicalCases.ToDictionary(mc => mc.Id);
+
+                // 获取所有诊疗记录（用于获取 TCMDiagnosis）
+                var allConsultations = await _consultationRepository.GetAllAsync();
+                var consultationDict = allConsultations.ToDictionary(c => c.Id);
+
+                // 获取患者信息
+                var patient = await _patientRepository.GetByIdAsync(patientId);
+                if (patient == null)
+                {
+                    return ServiceResult<List<PrescriptionSearchResultDto>>.Failure("患者不存在");
+                }
+
+                // 内存过滤：找到该患者的所有处方
+                var patientPrescriptions = new List<PrescriptionSearchResultDto>();
+
+                foreach (var prescription in allPrescriptions)
+                {
+                    // 关联病历
+                    if (!medicalCaseDict.TryGetValue(prescription.MedicalCaseId, out var medicalCase))
+                    {
+                        continue; // 找不到关联病历，跳过
+                    }
+
+                    // 筛选该患者的处方
+                    if (medicalCase.PatientId != patientId)
+                    {
+                        continue; // 不是该患者的处方，跳过
+                    }
+
+                    // 关联诊疗记录（MedicalCase 与 Consultation 共享主键）
+                    consultationDict.TryGetValue(medicalCase.Id, out var consultation);
+
+                    // 获取处方项以计算药材数量（Issue #1370 ENTRY-12 新增需求）
+                    var prescriptionWithItems = await _repository.GetByIdWithItemsAsync(prescription.Id);
+                    var herbCount = prescriptionWithItems?.Items?.Count ?? 0;
+
+                    // 构建搜索结果
+                    var prescriptionDto = new PrescriptionSearchResultDto
+                    {
+                        Id = prescription.Id,
+                        CreatedAt = prescription.CreatedAt,
+                        PatientId = patient.Id,
+                        PatientName = patient.Name ?? string.Empty,
+                        Indication = prescription.Indication,
+                        TCMDiagnosis = consultation?.TCMDiagnosis,
+                        DosageCount = prescription.DosageCount,
+                        Advice = prescription.Advice,
+                        FormulaSource = prescription.FormulaSource,
+                        Remark = prescription.Remark,
+                        HerbCount = herbCount, // Issue #1370 新增
+                        Items = prescriptionWithItems?.Items != null
+                            ? _mapper.Map<List<PrescriptionItemDto>>(prescriptionWithItems.Items)
+                            : new List<PrescriptionItemDto>() // Issue #1370 新增
+                    };
+
+                    patientPrescriptions.Add(prescriptionDto);
+                }
+
+                // 按创建日期倒序排列，取前count条
+                var recentPrescriptions = patientPrescriptions
+                    .OrderByDescending(p => p.CreatedAt)
+                    .Take(count)
+                    .ToList();
+
+                _logger.LogInformation("获取患者最近处方完成，患者ID：{PatientId}，患者姓名：{PatientName}，请求数量：{RequestCount}，实际返回：{ActualCount}",
+                    patientId, patient.Name ?? "(空)", count, recentPrescriptions.Count);
+
+                return ServiceResult<List<PrescriptionSearchResultDto>>.Success(recentPrescriptions);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "获取患者最近处方时发生错误，患者ID：{PatientId}", patientId);
+                return ServiceResult<List<PrescriptionSearchResultDto>>.Failure($"获取患者最近处方失败：{ex.Message}");
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## 📋 关联Issue
- Epic: #1343
- Issue: #1371 [ENTRY-13] 实现GetPatientRecentPrescriptionsAsync方法
- Depends on: #1370 ✅ (已完成)
- Closes #1371

## 📝 变更说明

### 接口层（IPrescriptionService.cs）
- ✅ 添加`GetPatientRecentPrescriptionsAsync`方法签名
- 参数：`patientId`（患者ID）、`count`（返回数量，默认5）
- 返回：`List<PrescriptionSearchResultDto>`（按日期倒序）

### 服务层（PrescriptionService.cs）
- ✅ 实现`GetPatientRecentPrescriptionsAsync`方法
- 查询逻辑：关联`MedicalCase`、`Consultation`、`Patient`三表
- 获取`TCMDiagnosis`（中医诊断）
- 获取`HerbCount`（药材数量）和`Items`（药材明细）
- 按`CreatedAt`倒序排列，取前`count`条

## 🎯 技术实现

### 1. 多表关联查询（MVP内存过滤）
```csharp
// 关联病历
var medicalCaseDict = allMedicalCases.ToDictionary(mc => mc.Id);

// 关联诊疗记录
var consultationDict = allConsultations.ToDictionary(c => c.Id);

// 关联患者
var patient = await _patientRepository.GetByIdAsync(patientId);
```

### 2. 筛选患者处方
```csharp
if (medicalCase.PatientId != patientId)
{
    continue; // 不是该患者的处方
}
```

### 3. 获取诊断信息和药材详情
```csharp
// 从Consultation获取TCMDiagnosis
consultationDict.TryGetValue(medicalCase.Id, out var consultation);

// 获取药材数量和明细
var prescriptionWithItems = await _repository.GetByIdWithItemsAsync(prescription.Id);
var herbCount = prescriptionWithItems?.Items?.Count ?? 0;
```

### 4. 按日期倒序，取前N条
```csharp
var recentPrescriptions = patientPrescriptions
    .OrderByDescending(p => p.CreatedAt)
    .Take(count)
    .ToList();
```

## ✅ 验收标准

- [x] GetPatientRecentPrescriptionsAsync方法已实现
- [x] 查询逻辑正确（Join Consultation表）
- [x] 按日期倒序，默认返回5条
- [x] 包含诊断信息（TCMDiagnosis）
- [x] 包含药材数量（HerbCount）和药材明细（Items）

## 🧪 测试结果

### 编译测试
```
✅ 编译通过
   0 个错误
   8 个警告（预存在）
```

### 代码统计
- **修改文件**: 2个
- **新增代码**: +106行

## 💡 设计亮点

1. **MVP内存过滤**：适用于小数据量（<1000条处方），简化实现
2. **字典优化**：使用Dictionary加速关联查询
3. **完整数据**：包含药材数量和明细列表，满足UI展示需求
4. **日志记录**：详细记录查询结果，便于调试和监控

## 📚 后续使用

该方法将用于以下功能：
- **ENTRY-16**: 集成患者历史处方下拉框
- **ENTRY-17**: 创建处方搜索对话框
- **ENTRY-18**: 测试历史和搜索工作流

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>