### PR TITLE
feat(prescription): 集成患者历史处方下拉框 (#1374)

### DIFF
--- a/src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs
@@ -46,5 +46,13 @@ namespace LYBT.Desktop.Contracts.Api
         /// </summary>
         [Refit.Get("/api/v1/prescriptions/medicalcase/{medicalCaseId}")]
         Task<Refit.ApiResponse<List<PrescriptionDto>>> GetPrescriptionsByMedicalCaseIdAsync(Guid medicalCaseId);
+
+        /// <summary>
+        /// 获取患者最近处方列表 (Issue #1371 ENTRY-13)
+        /// </summary>
+        [Refit.Get("/api/v1/prescriptions/patient/{patientId}/recent")]
+        Task<Refit.ApiResponse<List<PrescriptionSearchResultDto>>> GetPatientRecentPrescriptionsAsync(
+            Guid patientId,
+            [Refit.Query] int count = 5);
     }
 }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
@@ -15,5 +15,10 @@ namespace LYBT.Desktop.Prescriptions.Interfaces
         Task<PrescriptionDto> UpdateAsync(Guid id, PrescriptionUpdateDto dto);
         Task<bool> DeleteAsync(Guid id);
         Task<List<PrescriptionDto>> GetByMedicalCaseIdAsync(Guid medicalCaseId);
+
+        /// <summary>
+        /// 获取患者最近处方列表 (Issue #1371 ENTRY-13)
+        /// </summary>
+        Task<List<PrescriptionSearchResultDto>> GetPatientRecentPrescriptionsAsync(Guid patientId, int count = 5);
     }
 }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
@@ -62,6 +62,23 @@ namespace LYBT.Desktop.Prescriptions.Repositories
             }
         }
 
+        /// <summary>
+        /// 获取患者最近处方列表 (Issue #1371 ENTRY-13, Issue #1374 ENTRY-16)
+        /// </summary>
+        public async Task<List<PrescriptionSearchResultDto>> GetPatientRecentPrescriptionsAsync(Guid patientId, int count = 5)
+        {
+            try
+            {
+                var response = await _api.GetPatientRecentPrescriptionsAsync(patientId, count);
+                return response.Content ?? new List<PrescriptionSearchResultDto>();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "获取患者最近处方失败: PatientId={PatientId}, Count={Count}", patientId, count);
+                return new List<PrescriptionSearchResultDto>();
+            }
+        }
+
         #region RepositoryBase抽象方法实现
 
         protected override Task<Refit.ApiResponse<PrescriptionDto>> CallApiGetByIdAsync(Guid id)

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
@@ -7,6 +7,7 @@ using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Desktop.Herbs.Interfaces;
 using LYBT.Shared.Models.Contracts.MedicalCase;
 using LYBT.Shared.Models.Contracts.Herbs;
+using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
@@ -254,6 +255,35 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             set => SetProperty(ref _filteredHerbs, value);
         }
 
+        private ObservableCollection<PrescriptionSearchResultDto> _recentPrescriptions = new();
+
+        /// <summary>
+        /// 患者最近处方列表 (Issue #1374 ENTRY-16)
+        /// </summary>
+        public ObservableCollection<PrescriptionSearchResultDto> RecentPrescriptions
+        {
+            get => _recentPrescriptions;
+            set => SetProperty(ref _recentPrescriptions, value);
+        }
+
+        private PrescriptionSearchResultDto? _selectedRecentPrescription;
+
+        /// <summary>
+        /// 选中的历史处方 (Issue #1374 ENTRY-16)
+        /// </summary>
+        public PrescriptionSearchResultDto? SelectedRecentPrescription
+        {
+            get => _selectedRecentPrescription;
+            set
+            {
+                if (SetProperty(ref _selectedRecentPrescription, value) && value != null)
+                {
+                    // 选中后自动复制
+                    CopyFromHistoryCommand?.Execute(value);
+                }
+            }
+        }
+
         #endregion
 
         #region 计算属性
@@ -385,6 +415,11 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         /// </summary>
         public DelegateCommand<PrescriptionItemViewModel> EditHerbCommand { get; }
 
+        /// <summary>
+        /// 从历史处方复制命令 (Issue #1374 ENTRY-16)
+        /// </summary>
+        public DelegateCommand<PrescriptionSearchResultDto> CopyFromHistoryCommand { get; }
+
         #endregion
 
         #region 构造函数
@@ -426,6 +461,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             SaveDraftCommand = new DelegateCommand(ExecuteSaveDraft, CanSaveDraft);
             SavePrescriptionCommand = SaveCommand; // 别名
             EditHerbCommand = new DelegateCommand<PrescriptionItemViewModel>(ExecuteEditHerb, item => item != null && !IsBusy);
+            CopyFromHistoryCommand = new DelegateCommand<PrescriptionSearchResultDto>(ExecuteCopyFromHistory, prescription => prescription != null && !IsBusy);
 
             // 订阅事件
             SubscribeToEvents();
@@ -487,6 +523,9 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 
                 // 加载药材数据 (Issue #1362: [ENTRY-4] 实现ComboBox拼音码过滤)
                 await LoadAllHerbsAsync();
+
+                // 加载患者历史处方 (Issue #1374 ENTRY-16)
+                await LoadRecentPrescriptionsAsync();
 
                 // 初始化处方数据管理器
                 await _dataManager.InitializeAsync(MedicalCaseId);
@@ -581,6 +620,38 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             catch (Exception ex)
             {
                 Logger.LogError(ex, "过滤药材时发生异常");
+            }
+        }
+
+        /// <summary>
+        /// 加载患者最近处方列表 (Issue #1374 ENTRY-16)
+        /// </summary>
+        private async Task LoadRecentPrescriptionsAsync()
+        {
+            try
+            {
+                if (CurrentMedicalCase?.PatientId == null || CurrentMedicalCase.PatientId == Guid.Empty)
+                {
+                    Logger.LogWarning("无法加载历史处方：患者ID无效");
+                    return;
+                }
+
+                var recentPrescriptions = await _prescriptionRepository.GetPatientRecentPrescriptionsAsync(
+                    CurrentMedicalCase.PatientId, 
+                    count: 5);
+
+                RecentPrescriptions.Clear();
+                foreach (var prescription in recentPrescriptions)
+                {
+                    RecentPrescriptions.Add(prescription);
+                }
+
+                Logger.LogInformation("已加载患者最近处方，共 {Count} 条", recentPrescriptions.Count);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "加载患者最近处方失败");
+                // 不抛出异常，避免影响主流程
             }
         }
 
@@ -700,6 +771,60 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             {
                 Logger.LogError(ex, "编辑药材时发生异常");
                 ShowErrorMessage("编辑药材失败");
+            }
+        }
+
+        /// <summary>
+        /// 从历史处方复制 (Issue #1374 ENTRY-16)
+        /// </summary>
+        private void ExecuteCopyFromHistory(PrescriptionSearchResultDto prescription)
+        {
+            if (prescription == null) return;
+
+            try
+            {
+                Logger.LogInformation("从历史处方复制，处方ID: {PrescriptionId}, 患者: {PatientName}",
+                    prescription.Id, prescription.PatientName);
+
+                // 清空当前处方项
+                _dataManager.Clear();
+
+                // 复制处方项
+                foreach (var item in prescription.Items)
+                {
+                    var newItem = new PrescriptionItemViewModel(
+                        EventAggregator,
+                        LoggerFactory,
+                        RegionManager,
+                        SessionManager,
+                        UserNotificationService)
+                    {
+                        HerbId = item.HerbId,
+                        HerbName = item.HerbName,
+                        Dosage = item.Dosage,
+                        Unit = item.Unit,
+                        UnitPrice = item.UnitPrice,
+                        Remark = item.Remark
+                    };
+                    _dataManager.PrescriptionItems.Add(newItem);
+                }
+
+                // 重新计算价格
+                RecalculatePrice();
+
+                // 刷新ItemRows
+                RefreshItemRows();
+
+                // 清空选择（避免重复触发）
+                SelectedRecentPrescription = null;
+
+                ShowInfoMessage($"已从历史处方复制 {prescription.Items.Count} 味药材");
+                Logger.LogInformation("历史处方复制完成，共 {Count} 味药材", prescription.Items.Count);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "从历史处方复制时发生异常");
+                ShowErrorMessage("复制历史处方失败");
             }
         }
 

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionComposerView.xaml
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionComposerView.xaml
@@ -136,6 +136,29 @@
                                    Style="{StaticResource ButtonStyle}" Margin="0,0,10,0" />
                             <Button Content="导入验方" Command="{Binding ImportFormulaCommand}"
                                    Style="{StaticResource ButtonStyle}" Margin="0,0,10,0" />
+
+                            <!-- 历史处方下拉框 (Issue #1374 ENTRY-16) -->
+                            <StackPanel Margin="0,0,10,0">
+                                <TextBlock Text="历史处方" FontSize="10" Foreground="#7F8C8D" Margin="0,0,0,2" />
+                                <ComboBox Width="250" Height="32"
+                                         ItemsSource="{Binding RecentPrescriptions}"
+                                         SelectedItem="{Binding SelectedRecentPrescription, Mode=TwoWay}"
+                                         ToolTip="选择患者历史处方快速复制">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel>
+                                                <TextBlock>
+                                                    <Run Text="{Binding PrescriptionNo}" FontWeight="Bold" />
+                                                    <Run Text=" - " />
+                                                    <Run Text="{Binding PrescriptionDate, StringFormat='yyyy-MM-dd'}" />
+                                                </TextBlock>
+                                                <TextBlock Text="{Binding Diagnosis}" FontSize="11" Foreground="Gray" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </StackPanel>
+
                             <Button Content="清空处方" Command="{Binding ClearAllCommand}"
                                    Style="{StaticResource SecondaryButtonStyle}" />
                         </StackPanel>

--- a/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -378,6 +378,43 @@ namespace LYBT.WebAPI.Controllers
             }
         }
 
+        /// <summary>
+        /// 获取患者最近处方列表 (Issue #1371 ENTRY-13, Issue #1374 ENTRY-16)
+        /// </summary>
+        /// <param name="patientId">患者ID</param>
+        /// <param name="count">返回数量（默认5条）</param>
+        /// <returns>患者最近处方列表</returns>
+        [HttpGet("patient/{patientId}/recent")]
+        [ResponseCache(Duration = 300, VaryByQueryKeys = new[] { "patientId", "count" })]
+        [ProducesResponseType(typeof(ApiResponse<List<PrescriptionSearchResultDto>>), 200)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ApiResponse<List<PrescriptionSearchResultDto>>>> GetPatientRecentPrescriptions(
+            Guid patientId,
+            [FromQuery] int count = 5)
+        {
+            try
+            {
+                var validation = ValidateGuid<List<PrescriptionSearchResultDto>>(patientId, "患者ID");
+                if (validation != null)
+                {
+                    return validation;
+                }
+
+                if (count <= 0 || count > 100)
+                {
+                    return ValidationFail<List<PrescriptionSearchResultDto>>("返回数量必须在1-100之间");
+                }
+
+                var result = await _service.GetPatientRecentPrescriptionsAsync(patientId, count);
+                return HandleServiceResult(result, "查询成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<List<PrescriptionSearchResultDto>>(ex, "获取患者最近处方", new { patientId, count });
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## 📋 关联 Issue
Closes #1374

## 📝 功能描述
在处方编辑器中集成患者历史处方下拉框，实现从历史处方快速复制药材的功能。

## ✨ 主要变更

### API层
- ✅ `IPrescriptionApi`: 添加 `GetPatientRecentPrescriptionsAsync()` 方法
- ✅ `PrescriptionsController`: 添加 `GET /api/v1/prescriptions/patient/{patientId}/recent` 端点
- ✅ 参数验证：患者ID验证、返回数量范围验证（1-100）
- ✅ 响应缓存：300秒缓存提升性能

### Repository层
- ✅ `IPrescriptionRepository`: 添加获取患者最近处方接口方法
- ✅ `PrescriptionRepository`: 实现数据访问逻辑
- ✅ 异常处理：捕获异常返回空列表，不影响主流程

### ViewModel层（PrescriptionComposerViewModel）
- ✅ 添加 `RecentPrescriptions` 属性（ObservableCollection）
- ✅ 添加 `SelectedRecentPrescription` 属性（支持双向绑定）
- ✅ 实现 `LoadRecentPrescriptionsAsync()` 方法加载历史数据
- ✅ 实现 `CopyFromHistoryCommand` 命令
- ✅ 实现 `ExecuteCopyFromHistory()` 方法复制处方逻辑
- ✅ 集成到初始化工作流（在 `LoadPrescriptionDataAsync()` 中调用）

### View层（PrescriptionComposerView.xaml）
- ✅ 在工具栏添加历史处方下拉框组件
- ✅ 自定义 ItemTemplate 显示：处方编号、日期、诊断
- ✅ 双向绑定自动触发复制
- ✅ UI优化：添加"历史处方"标签，宽度250px

## 🔧 技术实现细节

### 复制逻辑
1. 用户从下拉框选择历史处方
2. 触发 `SelectedRecentPrescription` 属性变更
3. 自动执行 `CopyFromHistoryCommand`
4. 清空当前处方项
5. 遍历历史处方药材列表，创建新的 `PrescriptionItemViewModel` 实例
6. 复制药材属性：HerbId, HerbName, Dosage, Unit, UnitPrice, Remark
7. 重新计算价格
8. 刷新UI显示
9. 清空选择状态（避免重复触发）
10. 显示成功提示信息

### 依赖注入
创建 `PrescriptionItemViewModel` 时正确传递所有依赖：
- EventAggregator
- LoggerFactory
- RegionManager
- SessionManager
- UserNotificationService

## ✅ 测试验证

### 编译测试
- ✅ 编译通过（0错误，0警告）
- ✅ 所有修改文件编译成功

### 功能测试点
- [ ] API端点返回正确的患者历史处方数据
- [ ] 下拉框正确显示处方编号、日期、诊断
- [ ] 选择历史处方后药材正确复制到当前处方
- [ ] 价格自动重新计算
- [ ] 异常情况处理（患者无历史处方、网络错误等）

## 📦 影响范围
- **Server端**: 1个Controller文件
- **Client端API**: 1个API接口文件
- **Repository**: 2个文件（接口+实现）
- **ViewModel**: 1个文件
- **View**: 1个XAML文件

## 🔗 依赖任务
- ✅ Issue #1370 [ENTRY-12]: PrescriptionSearchResultDto增强（已完成）
- ✅ Issue #1371 [ENTRY-13]: 后端API实现（已完成）

## 📸 UI截图
（待实际运行后补充）

## 📚 文档更新
无需更新文档（功能增强，不涉及架构变更）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>