### PR TITLE
feat(medicalcase): 实现医案流程状态机逻辑 (#1501)

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Interfaces/ISaveable.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Interfaces/ISaveable.cs
@@ -1,0 +1,15 @@
+namespace LYBT.Desktop.MedicalCase.Interfaces
+{
+    /// <summary>
+    /// 可保存接口 - 流程状态机使用（Epic #1494 - Task #1501）
+    /// Step ViewModel实现此接口，提供保存当前步骤数据的能力
+    /// </summary>
+    public interface ISaveable
+    {
+        /// <summary>
+        /// 保存当前步骤数据
+        /// </summary>
+        /// <returns>保存成功返回true，失败返回false</returns>
+        Task<bool> SaveAsync();
+    }
+}

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Interfaces/IValidatable.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Interfaces/IValidatable.cs
@@ -1,0 +1,20 @@
+namespace LYBT.Desktop.MedicalCase.Interfaces
+{
+    /// <summary>
+    /// 可验证接口 - 流程状态机使用（Epic #1494 - Task #1501）
+    /// Step ViewModel实现此接口，提供验证当前步骤必填项的能力
+    /// </summary>
+    public interface IValidatable
+    {
+        /// <summary>
+        /// 验证当前步骤数据
+        /// </summary>
+        /// <returns>验证通过返回true，失败返回false</returns>
+        bool Validate();
+
+        /// <summary>
+        /// 获取验证错误消息
+        /// </summary>
+        string ValidationMessage { get; }
+    }
+}

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
@@ -1,3 +1,4 @@
+using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Desktop.MedicalCase.Models;
 using LYBT.Desktop.Models.ViewModels.Base;
 using Microsoft.Extensions.Logging;
@@ -137,7 +138,7 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
             // 初始化命令
             BackToHomeCommand = new DelegateCommand(ExecuteBackToHome);
             PreviousStepCommand = new DelegateCommand(ExecutePreviousStep, CanExecutePreviousStep);
-            NextStepCommand = new DelegateCommand(ExecuteNextStep, CanExecuteNextStep);
+            NextStepCommand = new DelegateCommand(async () => await ExecuteNextStepAsync(), CanExecuteNextStep);
             SaveDraftCommand = new DelegateCommand(ExecuteSaveDraft);
             CancelCommand = new DelegateCommand(ExecuteCancel);
 
@@ -193,9 +194,9 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
         }
 
         /// <summary>
-        /// 下一步
+        /// 下一步（Task #1501 - 状态机逻辑）
         /// </summary>
-        private void ExecuteNextStep()
+        private async Task ExecuteNextStepAsync()
         {
             if (CurrentStep >= FlowStep.CompleteMedicalCase)
             {
@@ -207,6 +208,61 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
 
             try
             {
+                SetIsBusy(true, "正在处理...");
+
+                // 1. 验证当前步骤
+                if (CurrentStepViewModel is IValidatable validatable)
+                {
+                    Logger.LogInformation("验证Step {CurrentStep}数据", CurrentStep);
+                    if (!validatable.Validate())
+                    {
+                        Logger.LogWarning("Step {CurrentStep}验证失败：{Message}", CurrentStep, validatable.ValidationMessage);
+                        await ShowErrorMessageAsync(validatable.ValidationMessage);
+                        return;
+                    }
+                }
+
+                // 2. 保存当前步骤
+                if (CurrentStepViewModel is ISaveable saveable)
+                {
+                    Logger.LogInformation("保存Step {CurrentStep}数据", CurrentStep);
+                    var saveResult = await saveable.SaveAsync();
+                    if (!saveResult)
+                    {
+                        Logger.LogWarning("Step {CurrentStep}保存失败", CurrentStep);
+                        await ShowErrorMessageAsync("保存失败，请检查数据后重试");
+                        return;
+                    }
+                }
+
+                // 3. 关键步骤自动创建实体
+                if (CurrentStep == FlowStep.SelectPatient)
+                {
+                    // Step 1 → Step 2: 自动创建MedicalCase
+                    Logger.LogInformation("Step 1完成，准备创建MedicalCase");
+
+                    // TODO: Task #1497实现PatientSelectionViewModel后，获取SelectedPatient
+                    // var patientVM = CurrentStepViewModel as PatientSelectionViewModel;
+                    // var selectedPatient = patientVM.SelectedPatient;
+
+                    // 创建MedicalCase
+                    var medicalCaseId = await CreateMedicalCaseAsync(Guid.Empty); // TODO: 传入真实PatientId
+                    if (medicalCaseId == Guid.Empty)
+                    {
+                        Logger.LogError("创建MedicalCase失败");
+                        await ShowErrorMessageAsync("创建医案失败，请重试");
+                        return;
+                    }
+
+                    MedicalCaseId = medicalCaseId;
+                    Logger.LogInformation("MedicalCase创建成功，ID: {MedicalCaseId}", MedicalCaseId);
+
+                    // TODO: Task #1497实现后，更新患者信息条
+                    // SelectedPatientName = selectedPatient.Name;
+                    // SelectedPatientInfo = $"{selectedPatient.Gender} | {selectedPatient.Age}岁 | {selectedPatient.PhoneNumber}";
+                }
+
+                // 4. 跳转到下一步
                 var nextStep = (FlowStep)((int)CurrentStep + 1);
                 Logger.LogInformation("从 {CurrentStep} 前进到 {NextStep}", CurrentStep, nextStep);
                 NavigateToStep(nextStep);
@@ -214,6 +270,11 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
             catch (Exception ex)
             {
                 Logger.LogError(ex, "执行下一步时发生异常");
+                await ShowErrorMessageAsync($"操作失败：{ex.Message}");
+            }
+            finally
+            {
+                SetIsBusy(false);
             }
         }
 
@@ -265,6 +326,40 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
         #endregion
 
         #region 辅助方法
+
+        /// <summary>
+        /// 创建MedicalCase（Task #1501 - Step 1 → Step 2 自动创建）
+        /// </summary>
+        /// <param name="patientId">患者ID</param>
+        /// <returns>创建成功返回MedicalCaseId，失败返回Guid.Empty</returns>
+        private async Task<Guid> CreateMedicalCaseAsync(Guid patientId)
+        {
+            try
+            {
+                Logger.LogInformation("开始创建MedicalCase，PatientId: {PatientId}", patientId);
+
+                // TODO: Task #1497实现后，调用真实API创建MedicalCase
+                // var request = new CreateMedicalCaseRequest
+                // {
+                //     PatientId = patientId,
+                //     DoctorId = _sessionManager.CurrentUser.Id,
+                //     VisitDate = DateTime.Now
+                // };
+                // var response = await _medicalCaseRepository.CreateAsync(request);
+                // return response.Id;
+
+                // 临时模拟：返回新GUID
+                await Task.Delay(500); // 模拟网络延迟
+                var medicalCaseId = Guid.NewGuid();
+                Logger.LogInformation("MedicalCase创建成功（模拟），ID: {MedicalCaseId}", medicalCaseId);
+                return medicalCaseId;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "创建MedicalCase失败，PatientId: {PatientId}", patientId);
+                return Guid.Empty;
+            }
+        }
 
         /// <summary>
         /// 导航到指定步骤


### PR DESCRIPTION
## 📋 关联Issue
Closes #1501

**Epic**: #1494 医案流程UI实现  
**Phase**: Phase 1 - 核心流程框架

---

## 📝 实施内容

### 1. 新增接口文件
- `Interfaces/ISaveable.cs` - 可保存接口（13行）
  - `Task<bool> SaveAsync()` 方法
- `Interfaces/IValidatable.cs` - 可验证接口（18行）
  - `bool Validate()` 方法
  - `string ValidationMessage` 属性

### 2. 重构 MedicalCaseFlowViewModel.cs
- **异步命令模式**：NextStepCommand改为异步包装器
- **ExecuteNextStepAsync 状态机逻辑**（80行）：
  - Step 4 特殊处理：完成看诊返回主页
  - **验证阶段**：检查 CurrentStepViewModel 是否实现 IValidatable，调用 Validate()
  - **保存阶段**：检查 CurrentStepViewModel 是否实现 ISaveable，调用 SaveAsync()
  - **实体创建**：Step 1→Step 2 自动创建 MedicalCase（DDD聚合根）
  - **错误处理**：验证/保存失败时显示错误提示，阻止流程前进
  - **加载状态**：SetIsBusy 管理 UI 加载状态
- **CreateMedicalCaseAsync 辅助方法**（33行）：
  - 临时模拟实现（返回新GUID + 500ms延迟）
  - TODO注释标记未来API集成点

---

## ✅ 验收标准检查

- [x] FlowStep枚举：SelectPatient(1), FillConsultation(2), FillPrescription(3), CompleteMedicalCase(4) *(Task #1496已实现)*
- [x] NavigateToStep逻辑：根据Step创建对应ViewModel *(Task #1496已实现)*
- [x] NextStep逻辑：
  - [x] 验证当前StepViewModel实现IValidatable接口，调用Validate()
  - [x] 保存当前StepViewModel实现ISaveable接口，调用SaveAsync()
  - [x] Step 1 → Step 2：自动创建MedicalCase
- [x] 编译通过（0 errors, 0 warnings）
- [ ] 单元测试：状态机切换逻辑、验证逻辑、数据传递逻辑 *(待Task #1497-#1500实现后补充)*

---

## 🔧 编译结果
```
已成功生成。
    0 个警告
    0 个错误
已用时间 00:01:17.17
```

---

## 📚 技术要点

1. **多态接口设计**：ISaveable/IValidatable 允许不同 Step ViewModel 实现各自的验证和保存逻辑
2. **异步命令包装**：`new DelegateCommand(async () => await ExecuteNextStepAsync(), ...)` 避免阻塞UI线程
3. **早返回模式**：验证/保存失败时立即返回，避免嵌套if
4. **DDD聚合根**：MedicalCase 在 Step 1→Step 2 自动创建，符合 `.spec-workflow/steering/tech.md` 设计
5. **TODO标记**：为 Task #1497-#1500 预留集成点（获取患者信息、调用真实API）

---

## 🎯 下一步

- Task #1497 - Step 1 - PatientSelectionView（实现 IValidatable 接口）
- Task #1498 - Step 2 - ConsultationFormView（实现 ISaveable + IValidatable 接口）
- Task #1499 - Step 3 - PrescriptionEditorView（实现 ISaveable + IValidatable 接口）
- Task #1500 - Step 4 - CompletionView（实现保存和状态设置逻辑）

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)