### PR TITLE
[ARCH-2] 重命名PrescriptionComposerView为PrescriptionView

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionViewModel.cs
@@ -16,10 +16,11 @@ using Prism.Regions;
 namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 {
     /// <summary>
-    /// 处方编写器视图模型 - UltraThink精简架构
-    /// 核心处方编写界面，整合所有处方组件
+    /// 处方视图模型 - 统一架构实现
+    /// Issue #1445 (ARCH-2): 已废弃Phase 4B骨架，统一到PrescriptionComposerView重命名版本
+    /// 完整实现包含：8列DataGrid、验方导入、价格计算、历史复制等功能
     /// </summary>
-    public class PrescriptionComposerViewModel : UnifiedViewModelBase
+    public class PrescriptionViewModel : UnifiedViewModelBase
     {
         #region 服务依赖
 
@@ -424,7 +425,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 
         #region 构造函数
 
-        public PrescriptionComposerViewModel(
+        public PrescriptionViewModel(
             IPrescriptionRepository prescriptionRepository,
             IMedicalCaseRepository medicalCaseRepository,
             IHerbRepository herbRepository,

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionView.xaml
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="LYBT.Desktop.Prescriptions.Views.PrescriptionComposerView"
+﻿<UserControl x:Class="LYBT.Desktop.Prescriptions.Views.PrescriptionView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionView.xaml.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/Views/PrescriptionView.xaml.cs
@@ -7,14 +7,15 @@ namespace LYBT.Desktop.Prescriptions.Views
 {
 
     /// <summary>
-    /// PrescriptionComposerView - 处方组成编辑器主界面
-    /// UltraThink简化版本：专注于处方组成编辑，不包含历史管理等复杂功能
+    /// PrescriptionView - 处方编辑主界面
+    /// 统一架构实现（原PrescriptionComposerView，Issue #1445 ARCH-2重命名）
+    /// 完整实现包含：8列DataGrid、验方导入、价格计算、历史复制等功能
     /// Issue #1362: [ENTRY-4] 实现ComboBox拼音码过滤
     /// </summary>
-    public partial class PrescriptionComposerView : UserControl
+    public partial class PrescriptionView : UserControl
     {
 
-        public PrescriptionComposerView()
+        public PrescriptionView()
         {
             InitializeComponent();
         }
@@ -51,7 +52,7 @@ namespace LYBT.Desktop.Prescriptions.Views
                     // 添加TextChanged事件处理，触发过滤
                     textBox.TextChanged += (s, args) =>
                     {
-                        if (DataContext is PrescriptionComposerViewModel viewModel)
+                        if (DataContext is PrescriptionViewModel viewModel)
                         {
                             viewModel.FilterHerbs(textBox.Text);
                         }


### PR DESCRIPTION
## 📋 关联Issue
Closes #1447  
Epic: #1445  
Depends on: #1446 (ARCH-1)

## 📝 变更说明

统一处方编辑视图命名，消除架构混乱：

### 重命名文件（3个）
- ✅ `PrescriptionComposerView.xaml` → `PrescriptionView.xaml`
- ✅ `PrescriptionComposerView.xaml.cs` → `PrescriptionView.xaml.cs`  
- ✅ `PrescriptionComposerViewModel.cs` → `PrescriptionViewModel.cs`

### 更新内容
- ✅ XAML x:Class属性：`LYBT.Desktop.Prescriptions.Views.PrescriptionView`
- ✅ Code-behind类名：`public partial class PrescriptionView`
- ✅ ViewModel类名：`public class PrescriptionViewModel`
- ✅ DataContext类型引用：`DataContext is PrescriptionViewModel`
- ✅ 注释更新：标注Issue #1445 (ARCH-2)架构统一来源

### ⚠️ 已知残留（ARCH-3处理）
以下导航引用将在ARCH-3统一更新：
- `PrescriptionManagementViewModel.cs`: 2处导航到"PrescriptionComposerView"
- `PrescriptionsMainViewModel.cs`: 4处引用"PrescriptionComposerView"

## ✅ 测试验证

```bash
# 编译验证
dotnet build LYBT.All.sln -c Debug --no-restore
# 结果：✅ 已成功生成（0错误，4警告均为已存在）
```

## 🎯 架构影响

**Before (双轨架构)**：
- ❌ PrescriptionView（空骨架）+ PrescriptionComposerView（完整实现）
- ❌ 导航混乱：ClinicalWorkstation → PrescriptionView（空白界面）

**After (统一架构)**：
- ✅ 单一PrescriptionView（完整实现）
- ✅ 名称统一：PrescriptionComposerView → PrescriptionView
- ⏭️ ARCH-3将修正所有导航配置

## 📚 后续任务

- [ ] #1448 (ARCH-3): 更新所有导航配置（6处引用）
- [ ] #1449 (ARCH-4): 更新架构文档

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>