### PR TITLE
test(herbs): 为HerbRepository添加单元测试 (#1469)

### DIFF
--- a/tests/UnitTests/Server/Modules/LYBT.Module.Herbs.Tests/Repositories/HerbRepositoryTests.cs
+++ b/tests/UnitTests/Server/Modules/LYBT.Module.Herbs.Tests/Repositories/HerbRepositoryTests.cs
@@ -1,0 +1,388 @@
+using FluentAssertions;
+using LYBT.Entities.Herbs;
+using LYBT.Infrastructure.Data;
+using LYBT.Module.Herbs.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LYBT.Module.Herbs.Tests.Repositories;
+
+/// <summary>
+/// HerbRepository 单元测试
+/// Issue #1469 (FORMULA-8) - 验证智能药材匹配功能
+/// </summary>
+public class HerbRepositoryTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly HerbRepository _sut;
+
+    public HerbRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new AppDbContext(options);
+        _sut = new HerbRepository(_context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    #region GetByNameAsync Tests
+
+    [Fact]
+    public async Task GetByNameAsync_WithExactName_ReturnsHerb()
+    {
+        // Arrange
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "柴胡",
+            PinYinCode = "CH",
+            Origin = "产地测试",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByNameAsync("柴胡");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("柴胡");
+        result.PinYinCode.Should().Be("CH");
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WithNonExistentName_ReturnsNull()
+    {
+        // Arrange - 空数据库
+
+        // Act
+        var result = await _sut.GetByNameAsync("不存在的药材");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_WithDeletedHerb_ReturnsNull()
+    {
+        // Arrange
+        var deletedHerb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "已删除药材",
+            PinYinCode = "YSCYC",
+            Origin = "测试",
+            CreatedBy = Guid.NewGuid(),
+            IsDeleted = true
+        };
+
+        _context.Herbs.Add(deletedHerb);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByNameAsync("已删除药材");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetByNameOrPinyinAsync Tests - Issue #1469核心功能
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithExactName_ReturnsHerb()
+    {
+        // Arrange
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "黄芪",
+            PinYinCode = "HQ",
+            Origin = "甘肃",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByNameOrPinyinAsync("黄芪");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("黄芪");
+        result.PinYinCode.Should().Be("HQ");
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithPinyinCode_ReturnsHerb()
+    {
+        // Arrange
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "当归",
+            PinYinCode = "DG",
+            Origin = "甘肃岷县",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act - 使用拼音码查询
+        var result = await _sut.GetByNameOrPinyinAsync("DG");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("当归");
+        result.PinYinCode.Should().Be("DG");
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithPartialPinyinCode_ReturnsHerb()
+    {
+        // Arrange
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "白芍",
+            PinYinCode = "BS",
+            Origin = "浙江",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act - 模糊匹配拼音码
+        var result = await _sut.GetByNameOrPinyinAsync("B");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("白芍");
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_PrioritizesExactNameMatch()
+    {
+        // Arrange - 创建两个药材，一个名称匹配，一个拼音码匹配
+        var herb1 = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "甘草",
+            PinYinCode = "GC",
+            Origin = "内蒙古",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var herb2 = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "测试药材",
+            PinYinCode = "甘草", // 拼音码包含"甘草"
+            Origin = "测试",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.AddRange(herb1, herb2);
+        await _context.SaveChangesAsync();
+
+        // Act - 应该优先返回名称精确匹配的
+        var result = await _sut.GetByNameOrPinyinAsync("甘草");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("甘草"); // 名称精确匹配优先
+        result.PinYinCode.Should().Be("GC");
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithNonExistentTerm_ReturnsNull()
+    {
+        // Arrange
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "川芎",
+            PinYinCode = "CX",
+            Origin = "四川",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByNameOrPinyinAsync("不存在");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithDeletedHerb_ReturnsNull()
+    {
+        // Arrange
+        var deletedHerb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "红花",
+            PinYinCode = "HH",
+            Origin = "新疆",
+            CreatedBy = Guid.NewGuid(),
+            IsDeleted = true
+        };
+
+        _context.Herbs.Add(deletedHerb);
+        await _context.SaveChangesAsync();
+
+        // Act - 按名称查询
+        var resultByName = await _sut.GetByNameOrPinyinAsync("红花");
+
+        // Act - 按拼音码查询
+        var resultByPinyin = await _sut.GetByNameOrPinyinAsync("HH");
+
+        // Assert
+        resultByName.Should().BeNull();
+        resultByPinyin.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithNullPinyinCode_OnlyMatchesName()
+    {
+        // Arrange - 药材没有拼音码
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "特殊药材",
+            PinYinCode = null, // 没有拼音码
+            Origin = "测试",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act - 按名称查询应该成功
+        var resultByName = await _sut.GetByNameOrPinyinAsync("特殊药材");
+
+        // Act - 按不存在的拼音码查询应该失败
+        var resultByPinyin = await _sut.GetByNameOrPinyinAsync("TSYC");
+
+        // Assert
+        resultByName.Should().NotBeNull();
+        resultByName!.Name.Should().Be("特殊药材");
+
+        resultByPinyin.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_WithMultiplePinyinMatches_ReturnsFirstMatch()
+    {
+        // Arrange - 创建多个拼音码包含相同字符的药材
+        var herb1 = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "白芷",
+            PinYinCode = "BZ",
+            Origin = "浙江",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        var herb2 = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "白术",
+            PinYinCode = "BS",
+            Origin = "浙江",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        // 确保插入顺序，先插入herb1
+        _context.Herbs.Add(herb1);
+        await _context.SaveChangesAsync();
+
+        _context.Herbs.Add(herb2);
+        await _context.SaveChangesAsync();
+
+        // Act - 模糊匹配"B"
+        var result = await _sut.GetByNameOrPinyinAsync("B");
+
+        // Assert - 应该返回第一个匹配的
+        result.Should().NotBeNull();
+        result!.PinYinCode.Should().Contain("B");
+    }
+
+    #endregion
+
+    #region 实际业务场景测试 - Issue #1469延迟绑定场景
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_ImportScenario_HandlesVariantNames()
+    {
+        // Arrange - 模拟老系统导入场景：药材有多个异名
+        var herb = new Herb
+        {
+            Id = Guid.NewGuid(),
+            Name = "柴胡", // 标准名称
+            PinYinCode = "CH",
+            Origin = "甘肃",
+            CreatedBy = Guid.NewGuid()
+        };
+
+        _context.Herbs.Add(herb);
+        await _context.SaveChangesAsync();
+
+        // Act - 老系统可能使用异名"北柴胡"导入
+        var resultByVariantName = await _sut.GetByNameOrPinyinAsync("北柴胡");
+
+        // Act - 但可以通过拼音码"CH"匹配
+        var resultByPinyin = await _sut.GetByNameOrPinyinAsync("CH");
+
+        // Assert
+        resultByVariantName.Should().BeNull(); // 异名无法直接匹配
+        resultByPinyin.Should().NotBeNull();   // 拼音码可以匹配
+        resultByPinyin!.Name.Should().Be("柴胡");
+    }
+
+    [Fact]
+    public async Task GetByNameOrPinyinAsync_BatchImportScenario_PerformanceTest()
+    {
+        // Arrange - 创建100个药材模拟大批量导入
+        var herbs = new List<Herb>();
+        for (int i = 0; i < 100; i++)
+        {
+            herbs.Add(new Herb
+            {
+                Id = Guid.NewGuid(),
+                Name = $"药材{i}",
+                PinYinCode = $"YC{i}",
+                Origin = "测试产地",
+                CreatedBy = Guid.NewGuid()
+            });
+        }
+
+        _context.Herbs.AddRange(herbs);
+        await _context.SaveChangesAsync();
+
+        // Act - 查询中间某个药材
+        var result = await _sut.GetByNameOrPinyinAsync("药材50");
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Name.Should().Be("药材50");
+        result.PinYinCode.Should().Be("YC50");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## 📝 变更摘要

为 `HerbRepository` 添加完整的单元测试覆盖，验证 Issue #1351 (FORMULA-8) 中实现的智能药材匹配功能。

**测试文件**：
- `tests/UnitTests/Server/Modules/LYBT.Module.Herbs.Tests/Repositories/HerbRepositoryTests.cs` (新增)

**测试覆盖**：
- ✅ `GetByNameAsync` 基础测试（3个）
- ✅ `GetByNameOrPinyinAsync` 核心功能测试（10个）
  - 精确名称匹配优先
  - 拼音码模糊匹配
  - 软删除过滤
  - 空值处理
  - 批量导入性能测试

## ✅ 测试结果

**测试通过率**: 100% (25/25)
- 新增: 13个 HerbRepositoryTests
- 已有: 12个 HerbMappingProfileTests

```
测试总数: 25
     通过数: 25
总时间: 3.28秒
```

## 🔗 关联Issue

Closes #1469

## 📋 验收标准

- [x] 所有新增测试通过
- [x] 测试覆盖核心功能（精确匹配、模糊匹配、优先级）
- [x] 测试覆盖边界情况（软删除、空值、批量）
- [x] 编译成功，无警告

## 🎯 验证Issue #1351功能

此PR验证了Issue #1351中已实现的 `GetByNameOrPinyinAsync` 方法，该方法是Epic #1343 FORMULA-8任务的核心功能，用于支持验方导入时的智能药材匹配。

🤖 Generated with [Claude Code](https://claude.com/claude-code)