### PR TITLE
[ENTRY-10] 集成验方导入功能到处方编辑页面 (#1368)

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionCommandHandler.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/Components/PrescriptionCommandHandler.cs
@@ -5,6 +5,7 @@ using LYBT.Shared.Models.Contracts.Common;
 using LYBT.Shared.Models.Contracts.Prescriptions;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
+using Prism.Services.Dialogs;
 
 namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
 {
@@ -16,6 +17,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
     {
         private readonly IPrescriptionRepository _prescriptionRepository;
         private readonly ILogger<PrescriptionCommandHandler> _logger;
+        private readonly IDialogService _dialogService;
 
         #region 事件定义
 
@@ -33,6 +35,11 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
         /// 处方清空事件
         /// </summary>
         public event Action? OnPrescriptionCleared;
+
+        /// <summary>
+        /// 验方导入成功事件 (Issue #1368 ENTRY-10)
+        /// </summary>
+        public event Action? OnFormulaImported;
         #endregion
 
         #region 命令定义
@@ -96,11 +103,13 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
         public PrescriptionCommandHandler(
             IPrescriptionRepository prescriptionService,
             ILogger<PrescriptionCommandHandler> logger,
-            ISessionManager sessionManager)
+            ISessionManager sessionManager,
+            IDialogService dialogService)
         {
             _prescriptionRepository = prescriptionService ?? throw new ArgumentNullException(nameof(prescriptionService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+            _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
 
             // 初始化命令
             RecalculateCommand = new DelegateCommand(ExecuteRecalculate);
@@ -283,11 +292,32 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels.Components
         }
 
         /// <summary>
-        /// 执行导入验方
+        /// 执行导入验方 (Issue #1368 ENTRY-10)
         /// </summary>
         private void ExecuteImportFormula()
         {
-            _logger.LogInformation("执行导入验方");
+            if (_dataManager?.PrescriptionId == null || _dataManager.PrescriptionId == Guid.Empty)
+            {
+                _logger.LogWarning("无法导入验方：处方ID无效");
+                return;
+            }
+
+            _logger.LogInformation("打开验方模板对话框，处方ID: {PrescriptionId}", _dataManager.PrescriptionId);
+
+            var parameters = new DialogParameters
+            {
+                { "PrescriptionId", _dataManager.PrescriptionId }
+            };
+
+            _dialogService.ShowDialog("FormulaTemplateDialog", parameters, result =>
+            {
+                if (result.Result == ButtonResult.OK && result.Parameters.ContainsKey("Imported"))
+                {
+                    var formulaName = result.Parameters.GetValue<string>("FormulaName");
+                    _logger.LogInformation("验方 \"{FormulaName}\" 导入成功", formulaName);
+                    OnFormulaImported?.Invoke();
+                }
+            });
         }
 
         /// <summary>

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionComposerViewModel.cs
@@ -673,6 +673,9 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             // 订阅清空事件
             _commandHandler.OnPrescriptionCleared += OnPrescriptionCleared;
 
+            // 订阅验方导入成功事件 (Issue #1368 ENTRY-10)
+            _commandHandler.OnFormulaImported += OnFormulaImported;
+
             // 订阅处方项集合变化事件（Issue #1360）
             PrescriptionItems.CollectionChanged += (s, e) => RefreshItemRows();
         }
@@ -692,6 +695,39 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         {
             // 处方清空后的操作
             RecalculatePrice();
+        }
+
+        /// <summary>
+        /// 验方导入成功后刷新处方数据 (Issue #1368 ENTRY-10)
+        /// </summary>
+        private async void OnFormulaImported()
+        {
+            Logger.LogInformation("验方导入成功，重新加载处方数据");
+            
+            try
+            {
+                SetIsBusy(true, "正在刷新处方数据...");
+
+                // 直接重新初始化数据管理器，会自动加载最新的处方数据
+                await _dataManager.InitializeAsync(MedicalCaseId);
+
+                // 刷新显示行
+                RefreshItemRows();
+
+                // 重新计算价格
+                RecalculatePrice();
+
+                Logger.LogInformation("处方数据刷新完成");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "刷新处方数据时发生异常");
+                await ShowErrorMessageAsync("刷新处方数据失败，请重新加载页面");
+            }
+            finally
+            {
+                SetIsBusy(false);
+            }
         }
 
         #endregion


### PR DESCRIPTION
## 📋 关联 Issue
Closes #1368

## 📝 任务描述
集成验方导入命令到处方编辑页面（PrescriptionComposerView），实现点击"导入验方"按钮后打开验方模板对话框，选择验方并导入到当前处方，导入成功后自动刷新处方数据。

## ✅ 实现内容

### 1. PrescriptionCommandHandler.cs
- **添加 IDialogService 依赖**：在构造函数中注入 IDialogService
- **添加 OnFormulaImported 事件**：用于通知验方导入成功
- **实现 ExecuteImportFormula 方法**：
  - 验证处方ID有效性
  - 打开 FormulaTemplateDialog 对话框
  - 传递 PrescriptionId 参数
  - 处理对话框返回结果
  - 触发 OnFormulaImported 事件

### 2. PrescriptionComposerViewModel.cs
- **订阅 OnFormulaImported 事件**：在 SubscribeToEvents 方法中订阅
- **实现 OnFormulaImported 方法**：
  - 重新初始化数据管理器（自动加载最新处方数据）
  - 刷新显示行
  - 重新计算价格
  - 异常处理和用户提示

### 3. UI（已存在）
- PrescriptionComposerView.xaml 中已有"导入验方"按钮
- 按钮绑定到 ImportFormulaCommand

## 🔗 依赖任务
- ✅ #1367 - 验方模板对话框添加导入功能

## ✅ 验收标准
- [x] 处方编辑页面有"导入验方"按钮
- [x] 点击按钮打开验方模板对话框
- [x] 对话框接收 PrescriptionId 参数
- [x] 用户选择验方并确认后导入
- [x] 导入成功后自动刷新处方Items和ItemRows
- [x] 代码编译通过

## 🧪 测试说明
1. 打开处方编辑页面
2. 点击"导入验方"按钮
3. 验方模板对话框打开，显示已验证的验方列表
4. 选择验方并点击"导入"
5. 验证处方药材列表自动刷新显示导入的药材
6. 验证价格自动重新计算

## 📊 影响范围
- ✅ Client端：处方编辑器ViewModel和CommandHandler
- ❌ Server端：无变更
- ❌ Shared层：无变更

## 🔄 代码审查要点
- IDialogService 依赖注入是否正确
- 事件订阅和触发逻辑是否完整
- 异常处理是否完善
- 数据刷新逻辑是否正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)