### PR TITLE
[ENTRY-9] 为FormulaTemplateDialogViewModel添加导入验方命令

### DIFF
--- a/src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs
@@ -54,5 +54,14 @@ namespace LYBT.Desktop.Contracts.Api
         Task<Refit.ApiResponse<List<PrescriptionSearchResultDto>>> GetPatientRecentPrescriptionsAsync(
             Guid patientId,
             [Refit.Query] int count = 5);
+
+        /// <summary>
+        /// 导入验方到处方 (Issue #1366 ENTRY-8, Issue #1367 ENTRY-9)
+        /// 从已验证的验方批量导入药材，并记录引用的验方名称
+        /// </summary>
+        [Refit.Post("/api/v1/prescriptions/{prescriptionId}/import-formula/{formulaId}")]
+        Task<Refit.ApiResponse<PrescriptionDto>> ImportFormulaIntoPrescriptionAsync(
+            Guid prescriptionId,
+            Guid formulaId);
     }
 }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs
@@ -20,5 +20,11 @@ namespace LYBT.Desktop.Prescriptions.Interfaces
         /// 获取患者最近处方列表 (Issue #1371 ENTRY-13)
         /// </summary>
         Task<List<PrescriptionSearchResultDto>> GetPatientRecentPrescriptionsAsync(Guid patientId, int count = 5);
+
+        /// <summary>
+        /// 导入验方到处方 (Issue #1366 ENTRY-8, Issue #1367 ENTRY-9)
+        /// 从已验证的验方批量导入药材，并记录引用的验方名称
+        /// </summary>
+        Task<PrescriptionDto> ImportFormulaIntoPrescriptionAsync(Guid prescriptionId, Guid formulaId);
     }
 }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs
@@ -79,6 +79,35 @@ namespace LYBT.Desktop.Prescriptions.Repositories
             }
         }
 
+        /// <summary>
+        /// 导入验方到处方 (Issue #1366 ENTRY-8, Issue #1367 ENTRY-9)
+        /// 从已验证的验方批量导入药材，并记录引用的验方名称
+        /// </summary>
+        public async Task<PrescriptionDto> ImportFormulaIntoPrescriptionAsync(Guid prescriptionId, Guid formulaId)
+        {
+            if (prescriptionId == Guid.Empty)
+            {
+                _logger.LogError("Cannot import formula with invalid prescription id");
+                throw new ArgumentException("Prescription ID is required", nameof(prescriptionId));
+            }
+            if (formulaId == Guid.Empty)
+            {
+                _logger.LogError("Cannot import formula with invalid formula id");
+                throw new ArgumentException("Formula ID is required", nameof(formulaId));
+            }
+
+            try
+            {
+                var response = await _api.ImportFormulaIntoPrescriptionAsync(prescriptionId, formulaId);
+                return response.Content ?? throw new InvalidOperationException($"导入验方失败，处方ID: {prescriptionId}, 验方ID: {formulaId}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "导入验方失败，处方ID: {PrescriptionId}, 验方ID: {FormulaId}", prescriptionId, formulaId);
+                throw;
+            }
+        }
+
         #region RepositoryBase抽象方法实现
 
         protected override Task<Refit.ApiResponse<PrescriptionDto>> CallApiGetByIdAsync(Guid id)

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/FormulaTemplateDialogViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/FormulaTemplateDialogViewModel.cs
@@ -2,6 +2,7 @@
 using LYBT.Desktop.Infrastructure.Interfaces;
 using LYBT.Desktop.Models.ViewModels.Base;
 using LYBT.Desktop.Formula.Interfaces;
+using LYBT.Desktop.Prescriptions.Interfaces;
 using LYBT.Shared.Models.Contracts.Formula;
 using LYBT.Shared.Models.Enums;
 using Microsoft.Extensions.Logging;
@@ -21,6 +22,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         #region 服务依赖
 
         private readonly IFormulaRepository _formulaRepository;
+        private readonly IPrescriptionRepository _prescriptionRepository;
 
         #endregion
 
@@ -82,6 +84,11 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             "化痰止咳方", "理气方", "活血化瘀方", "温里方", "其他"
         };
 
+        /// <summary>
+        /// 处方ID - 用于导入验方功能 (Issue #1367 ENTRY-9)
+        /// </summary>
+        public Guid PrescriptionId { get; private set; }
+
         #endregion
 
         #region 对话框属性
@@ -135,6 +142,11 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         /// </summary>
         public DelegateCommand ViewDetailsCommand { get; }
 
+        /// <summary>
+        /// 导入验方命令 (Issue #1367 ENTRY-9)
+        /// </summary>
+        public DelegateCommand ImportCommand { get; }
+
         #endregion
 
         #region 构造函数
@@ -144,11 +156,13 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
             IFormulaRepository formulaService,
+            IPrescriptionRepository prescriptionRepository,
             ISessionManager? sessionManager = null,
             IUserNotificationService? userNotificationService = null)
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
             _formulaRepository = formulaService ?? throw new ArgumentNullException(nameof(formulaService));
+            _prescriptionRepository = prescriptionRepository ?? throw new ArgumentNullException(nameof(prescriptionRepository));
 
             // 初始化命令
             SearchCommand = new DelegateCommand(async () => await SearchAsync());
@@ -156,6 +170,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             CancelCommand = new DelegateCommand(Cancel);
             PreviewCommand = new DelegateCommand(Preview, CanPreview);
             RefreshCommand = new DelegateCommand(async () => await RefreshAsync());
+            ImportCommand = new DelegateCommand(async () => await ImportFormulaAsync(), CanImport);
 
             // Phase 4B 别名命令
             SelectCommand = ConfirmCommand;
@@ -195,6 +210,12 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
                 if (parameters.ContainsKey("Category"))
                 {
                     CategoryFilter = parameters.GetValue<string>("Category");
+                }
+
+                // Issue #1367 ENTRY-9: 获取处方ID用于导入功能
+                if (parameters.ContainsKey("PrescriptionId"))
+                {
+                    PrescriptionId = parameters.GetValue<Guid>("PrescriptionId");
                 }
 
                 // 加载数据
@@ -340,17 +361,58 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             }
         }
 
+        /// <summary>
+        /// 导入验方到处方 (Issue #1367 ENTRY-9)
+        /// </summary>
+        private async Task ImportFormulaAsync()
+        {
+            if (SelectedFormula == null || PrescriptionId == Guid.Empty)
+            {
+                return;
+            }
+
+            try
+            {
+                SetIsBusy(true, $"正在导入验方\"{SelectedFormula.Name}\"...");
+
+                await _prescriptionRepository.ImportFormulaIntoPrescriptionAsync(PrescriptionId, SelectedFormula.Id);
+
+                Logger.LogInformation("验方\"{FormulaName}\"导入成功", SelectedFormula.Name);
+                await ShowSuccessMessageAsync($"验方\"{SelectedFormula.Name}\"已成功导入到处方");
+
+                // 关闭对话框并通知刷新
+                var parameters = new DialogParameters
+                {
+                    { "Imported", true },
+                    { "FormulaName", SelectedFormula.Name }
+                };
+
+                RequestClose?.Invoke(new DialogResult(ButtonResult.OK, parameters));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "导入验方时发生异常: {FormulaName}", SelectedFormula?.Name);
+                await ShowErrorMessageAsync($"导入验方失败: {ex.Message}");
+            }
+            finally
+            {
+                SetIsBusy(false);
+            }
+        }
+
         #endregion
 
         #region 命令状态检查
 
         private bool CanConfirm() => SelectedFormula != null && !IsBusy;
         private bool CanPreview() => SelectedFormula != null;
+        private bool CanImport() => SelectedFormula != null && PrescriptionId != Guid.Empty && !IsBusy;
 
         private void UpdateCommandStates()
         {
             ConfirmCommand.RaiseCanExecuteChanged();
             PreviewCommand.RaiseCanExecuteChanged();
+            ImportCommand.RaiseCanExecuteChanged();
         }
 
         #endregion

--- a/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
+++ b/src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs
@@ -415,6 +415,57 @@ namespace LYBT.WebAPI.Controllers
             }
         }
 
+        /// <summary>
+        /// 导入验方到处方 (Issue #1366 ENTRY-8, Issue #1367 ENTRY-9)
+        /// 从已验证的验方批量导入药材，并记录引用的验方名称
+        /// </summary>
+        /// <param name="prescriptionId">处方ID</param>
+        /// <param name="formulaId">验方ID</param>
+        /// <returns>更新后的处方DTO</returns>
+        [HttpPost("{prescriptionId}/import-formula/{formulaId}")]
+        [ProducesResponseType(typeof(ApiResponse<PrescriptionDto>), 200)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(404)]
+        public async Task<ActionResult<ApiResponse<PrescriptionDto>>> ImportFormulaIntoPrescription(
+            Guid prescriptionId,
+            Guid formulaId)
+        {
+            try
+            {
+                var prescriptionValidation = ValidateGuid<PrescriptionDto>(prescriptionId, "处方ID");
+                if (prescriptionValidation != null)
+                {
+                    return prescriptionValidation;
+                }
+
+                var formulaValidation = ValidateGuid<PrescriptionDto>(formulaId, "验方ID");
+                if (formulaValidation != null)
+                {
+                    return formulaValidation;
+                }
+
+                var result = await _service.ImportFormulaIntoPrescriptionAsync(prescriptionId, formulaId);
+
+                if (!result.IsSuccess || result.Data == null)
+                {
+                    return BusinessFail<PrescriptionDto>(
+                        result.ErrorMessage ?? "导入验方失败",
+                        ApiErrorCodes.DATASAVEFAILED);
+                }
+
+                // 记录操作日志
+                LogOperation("导入验方到处方",
+                    new { PrescriptionId = prescriptionId, FormulaId = formulaId },
+                    prescriptionId);
+
+                return Success(result.Data, result.Message ?? "验方导入成功");
+            }
+            catch (Exception ex)
+            {
+                return HandleException<PrescriptionDto>(ex, "导入验方到处方", new { prescriptionId, formulaId });
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
## 📋 关联Issue
- Closes #1367 [ENTRY-9] 调整FormulaTemplateDialogViewModel支持处方导入
- Related to #1366 [ENTRY-8] 增强ImportFormulaAsync方法
- Part of Epic #1343 MVP实现 - 能看诊

## 📝 变更摘要

本PR为验方模板对话框添加导入验方功能，完成从Server到Client的全链路实现：
- ✅ Server端添加导入验方API端点
- ✅ Client端API/Repository/ViewModel三层实现
- ✅ 完整的依赖注入和命令绑定
- ✅ 对话框参数传递和结果通知

## 🔄 技术实现

### 1. Server端 (PrescriptionsController)
```csharp
[HttpPost("{prescriptionId}/import-formula/{formulaId}")]
public async Task<ActionResult<ApiResponse<PrescriptionDto>>> ImportFormulaIntoPrescription(
    Guid prescriptionId, Guid formulaId)
```
- RESTful路径设计
- 完整参数验证
- 操作日志记录

### 2. Client端 - API层 (IPrescriptionApi)
```csharp
[Refit.Post("/api/v1/prescriptions/{prescriptionId}/import-formula/{formulaId}")]
Task<Refit.ApiResponse<PrescriptionDto>> ImportFormulaIntoPrescriptionAsync(
    Guid prescriptionId, Guid formulaId);
```

### 3. Client端 - Repository层
- `IPrescriptionRepository`: 添加方法签名
- `PrescriptionRepository`: 实现导入逻辑
  - 参数验证
  - 异常处理
  - 日志记录

### 4. Client端 - ViewModel层 (FormulaTemplateDialogViewModel)
**新增内容**：
- 字段: `IPrescriptionRepository _prescriptionRepository`
- 属性: `Guid PrescriptionId`（通过对话框参数接收）
- 命令: `DelegateCommand ImportCommand`
- 方法: `ImportFormulaAsync()`, `CanImport()`

**修改内容**：
- 构造函数: 添加`IPrescriptionRepository`参数
- `OnDialogOpened`: 接收`PrescriptionId`参数
- `UpdateCommandStates`: 刷新ImportCommand状态

## ✅ 验收标准

- [x] Server端API端点添加完成
- [x] Client端API接口添加完成
- [x] Repository层实现完成
- [x] ViewModel添加ImportCommand
- [x] 实现导入验方逻辑
- [x] 对话框参数传递正确
- [x] 导入成功后关闭对话框并通知刷新
- [x] 编译通过（0错误）

## 🧪 测试验证

### 编译测试
```
dotnet build LYBT.All.sln -c Release --no-restore
✅ 编译成功: 0 错误, 7 警告（现有警告）
```

### 架构合规性
- ✅ 遵循三层架构（Server/Repository/ViewModel）
- ✅ 依赖注入使用正确
- ✅ 命令模式实现规范
- ✅ 异步方法命名规范（Async结尾）

## 📂 修改文件清单
- `src/Server/Services/LYBT.WebAPI/Controllers/PrescriptionsController.cs` (+50 lines)
- `src/Client/Desktop/Core/LYBT.Desktop.Contracts/Api/IPrescriptionApi.cs` (+9 lines)
- `src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Interfaces/IPrescriptionRepository.cs` (+7 lines)
- `src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Repositories/PrescriptionRepository.cs` (+29 lines)
- `src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/FormulaTemplateDialogViewModel.cs` (+62 lines)

**总计**: 5 个文件, +157 行

## 📚 后续任务
- Issue #1368 [ENTRY-10]: 在PrescriptionComposerViewModel中添加调用FormulaTemplateDialog的逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>