### PR TITLE
[BUG] 修复诊疗录入导航空白问题 (#1454)

### DIFF
--- a/src/Client/Desktop/Workstations/ClinicalWorkstation/ViewModels/ClinicalWorkstationViewModel.cs
+++ b/src/Client/Desktop/Workstations/ClinicalWorkstation/ViewModels/ClinicalWorkstationViewModel.cs
@@ -243,13 +243,14 @@ namespace LYBT.Desktop.ClinicalWorkstation.ViewModels
                 UpdateSelectionState(targetView);
 
                 // 根据参数映射视图
+                // Issue #1454: 修正DiagnosisView → ConsultationManagementView
                 string viewName = targetView switch
                 {
-                    "Diagnosis" => "DiagnosisView",
+                    "Diagnosis" => "ConsultationManagementView",  // ✅ 修正：使用实际存在的视图
                     "Prescription" => "PrescriptionView",
                     "PatientManagement" => "PatientManagementView",
                     "History" => "HistoryView",
-                    _ => "DiagnosisView"
+                    _ => "ConsultationManagementView"  // ✅ 默认也修正
                 };
 
                 _regionManager.RequestNavigate("ClinicalContentRegion", viewName);


### PR DESCRIPTION
## 📋 Issue
#1454 诊疗录入导航到不存在的DiagnosisView导致空白

## 🐛 问题描述
用户点击医生工作站"诊疗录入"菜单后，右侧内容区域完全空白，无法进行诊疗操作。

## 🔍 根本原因
```csharp
// Before (ClinicalWorkstationViewModel.cs:248)
"Diagnosis" => "DiagnosisView",  // ❌ DiagnosisView根本不存在！
```

**问题分析**：
- ClinicalWorkstationViewModel尝试导航到 `DiagnosisView`
- 但Consultation模块只注册了 `ConsultationManagementView`
- 导致Prism找不到视图，内容区域空白

## 🔧 修复方案
```csharp
// After (ClinicalWorkstationViewModel.cs:249)
"Diagnosis" => "ConsultationManagementView",  // ✅ 使用实际存在的视图
```

## 📝 变更内容
- 修改 `ClinicalWorkstationViewModel.cs` 第249行和253行
- 将导航目标从 `DiagnosisView` 改为 `ConsultationManagementView`
- 添加Issue注释说明修复原因

## ✅ 编译结果
- 编译成功：0 错误，4 警告（都是现有警告）

## 🎯 影响范围
- **核心功能修复**：医生工作站的诊疗录入功能恢复正常
- **不影响其他模块**：仅修改导航映射，不涉及数据逻辑

Closes #1454