### PR TITLE
feat(desktop): Desktop端功能简化 - FeatureToggleService实现 (Issue #1479 Phase 2)

### DIFF
--- a/src/Client/Desktop/Core/LYBT.Desktop.Infrastructure/Interfaces/IFeatureToggleService.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Infrastructure/Interfaces/IFeatureToggleService.cs
@@ -1,0 +1,19 @@
+namespace LYBT.Desktop.Infrastructure.Interfaces
+{
+    /// <summary>
+    /// 功能开关服务接口 - MVP阶段功能控制 (Issue #1477 #1479)
+    /// </summary>
+    /// <remarks>
+    /// 用于控制Desktop端功能的启用/禁用状态，支持MVP阶段的功能简化。
+    /// 配置存储在appsettings.json的FeatureToggles节点中。
+    /// </remarks>
+    public interface IFeatureToggleService
+    {
+        /// <summary>
+        /// 检查指定功能是否启用
+        /// </summary>
+        /// <param name="featureKey">功能键名（如 "Consultation.Create"）</param>
+        /// <returns>true表示功能启用，false表示功能禁用</returns>
+        bool IsEnabled(string featureKey);
+    }
+}

--- a/src/Client/Desktop/Core/LYBT.Desktop.Infrastructure/Services/FeatureToggleService.cs
+++ b/src/Client/Desktop/Core/LYBT.Desktop.Infrastructure/Services/FeatureToggleService.cs
@@ -1,0 +1,43 @@
+using LYBT.Desktop.Infrastructure.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace LYBT.Desktop.Infrastructure.Services
+{
+    /// <summary>
+    /// 功能开关服务实现 - 简化的Dictionary版本 (Issue #1477 #1479)
+    /// </summary>
+    /// <remarks>
+    /// MVP阶段使用简单的Dictionary&lt;string, bool&gt;存储功能开关配置。
+    /// 配置从appsettings.json的FeatureToggles节点读取。
+    /// Post-MVP阶段可扩展为支持远程配置、动态刷新、AB测试等高级功能。
+    /// </remarks>
+    public class FeatureToggleService : IFeatureToggleService
+    {
+        private readonly Dictionary<string, bool> _features;
+
+        /// <summary>
+        /// 构造函数 - 从配置文件加载功能开关
+        /// </summary>
+        /// <param name="configuration">配置对象（注入）</param>
+        public FeatureToggleService(IConfiguration configuration)
+        {
+            // 从配置文件的FeatureToggles节点读取功能开关
+            _features = configuration.GetSection("FeatureToggles")
+                .Get<Dictionary<string, bool>>() ?? new Dictionary<string, bool>();
+
+            // 记录加载的功能开关数量（便于调试）
+            Console.WriteLine($"[FeatureToggleService] 已加载 {_features.Count} 个功能开关配置");
+        }
+
+        /// <summary>
+        /// 检查指定功能是否启用
+        /// </summary>
+        /// <param name="featureKey">功能键名（如 "Consultation.Create"）</param>
+        /// <returns>true表示功能启用，false表示功能禁用或未配置</returns>
+        public bool IsEnabled(string featureKey)
+        {
+            // 如果配置中没有该功能键，默认返回false（保守策略）
+            return _features.TryGetValue(featureKey, out var enabled) && enabled;
+        }
+    }
+}

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationManagementViewModel.cs
@@ -13,17 +13,18 @@ namespace LYBT.Desktop.Consultation.ViewModels
 {
 
     /// <summary>
-    /// ���Ƽ�¼������ͼģ�� - �򻯰�
-    /// ֻ������ʾ�ͻ����������Ƽ�¼�����������ӵ����̿���
+    /// 诊疗记录管理视图模型 - 简化版 (Issue #1477 #1479)
+    /// 只支持查看和基本操作，诊疗记录的创建由病案流程控制
     /// </summary>
     public class ConsultationManagementViewModel : UnifiedViewModelBase
     {
 
-        #region ��������
+        #region 私有字段
 
         private readonly IConsultationRepository _consultationRepository;
+        private readonly IFeatureToggleService _featureToggleService;
 
-        #endregion ��������
+        #endregion 私有字段
 
         #region ����
 
@@ -59,7 +60,21 @@ namespace LYBT.Desktop.Consultation.ViewModels
             set => SetProperty(ref _searchKeyword, value);
         }
 
-        #endregion ����
+        #endregion 属性
+
+        #region 功能开关属性 (Issue #1477 #1479)
+
+        /// <summary>
+        /// 是否允许查看详情
+        /// </summary>
+        public bool CanViewDetail => _featureToggleService.IsEnabled("Consultation.ViewDetail");
+
+        /// <summary>
+        /// 是否允许搜索
+        /// </summary>
+        public bool CanSearch => _featureToggleService.IsEnabled("Consultation.Search");
+
+        #endregion 功能开关属性
 
         #region ����
 
@@ -79,10 +94,11 @@ namespace LYBT.Desktop.Consultation.ViewModels
 
         #endregion ����
 
-        #region ���캯��
+        #region 构造函数
 
         public ConsultationManagementViewModel(
         IConsultationRepository consultationRepository,
+        IFeatureToggleService featureToggleService,
         IEventAggregator eventAggregator,
         ILoggerFactory loggerFactory,
         IRegionManager regionManager,
@@ -91,11 +107,12 @@ namespace LYBT.Desktop.Consultation.ViewModels
         : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
             _consultationRepository = consultationRepository ?? throw new ArgumentNullException(nameof(consultationRepository));
+            _featureToggleService = featureToggleService ?? throw new ArgumentNullException(nameof(featureToggleService));
 
             LoadDataCommand = new DelegateCommand(async () => await LoadDataAsync());
-            SearchCommand = new DelegateCommand(async () => await SearchAsync());
+            SearchCommand = new DelegateCommand(async () => await SearchAsync(), () => CanSearch);
             RefreshCommand = new DelegateCommand(async () => await RefreshAsync());
-            ViewDetailsCommand = new DelegateCommand<ConsultationDto>(ViewDetails, item => item != null);
+            ViewDetailsCommand = new DelegateCommand<ConsultationDto>(ViewDetails, item => item != null && CanViewDetail);
 
             ViewPrescriptionCommand = new DelegateCommand<ConsultationDto>(ViewPrescription, item => item != null);
             PrintCommand = new DelegateCommand<ConsultationDto>(Print, item => item != null);

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Herbs/ViewModels/HerbDetailViewModel.cs
@@ -424,6 +424,11 @@ namespace LYBT.Desktop.Herbs.ViewModels
                 StatusMessage = "正在加载药材信息...";
 
                 var herb = await _herbRepository.GetByIdAsync(herbId);
+                if (herb == null)
+                {
+                    StatusMessage = "未找到药材信息";
+                    return;
+                }
                 Herb = herb;
                 LoadFromDto(herb);
             }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseDetailViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseDetailViewModel.cs
@@ -357,6 +357,11 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
 
                 // 重新加载病历数据
                 var medicalCase = await _medicalCaseRepository.GetByIdAsync(MedicalCase.Id);
+                if (medicalCase == null)
+                {
+                    await ShowErrorMessageAsync("未找到病历数据");
+                    return;
+                }
                 LoadMedicalCase(medicalCase);
                 await ShowSuccessMessageAsync("数据刷新成功");
             }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionManagementViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Prescriptions/ViewModels/PrescriptionManagementViewModel.cs
@@ -11,7 +11,7 @@ using Prism.Regions;
 namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 {
     /// <summary>
-    /// 处方管理视图模型 - UltraThink精简架构
+    /// 处方管理视图模型 - UltraThink精简架构 (Issue #1477 #1479)
     /// 作为处方模块的主导航和管理容器
     /// Issue #1445 (ARCH-3): 统一导航目标到PrescriptionView（已删除空骨架）
     /// </summary>
@@ -20,6 +20,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
         #region 服务依赖
 
         private readonly IPrescriptionRepository _prescriptionRepository;
+        private readonly IFeatureToggleService _featureToggleService;
 
         #endregion
 
@@ -111,6 +112,40 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             get => _pageSize;
             set => SetProperty(ref _pageSize, value);
         }
+
+        #endregion
+
+        #region 功能开关属性 (Issue #1477 #1479)
+
+        /// <summary>
+        /// 是否允许创建处方（MVP禁用）
+        /// </summary>
+        public bool CanCreate => _featureToggleService.IsEnabled("Prescription.Create");
+
+        /// <summary>
+        /// 是否允许删除处方（MVP禁用）
+        /// </summary>
+        public bool CanDelete => _featureToggleService.IsEnabled("Prescription.Delete");
+
+        /// <summary>
+        /// 是否允许复制处方（MVP启用）
+        /// </summary>
+        public bool CanClone => _featureToggleService.IsEnabled("Prescription.Clone");
+
+        /// <summary>
+        /// 是否允许导出处方（MVP启用）
+        /// </summary>
+        public bool CanExport => _featureToggleService.IsEnabled("Prescription.Export");
+
+        /// <summary>
+        /// 是否允许查看详情（MVP启用）
+        /// </summary>
+        public bool CanViewDetail => _featureToggleService.IsEnabled("Prescription.ViewDetail");
+
+        /// <summary>
+        /// 是否允许搜索（MVP启用）
+        /// </summary>
+        public bool CanSearch => _featureToggleService.IsEnabled("Prescription.Search");
 
         #endregion
 
@@ -213,6 +248,7 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
 
         public PrescriptionManagementViewModel(
             IPrescriptionRepository prescriptionRepository,
+            IFeatureToggleService featureToggleService,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
@@ -221,30 +257,31 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             : base(eventAggregator, loggerFactory, regionManager, sessionManager, userNotificationService)
         {
             _prescriptionRepository = prescriptionRepository ?? throw new ArgumentNullException(nameof(prescriptionRepository));
+            _featureToggleService = featureToggleService ?? throw new ArgumentNullException(nameof(featureToggleService));
 
-            // 初始化命令
+            // 初始化命令（基于功能开关）
             LoadDataCommand = new DelegateCommand(async () => await LoadDataAsync());
-            SearchCommand = new DelegateCommand(async () => await SearchAsync());
-            CreateCommand = new DelegateCommand(Create);
+            SearchCommand = new DelegateCommand(async () => await SearchAsync(), () => CanSearch);
+            CreateCommand = new DelegateCommand(Create, () => CanCreate);
             AddPrescriptionCommand = CreateCommand; // 别名
-            EditCommand = new DelegateCommand(Edit, CanEdit);
-            DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), CanDelete);
-            ViewDetailCommand = new DelegateCommand(ViewDetail, CanViewDetail);
+            EditCommand = new DelegateCommand(Edit, CanEditInternal);
+            DeleteCommand = new DelegateCommand(async () => await DeleteAsync(), CanDeleteInternal);
+            ViewDetailCommand = new DelegateCommand(ViewDetail, CanViewDetailInternal);
             PrintCommand = new DelegateCommand(Print, CanPrint);
             RefreshCommand = new DelegateCommand(async () => await RefreshAsync());
             PreviousPageCommand = new DelegateCommand(async () => await PreviousPageAsync(), CanPreviousPage);
             NextPageCommand = new DelegateCommand(async () => await NextPageAsync(), CanNextPage);
 
-            // DataGrid 行命令
-            ViewPrescriptionCommand = new DelegateCommand<PrescriptionDto>(ViewPrescriptionItem, item => item != null);
+            // DataGrid 行命令（基于功能开关）
+            ViewPrescriptionCommand = new DelegateCommand<PrescriptionDto>(ViewPrescriptionItem, item => item != null && CanViewDetail);
             ViewPatientHistoryCommand = new DelegateCommand<PrescriptionDto>(ViewPatientHistory, item => item != null);
             EditPrescriptionCommand = new DelegateCommand<PrescriptionDto>(EditPrescriptionItem, item => item != null && !IsBusy);
-            CopyPrescriptionCommand = new DelegateCommand<PrescriptionDto>(CopyPrescription, item => item != null && !IsBusy);
-            DeletePrescriptionCommand = new DelegateCommand<PrescriptionDto>(async item => await DeletePrescriptionItemAsync(item), item => item != null && !IsBusy);
+            CopyPrescriptionCommand = new DelegateCommand<PrescriptionDto>(CopyPrescription, item => item != null && !IsBusy && CanClone);
+            DeletePrescriptionCommand = new DelegateCommand<PrescriptionDto>(async item => await DeletePrescriptionItemAsync(item), item => item != null && !IsBusy && CanDelete);
 
-            // 其他命令
+            // 其他命令（基于功能开关）
             ClearFiltersCommand = new DelegateCommand(ClearFilters, () => !string.IsNullOrEmpty(SearchText) || StartDate.HasValue || EndDate.HasValue);
-            ExportPrescriptionsCommand = new DelegateCommand(async () => await ExportPrescriptionsAsync(), () => Prescriptions.Count > 0 && !IsBusy);
+            ExportPrescriptionsCommand = new DelegateCommand(async () => await ExportPrescriptionsAsync(), () => Prescriptions.Count > 0 && !IsBusy && CanExport);
 
             // 属性变更时刷新命令状态
             PropertyChanged += (s, e) => UpdateCommandStates();
@@ -522,9 +559,9 @@ namespace LYBT.Desktop.Modules.Prescriptions.ViewModels
             }
         }
 
-        private bool CanEdit() => SelectedPrescription != null && !IsBusy;
-        private bool CanDelete() => SelectedPrescription != null && !IsBusy;
-        private bool CanViewDetail() => SelectedPrescription != null;
+        private bool CanEditInternal() => SelectedPrescription != null && !IsBusy;
+        private bool CanDeleteInternal() => SelectedPrescription != null && !IsBusy && CanDelete;
+        private bool CanViewDetailInternal() => SelectedPrescription != null && CanViewDetail;
         private bool CanPrint() => SelectedPrescription != null;
         private bool CanPreviousPage() => CurrentPage > 1 && !IsBusy;
         private bool CanNextPage()

--- a/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Client/Desktop/Shell/Extensions/ServiceCollectionExtensions.cs
@@ -322,6 +322,10 @@ namespace LYBT.Desktop.Shell.Extensions
             containerRegistry.RegisterSingleton<LYBT.Desktop.Infrastructure.Services.IKeyboardShortcutService,
                 LYBT.Desktop.Infrastructure.Services.KeyboardShortcutService>();
 
+            // 功能开关服务 (Issue #1477 #1479 架构纠正v2)
+            containerRegistry.RegisterSingleton<LYBT.Desktop.Infrastructure.Interfaces.IFeatureToggleService,
+                LYBT.Desktop.Infrastructure.Services.FeatureToggleService>();
+
             // 注意：UserExperienceService 已移至 Presentation 层（UI体验服务应属于 Presentation 层）
             // 如需使用，请在 App.xaml.cs 中调用 services.AddDesktopPresentation()
         }

--- a/src/Client/Desktop/Shell/appsettings.json
+++ b/src/Client/Desktop/Shell/appsettings.json
@@ -10,5 +10,23 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "FeatureToggles": {
+    "Consultation.Create": false,
+    "Consultation.Edit": false,
+    "Consultation.Delete": false,
+    "Consultation.ViewDetail": true,
+    "Consultation.Search": true,
+    "Prescription.Create": false,
+    "Prescription.Delete": false,
+    "Prescription.Clone": true,
+    "Prescription.Export": true,
+    "Prescription.ViewDetail": true,
+    "Prescription.Search": true,
+    "MedicalCase.Create": true,
+    "MedicalCase.Edit": true,
+    "MedicalCase.Delete": true,
+    "MedicalCase.ViewDetail": true,
+    "MedicalCase.Search": true
   }
 }

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.Consultation.Tests/ViewModels/ConsultationManagementViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.Consultation.Tests/ViewModels/ConsultationManagementViewModelTests.cs
@@ -20,6 +20,7 @@ namespace LYBT.Desktop.Consultation.Tests.ViewModels
     public class ConsultationManagementViewModelTests : IDisposable
     {
         private readonly Mock<IConsultationRepository> _consultationRepositoryMock;
+        private readonly Mock<IFeatureToggleService> _featureToggleServiceMock;
         private readonly Mock<IEventAggregator> _eventAggregatorMock;
         private readonly Mock<ILoggerFactory> _loggerFactoryMock;
         private readonly Mock<ILogger<ConsultationManagementViewModel>> _loggerMock;
@@ -32,6 +33,7 @@ namespace LYBT.Desktop.Consultation.Tests.ViewModels
         {
             // 初始化Mocks
             _consultationRepositoryMock = new Mock<IConsultationRepository>();
+            _featureToggleServiceMock = new Mock<IFeatureToggleService>();
             _eventAggregatorMock = new Mock<IEventAggregator>();
             _loggerFactoryMock = new Mock<ILoggerFactory>();
             _loggerMock = new Mock<ILogger<ConsultationManagementViewModel>>();
@@ -44,11 +46,20 @@ namespace LYBT.Desktop.Consultation.Tests.ViewModels
                 .Setup(x => x.CreateLogger(It.IsAny<string>()))
                 .Returns(_loggerMock.Object);
 
+            // 设置FeatureToggleService默认行为（MVP配置：ViewDetail和Search启用）
+            _featureToggleServiceMock
+                .Setup(x => x.IsEnabled("Consultation.ViewDetail"))
+                .Returns(true);
+            _featureToggleServiceMock
+                .Setup(x => x.IsEnabled("Consultation.Search"))
+                .Returns(true);
+
             // EventAggregator不需要特殊设置，使用默认Mock行为即可
 
             // 创建ViewModel实例（使用Repository）
             _viewModel = new ConsultationManagementViewModel(
                 _consultationRepositoryMock.Object,
+                _featureToggleServiceMock.Object,
                 _eventAggregatorMock.Object,
                 _loggerFactoryMock.Object,
                 _regionManagerMock.Object,


### PR DESCRIPTION
## 📋 关联Issue
Closes #1479

## 📝 变更概述

实现Desktop端功能开关服务（FeatureToggleService），基于appsettings.json配置实现MVP阶段的功能简化。

### 核心变更

#### 1. FeatureToggleService实现
- ✅ 新增`IFeatureToggleService`接口
- ✅ 新增`FeatureToggleService`实现（基于Dictionary<string, bool>的MVP版本）
- ✅ 在`ServiceCollectionExtensions`中注册服务（Singleton生命周期）
- ✅ 在`appsettings.json`中配置FeatureToggles节点

#### 2. ViewModel调整
- ✅ `ConsultationManagementViewModel`：注入IFeatureToggleService，添加功能开关属性
- ✅ `PrescriptionManagementViewModel`：注入IFeatureToggleService，添加功能开关属性

#### 3. 测试修复
- ✅ `ConsultationManagementViewModelTests`：添加IFeatureToggleService Mock
- ✅ 8个测试全部通过

#### 4. 代码质量改进
- ✅ 修复2个编译警告（MedicalCaseDetailViewModel和HerbDetailViewModel的null检查）

### MVP功能配置

**Consultation模块**：
- ✅ ViewDetail: 启用
- ✅ Search: 启用
- ❌ Create/Edit/Delete: 禁用（通过MedicalCase聚合根）

**Prescription模块**：
- ✅ ViewDetail: 启用
- ✅ Search: 启用
- ✅ Clone: 启用
- ✅ Export: 启用
- ❌ Create/Delete: 禁用（通过MedicalCase聚合根）

**MedicalCase模块**：
- ✅ 所有功能启用（作为聚合根）

## ✅ 验证结果

### 编译验证
- ✅ 编译通过（0警告0错误）
- ✅ 所有项目成功生成

### 单元测试
- ✅ ConsultationManagementViewModel: 8个测试通过

### 架构验证
- ✅ 符合DDD聚合根模式
- ✅ 符合MVP简化原则
- ✅ 依赖注入配置正确

## 🔄 后续工作

Phase 2 Day 2下午的MedicalCaseModule强化任务已在Phase 1完成，可跳过。

## 📚 文档影响

无需更新文档（配置驱动，无架构变更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)