### PR TITLE
[Task-5] Step 3 - PrescriptionEditor实现（8列DataGrid）

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/MedicalCaseModule.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/MedicalCaseModule.cs
@@ -29,14 +29,16 @@ namespace LYBT.Desktop.MedicalCase
             containerRegistry.RegisterDialog<Views.CreateMedicalCaseDialog, ViewModels.CreateMedicalCaseDialogViewModel>();
 
             // 注册视图模型 - MVP核心功能
-            containerRegistry.Register<ViewModels.MedicalCaseEntryViewModel>();  // Issue #1463: 病案录入
+            containerRegistry.Register<ViewModels.MedicalCaseEntryViewModel>();       // Issue #1463: 病案录入
+            containerRegistry.Register<ViewModels.PrescriptionEditorViewModel>();     // Epic #1494 - Task #1499: Step 3 处方编辑器
             // TODO: 修复编译错误后再启用
             // containerRegistry.Register<MedicalCaseManagementViewModel>();
             // containerRegistry.Register<MedicalCaseListViewModel>();
 
             // 注册视图用于导航 - 需要对应视图文件存在
-            containerRegistry.RegisterForNavigation<Views.MedicalCaseEntryView>();  // Issue #1463: 病案录入视图
-            containerRegistry.RegisterForNavigation<Views.MedicalCaseFlowView>();   // Epic #1494 - Task #1496: 医案流程主视图
+            containerRegistry.RegisterForNavigation<Views.MedicalCaseEntryView>();    // Issue #1463: 病案录入视图
+            containerRegistry.RegisterForNavigation<Views.MedicalCaseFlowView>();     // Epic #1494 - Task #1496: 医案流程主视图
+            containerRegistry.RegisterForNavigation<Views.PrescriptionEditorView>();  // Epic #1494 - Task #1499: Step 3 处方编辑视图
             // containerRegistry.RegisterForNavigation<Views.MedicalCaseManagementView>();
             // containerRegistry.RegisterForNavigation<Views.MedicalCaseListView>();
         }

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
@@ -1,6 +1,7 @@
 using LYBT.Desktop.MedicalCase.Interfaces;
 using LYBT.Desktop.MedicalCase.Models;
 using LYBT.Desktop.Models.ViewModels.Base;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Prism.Commands;
 using Prism.Events;
@@ -17,6 +18,7 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
         #region 字段
 
         private readonly IRegionManager _regionManager;
+        private readonly IServiceProvider _serviceProvider; // Task #1499 - 用于动态解析Step ViewModel
 
         #endregion
 
@@ -129,11 +131,13 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
 
         public MedicalCaseFlowViewModel(
             IRegionManager regionManager,
+            IServiceProvider serviceProvider,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory)
             : base(eventAggregator, loggerFactory, regionManager)
         {
             _regionManager = regionManager ?? throw new ArgumentNullException(nameof(regionManager));
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider)); // Task #1499
 
             // 初始化命令
             BackToHomeCommand = new DelegateCommand(ExecuteBackToHome);
@@ -386,8 +390,14 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
 
                 case FlowStep.FillPrescription:
                     Logger.LogInformation("导航到处方编辑步骤");
-                    // _regionManager.RequestNavigate("MedicalCaseStepRegion", "PrescriptionEditorView");
-                    CurrentStepViewModel = null; // 占位，待Task #1499实现
+
+                    // Task #1499 - 创建PrescriptionEditorViewModel实例
+                    var prescriptionEditorVM = _serviceProvider.GetRequiredService<PrescriptionEditorViewModel>();
+
+                    // 设置MedicalCaseId和PatientId（从Step 1创建的医案）
+                    prescriptionEditorVM.SetMedicalCaseIdAndPatientId(MedicalCaseId, Guid.Empty); // TODO: PatientId
+
+                    CurrentStepViewModel = prescriptionEditorVM;
                     break;
 
                 case FlowStep.CompleteMedicalCase:

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/PrescriptionEditorViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/PrescriptionEditorViewModel.cs
@@ -1,0 +1,588 @@
+using LYBT.Desktop.Infrastructure.Interfaces;
+using LYBT.Desktop.MedicalCase.Interfaces;
+using LYBT.Desktop.Models.ViewModels.Base;
+using LYBT.Shared.Models.Contracts.Herbs;
+using LYBT.Shared.Models.Contracts.Prescriptions;
+using Microsoft.Extensions.Logging;
+using Prism.Commands;
+using Prism.Events;
+using Prism.Mvvm;
+using Prism.Regions;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+
+namespace LYBT.Desktop.MedicalCase.ViewModels
+{
+    /// <summary>
+    /// 处方编辑器ViewModel - Task #1499
+    /// 8列DataGrid布局（每行4个药材），支持手工录入、验方导入、历史复制
+    ///
+    /// 架构说明：
+    /// 为避免循环依赖（MedicalCase ↔ Prescriptions），本ViewModel暂不注入Repository
+    /// SaveAsync()使用临时Mock实现，待后续通过事件总线或服务抽象层解耦
+    /// </summary>
+    public class PrescriptionEditorViewModel : UnifiedViewModelBase, ISaveable, IValidatable
+    {
+        #region 字段
+
+        private readonly ICommonDialogService _dialogService;
+        private Guid _medicalCaseId = Guid.Empty;
+        private Guid _patientId = Guid.Empty;
+
+        #endregion
+
+        #region 属性
+
+        private ObservableCollection<PrescriptionItemRowViewModel> _itemRows = new();
+        /// <summary>
+        /// DataGrid行集合（每行4个药材）
+        /// </summary>
+        public ObservableCollection<PrescriptionItemRowViewModel> ItemRows
+        {
+            get => _itemRows;
+            set => SetProperty(ref _itemRows, value);
+        }
+
+        private ObservableCollection<HerbDto> _allHerbs = new();
+        /// <summary>
+        /// 所有药材列表（用于ComboBox绑定）
+        /// </summary>
+        public ObservableCollection<HerbDto> AllHerbs
+        {
+            get => _allHerbs;
+            set => SetProperty(ref _allHerbs, value);
+        }
+
+        private int _dosageCount = 7;
+        /// <summary>
+        /// 剂数（默认7帖）
+        /// </summary>
+        public int DosageCount
+        {
+            get => _dosageCount;
+            set
+            {
+                if (SetProperty(ref _dosageCount, value))
+                {
+                    RaisePropertyChanged(nameof(TotalPrice));
+                }
+            }
+        }
+
+        private string _usage = "水煎服，一日一剂";
+        /// <summary>
+        /// 用法说明
+        /// </summary>
+        public string Usage
+        {
+            get => _usage;
+            set => SetProperty(ref _usage, value);
+        }
+
+        private string _remark = string.Empty;
+        /// <summary>
+        /// 备注
+        /// </summary>
+        public string Remark
+        {
+            get => _remark;
+            set => SetProperty(ref _remark, value);
+        }
+
+        private int _selectedTabIndex = 0;
+        /// <summary>
+        /// 当前选中的Tab索引（0=手工录入, 1=验方导入, 2=历史复制）
+        /// </summary>
+        public int SelectedTabIndex
+        {
+            get => _selectedTabIndex;
+            set => SetProperty(ref _selectedTabIndex, value);
+        }
+
+        /// <summary>
+        /// 单剂价格（计算属性）
+        /// </summary>
+        public decimal SingleDosagePrice
+        {
+            get
+            {
+                decimal total = 0;
+                foreach (var row in ItemRows)
+                {
+                    total += row.GetRowSubtotal();
+                }
+                return total;
+            }
+        }
+
+        /// <summary>
+        /// 总价格（计算属性）
+        /// </summary>
+        public decimal TotalPrice => SingleDosagePrice * DosageCount;
+
+        /// <summary>
+        /// 药材总数（计算属性）
+        /// </summary>
+        public int HerbCount
+        {
+            get
+            {
+                int count = 0;
+                foreach (var row in ItemRows)
+                {
+                    if (row.Herb1.Herb != null) count++;
+                    if (row.Herb2.Herb != null) count++;
+                    if (row.Herb3.Herb != null) count++;
+                    if (row.Herb4.Herb != null) count++;
+                }
+                return count;
+            }
+        }
+
+        #endregion
+
+        #region 命令
+
+        public DelegateCommand AddRowCommand { get; }
+        public DelegateCommand<PrescriptionItemRowViewModel> DeleteRowCommand { get; }
+        public DelegateCommand ClearCommand { get; }
+        public DelegateCommand ImportFormulaCommand { get; }
+        public DelegateCommand ImportHistoryCommand { get; }
+
+        #endregion
+
+        #region 构造函数
+
+        public PrescriptionEditorViewModel(
+            ICommonDialogService dialogService,
+            IEventAggregator eventAggregator,
+            ILoggerFactory loggerFactory,
+            IRegionManager regionManager)
+            : base(eventAggregator, loggerFactory, regionManager)
+        {
+            _dialogService = dialogService ?? throw new ArgumentNullException(nameof(dialogService));
+
+            // 初始化命令
+            AddRowCommand = new DelegateCommand(ExecuteAddRow);
+            DeleteRowCommand = new DelegateCommand<PrescriptionItemRowViewModel>(ExecuteDeleteRow, CanExecuteDeleteRow);
+            ClearCommand = new DelegateCommand(ExecuteClear);
+            ImportFormulaCommand = new DelegateCommand(async () => await ExecuteImportFormulaAsync());
+            ImportHistoryCommand = new DelegateCommand(async () => await ExecuteImportHistoryAsync());
+
+            // 初始化默认行
+            AddDefaultRows();
+
+            Logger.LogInformation("PrescriptionEditorViewModel已初始化");
+        }
+
+        #endregion
+
+        #region ISaveable实现
+
+        /// <summary>
+        /// 保存处方数据
+        /// </summary>
+        public async Task<bool> SaveAsync()
+        {
+            try
+            {
+                if (_medicalCaseId == Guid.Empty)
+                {
+                    Logger.LogError("MedicalCaseId未设置，无法保存处方");
+                    await ShowErrorMessageAsync("未关联医案，无法保存处方");
+                    return false;
+                }
+
+                SetIsBusy(true, "正在保存处方...");
+
+                // TODO: Task #1499 - 临时Mock实现
+                // 待解决循环依赖后，通过事件总线或服务抽象层调用PrescriptionRepository
+                // 构建PrescriptionCreateDto
+                var items = GetPrescriptionItems();
+                Logger.LogInformation("处方药材数量：{Count}，剂数：{DosageCount}，总价：{TotalPrice:C2}",
+                    items.Count, DosageCount, TotalPrice);
+
+                // 临时模拟保存
+                await Task.Delay(500);
+                Logger.LogInformation("处方保存成功（模拟），MedicalCaseId: {MedicalCaseId}", _medicalCaseId);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "保存处方失败");
+                await ShowErrorMessageAsync($"保存处方失败：{ex.Message}");
+                return false;
+            }
+            finally
+            {
+                SetIsBusy(false);
+            }
+        }
+
+        #endregion
+
+        #region IValidatable实现
+
+        /// <summary>
+        /// 验证处方数据
+        /// </summary>
+        public bool Validate()
+        {
+            if (DosageCount <= 0)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(Usage))
+            {
+                return false;
+            }
+
+            // 检查是否至少有一味药材
+            int herbCount = GetPrescriptionItems().Count;
+            if (herbCount == 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 验证失败消息
+        /// </summary>
+        public string ValidationMessage
+        {
+            get
+            {
+                if (DosageCount <= 0)
+                    return "剂数必须大于0";
+
+                if (string.IsNullOrWhiteSpace(Usage))
+                    return "用法说明不能为空";
+
+                int herbCount = GetPrescriptionItems().Count;
+                if (herbCount == 0)
+                    return "处方至少需要一味药材";
+
+                return string.Empty;
+            }
+        }
+
+        #endregion
+
+        #region 公共方法
+
+        /// <summary>
+        /// 设置医案ID和患者ID（从MedicalCaseFlowViewModel调用）
+        /// </summary>
+        public void SetMedicalCaseIdAndPatientId(Guid medicalCaseId, Guid patientId)
+        {
+            _medicalCaseId = medicalCaseId;
+            _patientId = patientId;
+            Logger.LogInformation("设置MedicalCaseId: {MedicalCaseId}, PatientId: {PatientId}", medicalCaseId, patientId);
+        }
+
+        /// <summary>
+        /// 加载所有药材列表（临时Mock数据）
+        /// </summary>
+        public async Task LoadHerbsAsync()
+        {
+            try
+            {
+                SetIsBusy(true, "正在加载药材列表...");
+
+                // TODO: Task #1499 - 临时Mock数据
+                // 待解决循环依赖后，通过事件总线或服务抽象层调用HerbRepository
+                await Task.Delay(300);
+                AllHerbs = new ObservableCollection<HerbDto>
+                {
+                    new HerbDto { Id = Guid.NewGuid(), Name = "人参", PinYinCode = "RS", Unit = "克", Price = 5.0m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "黄芪", PinYinCode = "HQ", Unit = "克", Price = 3.5m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "当归", PinYinCode = "DG", Unit = "克", Price = 4.0m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "川芎", PinYinCode = "CX", Unit = "克", Price = 3.0m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "白术", PinYinCode = "BS", Unit = "克", Price = 2.5m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "茯苓", PinYinCode = "FL", Unit = "克", Price = 2.0m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "甘草", PinYinCode = "GC", Unit = "克", Price = 1.5m },
+                    new HerbDto { Id = Guid.NewGuid(), Name = "生姜", PinYinCode = "SJ", Unit = "克", Price = 1.0m }
+                };
+
+                Logger.LogInformation("已加载{Count}个药材（Mock数据）", AllHerbs.Count);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "加载药材列表失败");
+                await ShowErrorMessageAsync($"加载药材列表失败：{ex.Message}");
+            }
+            finally
+            {
+                SetIsBusy(false);
+            }
+        }
+
+        #endregion
+
+        #region 命令实现
+
+        /// <summary>
+        /// 添加新行（4个空药材）
+        /// </summary>
+        private void ExecuteAddRow()
+        {
+            var newRow = new PrescriptionItemRowViewModel(this);
+            ItemRows.Add(newRow);
+            RaisePropertyChanged(nameof(HerbCount));
+            RaisePropertyChanged(nameof(SingleDosagePrice));
+            RaisePropertyChanged(nameof(TotalPrice));
+            Logger.LogInformation("添加新行，当前行数：{RowCount}", ItemRows.Count);
+        }
+
+        /// <summary>
+        /// 删除行
+        /// </summary>
+        private void ExecuteDeleteRow(PrescriptionItemRowViewModel row)
+        {
+            if (row != null && ItemRows.Contains(row))
+            {
+                ItemRows.Remove(row);
+                RaisePropertyChanged(nameof(HerbCount));
+                RaisePropertyChanged(nameof(SingleDosagePrice));
+                RaisePropertyChanged(nameof(TotalPrice));
+                DeleteRowCommand.RaiseCanExecuteChanged();
+                Logger.LogInformation("删除行，当前行数：{RowCount}", ItemRows.Count);
+            }
+        }
+
+        private bool CanExecuteDeleteRow(PrescriptionItemRowViewModel row)
+        {
+            return ItemRows.Count > 1; // 至少保留1行
+        }
+
+        /// <summary>
+        /// 清空表单
+        /// </summary>
+        private void ExecuteClear()
+        {
+            ItemRows.Clear();
+            AddDefaultRows();
+            DosageCount = 7;
+            Usage = "水煎服，一日一剂";
+            Remark = string.Empty;
+            RaisePropertyChanged(nameof(HerbCount));
+            RaisePropertyChanged(nameof(SingleDosagePrice));
+            RaisePropertyChanged(nameof(TotalPrice));
+            Logger.LogInformation("清空处方表单");
+        }
+
+        /// <summary>
+        /// 验方导入
+        /// </summary>
+        private async Task ExecuteImportFormulaAsync()
+        {
+            try
+            {
+                Logger.LogInformation("执行验方导入");
+                // TODO: Task #1499 - 实现验方选择对话框
+                // 1. 弹出验方搜索对话框
+                // 2. 用户选择验方后，调用ImportFormulaIntoPrescriptionAsync
+                // 3. 自动填充ItemRows
+                await Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "验方导入失败");
+                await ShowErrorMessageAsync($"验方导入失败：{ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 历史复制
+        /// </summary>
+        private async Task ExecuteImportHistoryAsync()
+        {
+            try
+            {
+                Logger.LogInformation("执行历史复制");
+                // TODO: Task #1499 - 实现历史处方选择对话框
+                // 1. 弹出患者历史处方列表对话框
+                // 2. 用户选择历史处方后，复制处方项到ItemRows
+                await Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "历史复制失败");
+                await ShowErrorMessageAsync($"历史复制失败：{ex.Message}");
+            }
+        }
+
+        #endregion
+
+        #region 辅助方法
+
+        /// <summary>
+        /// 添加默认行（2行，每行4个空药材）
+        /// </summary>
+        private void AddDefaultRows()
+        {
+            ItemRows.Add(new PrescriptionItemRowViewModel(this));
+            ItemRows.Add(new PrescriptionItemRowViewModel(this));
+        }
+
+        /// <summary>
+        /// 获取处方项列表（过滤空药材）
+        /// </summary>
+        private List<PrescriptionItemCreateDto> GetPrescriptionItems()
+        {
+            var items = new List<PrescriptionItemCreateDto>();
+
+            foreach (var row in ItemRows)
+            {
+                // Herb1
+                if (row.Herb1.Herb != null && row.Herb1.Dosage > 0)
+                {
+                    items.Add(new PrescriptionItemCreateDto
+                    {
+                        HerbId = row.Herb1.Herb.Id,
+                        Quantity = row.Herb1.Dosage,
+                        Unit = row.Herb1.Herb.Unit
+                    });
+                }
+
+                // Herb2
+                if (row.Herb2.Herb != null && row.Herb2.Dosage > 0)
+                {
+                    items.Add(new PrescriptionItemCreateDto
+                    {
+                        HerbId = row.Herb2.Herb.Id,
+                        Quantity = row.Herb2.Dosage,
+                        Unit = row.Herb2.Herb.Unit
+                    });
+                }
+
+                // Herb3
+                if (row.Herb3.Herb != null && row.Herb3.Dosage > 0)
+                {
+                    items.Add(new PrescriptionItemCreateDto
+                    {
+                        HerbId = row.Herb3.Herb.Id,
+                        Quantity = row.Herb3.Dosage,
+                        Unit = row.Herb3.Herb.Unit
+                    });
+                }
+
+                // Herb4
+                if (row.Herb4.Herb != null && row.Herb4.Dosage > 0)
+                {
+                    items.Add(new PrescriptionItemCreateDto
+                    {
+                        HerbId = row.Herb4.Herb.Id,
+                        Quantity = row.Herb4.Dosage,
+                        Unit = row.Herb4.Herb.Unit
+                    });
+                }
+            }
+
+            return items;
+        }
+
+        /// <summary>
+        /// 通知价格更新（从HerbItemViewModel调用）
+        /// </summary>
+        internal void NotifyPriceChanged()
+        {
+            RaisePropertyChanged(nameof(SingleDosagePrice));
+            RaisePropertyChanged(nameof(TotalPrice));
+            RaisePropertyChanged(nameof(HerbCount));
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// DataGrid行ViewModel（每行4个药材）
+    /// </summary>
+    public class PrescriptionItemRowViewModel : BindableBase
+    {
+        private readonly PrescriptionEditorViewModel _parentViewModel;
+
+        public HerbItemViewModel Herb1 { get; }
+        public HerbItemViewModel Herb2 { get; }
+        public HerbItemViewModel Herb3 { get; }
+        public HerbItemViewModel Herb4 { get; }
+
+        public PrescriptionItemRowViewModel(PrescriptionEditorViewModel parentViewModel)
+        {
+            _parentViewModel = parentViewModel ?? throw new ArgumentNullException(nameof(parentViewModel));
+
+            Herb1 = new HerbItemViewModel(parentViewModel);
+            Herb2 = new HerbItemViewModel(parentViewModel);
+            Herb3 = new HerbItemViewModel(parentViewModel);
+            Herb4 = new HerbItemViewModel(parentViewModel);
+        }
+
+        /// <summary>
+        /// 获取本行小计（4个药材的总价）
+        /// </summary>
+        public decimal GetRowSubtotal()
+        {
+            return Herb1.GetSubtotal() + Herb2.GetSubtotal() + Herb3.GetSubtotal() + Herb4.GetSubtotal();
+        }
+    }
+
+    /// <summary>
+    /// 单个药材项ViewModel
+    /// </summary>
+    public class HerbItemViewModel : BindableBase
+    {
+        private readonly PrescriptionEditorViewModel _parentViewModel;
+
+        private HerbDto? _herb;
+        /// <summary>
+        /// 选中的药材
+        /// </summary>
+        public HerbDto? Herb
+        {
+            get => _herb;
+            set
+            {
+                if (SetProperty(ref _herb, value))
+                {
+                    _parentViewModel.NotifyPriceChanged();
+                }
+            }
+        }
+
+        private decimal _dosage = 0;
+        /// <summary>
+        /// 用量（克/个/片等）
+        /// </summary>
+        public decimal Dosage
+        {
+            get => _dosage;
+            set
+            {
+                if (SetProperty(ref _dosage, value))
+                {
+                    _parentViewModel.NotifyPriceChanged();
+                }
+            }
+        }
+
+        public HerbItemViewModel(PrescriptionEditorViewModel parentViewModel)
+        {
+            _parentViewModel = parentViewModel ?? throw new ArgumentNullException(nameof(parentViewModel));
+        }
+
+        /// <summary>
+        /// 计算小计（单价 × 用量）
+        /// </summary>
+        public decimal GetSubtotal()
+        {
+            if (Herb == null || Dosage <= 0)
+                return 0;
+
+            return Herb.Price * Dosage;
+        }
+    }
+}

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Views/PrescriptionEditorView.xaml
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Views/PrescriptionEditorView.xaml
@@ -1,0 +1,273 @@
+<UserControl x:Class="LYBT.Desktop.MedicalCase.Views.PrescriptionEditorView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             prism:ViewModelLocator.AutoWireViewModel="True">
+    <Grid Background="White" Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>  <!-- 工具栏 -->
+            <RowDefinition Height="*"/>     <!-- TabControl -->
+            <RowDefinition Height="Auto"/>  <!-- 统计信息 -->
+        </Grid.RowDefinitions>
+
+        <!-- Row 0: 工具栏 -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,0,0,10">
+            <Button Content="清空表单" Command="{Binding ClearCommand}" Padding="15,5" Margin="5,0"/>
+        </StackPanel>
+
+        <!-- Row 1: TabControl（手工录入、验方导入、历史复制） -->
+        <TabControl Grid.Row="1" SelectedIndex="{Binding SelectedTabIndex}">
+            
+            <!-- Tab 1: 手工录入（默认） -->
+            <TabItem Header="手工录入">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>  <!-- DataGrid工具栏 -->
+                        <RowDefinition Height="*"/>     <!-- DataGrid -->
+                        <RowDefinition Height="Auto"/>  <!-- 剂数、用法、备注 -->
+                    </Grid.RowDefinitions>
+
+                    <!-- DataGrid工具栏 -->
+                    <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,10,0,5">
+                        <Button Content="添加行" Command="{Binding AddRowCommand}" Padding="10,5" Margin="0,0,5,0"/>
+                        <Button Content="删除选中行" Command="{Binding DeleteRowCommand}" 
+                                CommandParameter="{Binding SelectedItem, ElementName=PrescriptionDataGrid}" 
+                                Padding="10,5"/>
+                    </StackPanel>
+
+                    <!-- DataGrid：8列布局（每行4个药材） -->
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                        <DataGrid x:Name="PrescriptionDataGrid" 
+                                  ItemsSource="{Binding ItemRows}" 
+                                  AutoGenerateColumns="False"
+                                  CanUserAddRows="False"
+                                  CanUserDeleteRows="False"
+                                  CanUserSortColumns="False"
+                                  HeadersVisibility="Column"
+                                  GridLinesVisibility="All"
+                                  RowHeight="30"
+                                  MinHeight="300"
+                                  MinWidth="1200">
+
+                            <!-- 列定义：药材1+用量1+药材2+用量2+药材3+用量3+药材4+用量4 -->
+                            
+                            <!-- 药材1 -->
+                            <DataGrid.Columns>
+                                <DataGridTemplateColumn Header="药材1" Width="150">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <ComboBox ItemsSource="{Binding DataContext.AllHerbs, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                      SelectedItem="{Binding Herb1.Herb, UpdateSourceTrigger=PropertyChanged}"
+                                                      DisplayMemberPath="Name"
+                                                      IsEditable="True"
+                                                      BorderThickness="0"
+                                                      Padding="5,2"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <DataGridTemplateColumn Header="用量1(克)" Width="80">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBox Text="{Binding Herb1.Dosage, UpdateSourceTrigger=PropertyChanged, StringFormat=N1}"
+                                                     BorderThickness="0"
+                                                     Padding="5,2"
+                                                     TextAlignment="Right"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <!-- 药材2 -->
+                                <DataGridTemplateColumn Header="药材2" Width="150">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <ComboBox ItemsSource="{Binding DataContext.AllHerbs, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                      SelectedItem="{Binding Herb2.Herb, UpdateSourceTrigger=PropertyChanged}"
+                                                      DisplayMemberPath="Name"
+                                                      IsEditable="True"
+                                                      BorderThickness="0"
+                                                      Padding="5,2"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <DataGridTemplateColumn Header="用量2(克)" Width="80">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBox Text="{Binding Herb2.Dosage, UpdateSourceTrigger=PropertyChanged, StringFormat=N1}"
+                                                     BorderThickness="0"
+                                                     Padding="5,2"
+                                                     TextAlignment="Right"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <!-- 药材3 -->
+                                <DataGridTemplateColumn Header="药材3" Width="150">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <ComboBox ItemsSource="{Binding DataContext.AllHerbs, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                      SelectedItem="{Binding Herb3.Herb, UpdateSourceTrigger=PropertyChanged}"
+                                                      DisplayMemberPath="Name"
+                                                      IsEditable="True"
+                                                      BorderThickness="0"
+                                                      Padding="5,2"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <DataGridTemplateColumn Header="用量3(克)" Width="80">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBox Text="{Binding Herb3.Dosage, UpdateSourceTrigger=PropertyChanged, StringFormat=N1}"
+                                                     BorderThickness="0"
+                                                     Padding="5,2"
+                                                     TextAlignment="Right"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <!-- 药材4 -->
+                                <DataGridTemplateColumn Header="药材4" Width="150">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <ComboBox ItemsSource="{Binding DataContext.AllHerbs, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                      SelectedItem="{Binding Herb4.Herb, UpdateSourceTrigger=PropertyChanged}"
+                                                      DisplayMemberPath="Name"
+                                                      IsEditable="True"
+                                                      BorderThickness="0"
+                                                      Padding="5,2"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+
+                                <DataGridTemplateColumn Header="用量4(克)" Width="80">
+                                    <DataGridTemplateColumn.CellTemplate>
+                                        <DataTemplate>
+                                            <TextBox Text="{Binding Herb4.Dosage, UpdateSourceTrigger=PropertyChanged, StringFormat=N1}"
+                                                     BorderThickness="0"
+                                                     Padding="5,2"
+                                                     TextAlignment="Right"/>
+                                        </DataTemplate>
+                                    </DataGridTemplateColumn.CellTemplate>
+                                </DataGridTemplateColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </ScrollViewer>
+
+                    <!-- 剂数、用法、备注 -->
+                    <Grid Grid.Row="2" Margin="0,10,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
+
+                        <!-- 剂数 + 用法 -->
+                        <Grid Grid.Row="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="20"/>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <TextBlock Grid.Column="0" Text="剂数：" VerticalAlignment="Center" FontWeight="Bold"/>
+                            <TextBox Grid.Column="1" Text="{Binding DosageCount, UpdateSourceTrigger=PropertyChanged}" 
+                                     VerticalAlignment="Center" Padding="5,2"/>
+
+                            <TextBlock Grid.Column="3" Text="用法：" VerticalAlignment="Center" FontWeight="Bold" Margin="10,0,0,0"/>
+                            <TextBox Grid.Column="4" Text="{Binding Usage, UpdateSourceTrigger=PropertyChanged}" 
+                                     VerticalAlignment="Center" Padding="5,2"/>
+                        </Grid>
+
+                        <!-- 备注 -->
+                        <StackPanel Grid.Row="1" Margin="0,10,0,0">
+                            <TextBlock Text="备注：" FontWeight="Bold" Margin="0,0,0,5"/>
+                            <TextBox Text="{Binding Remark, UpdateSourceTrigger=PropertyChanged}" 
+                                     Height="60" 
+                                     TextWrapping="Wrap" 
+                                     AcceptsReturn="True" 
+                                     VerticalScrollBarVisibility="Auto"/>
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+            </TabItem>
+
+            <!-- Tab 2: 验方导入（占位） -->
+            <TabItem Header="验方导入">
+                <Grid>
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <TextBlock Text="验方导入功能" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
+                        <Button Content="选择验方" Command="{Binding ImportFormulaCommand}" Padding="20,10"/>
+                        <TextBlock Text="TODO: 实现验方搜索和选择对话框" 
+                                   Foreground="Gray" 
+                                   Margin="0,20,0,0" 
+                                   HorizontalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+
+            <!-- Tab 3: 历史复制（占位） -->
+            <TabItem Header="历史复制">
+                <Grid>
+                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <TextBlock Text="历史处方复制" FontSize="18" FontWeight="Bold" Margin="0,0,0,10"/>
+                        <Button Content="选择历史处方" Command="{Binding ImportHistoryCommand}" Padding="20,10"/>
+                        <TextBlock Text="TODO: 实现患者历史处方列表对话框" 
+                                   Foreground="Gray" 
+                                   Margin="0,20,0,0" 
+                                   HorizontalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+        </TabControl>
+
+        <!-- Row 2: 统计信息 -->
+        <Border Grid.Row="2" 
+                BorderBrush="#CCCCCC" 
+                BorderThickness="0,1,0,0" 
+                Padding="0,10,0,0" 
+                Margin="0,10,0,0">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Margin="0,0,20,0">
+                    <TextBlock Text="药材总数：" FontWeight="Bold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding HerbCount}" 
+                               FontWeight="Bold" 
+                               Foreground="#0078D4" 
+                               VerticalAlignment="Center"
+                               Margin="5,0,0,0"/>
+                    <TextBlock Text="味" VerticalAlignment="Center" Margin="2,0,0,0"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="2" Orientation="Horizontal" Margin="0,0,20,0">
+                    <TextBlock Text="单剂价格：" FontWeight="Bold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding SingleDosagePrice, StringFormat=￥{0:F2}}" 
+                               FontWeight="Bold" 
+                               Foreground="#0078D4" 
+                               FontSize="16"
+                               VerticalAlignment="Center"
+                               Margin="5,0,0,0"/>
+                </StackPanel>
+
+                <StackPanel Grid.Column="3" Orientation="Horizontal">
+                    <TextBlock Text="总价格：" FontWeight="Bold" VerticalAlignment="Center"/>
+                    <TextBlock Text="{Binding TotalPrice, StringFormat=￥{0:F2}}" 
+                               FontWeight="Bold" 
+                               Foreground="#E74856" 
+                               FontSize="18"
+                               VerticalAlignment="Center"
+                               Margin="5,0,0,0"/>
+                </StackPanel>
+            </Grid>
+        </Border>
+    </Grid>
+</UserControl>

--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Views/PrescriptionEditorView.xaml.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/Views/PrescriptionEditorView.xaml.cs
@@ -1,0 +1,29 @@
+using System.Windows.Controls;
+
+namespace LYBT.Desktop.MedicalCase.Views
+{
+    /// <summary>
+    /// PrescriptionEditorView.xaml 的交互逻辑
+    /// Task #1499 - 处方编辑器视图（8列DataGrid布局）
+    /// </summary>
+    public partial class PrescriptionEditorView : UserControl
+    {
+        public PrescriptionEditorView()
+        {
+            InitializeComponent();
+
+            // 视图加载完成后，触发ViewModel加载药材列表
+            this.Loaded += PrescriptionEditorView_Loaded;
+        }
+
+        private async void PrescriptionEditorView_Loaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            // 从DataContext获取ViewModel
+            if (this.DataContext is ViewModels.PrescriptionEditorViewModel viewModel)
+            {
+                // 加载药材列表
+                await viewModel.LoadHerbsAsync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📋 任务概述

实现**Epic #1494 - Task #1499**：Step 3 处方编辑器视图，采用8列DataGrid布局（每行4个药材），支持手工录入、验方导入、历史复制三种模式。

---

## ✅ 实现功能

### 核心功能
- ✅ **8列DataGrid布局**：每行4个药材，每个药材2列（名称+用量）
- ✅ **3个Tab**：
  - Tab 1：手工录入（默认，已完整实现）
  - Tab 2：验方导入（占位，显示选择按钮）
  - Tab 3：历史复制（占位，显示选择按钮）
- ✅ **自动计算**：药材总数、单剂价格、总价格（实时更新）
- ✅ **剂数输入**：默认7帖
- ✅ **用法输入**：默认"水煎服，一日一剂"
- ✅ **备注输入**：多行文本框
- ✅ **ISaveable接口**：实现SaveAsync()方法（状态机集成）
- ✅ **IValidatable接口**：实现Validate()和ValidationMessage属性
- ✅ **添加行/删除行/清空表单**：完整交互功能

### DataGrid布局
```
| 药材1 | 用量1(克) | 药材2 | 用量2(克) | 药材3 | 用量3(克) | 药材4 | 用量4(克) |
|-------|-----------|-------|-----------|-------|-----------|-------|-----------|
| ComboBox | TextBox | ComboBox | TextBox | ComboBox | TextBox | ComboBox | TextBox |
```

### Mock数据
- **药材列表**（8个常用中药）：人参、黄芪、当归、川芎、白术、茯苓、甘草、生姜
- **LoadHerbsAsync()**：临时Mock实现，视图加载时自动调用
- **SaveAsync()**：临时Mock实现，记录日志并返回成功

---

## 🏗️ 架构设计

### 文件变更
#### 新增文件（3个）
1. **PrescriptionEditorViewModel.cs**（580行）
   - 主ViewModel（继承UnifiedViewModelBase）
   - 辅助类：PrescriptionItemRowViewModel（每行4个药材）
   - 辅助类：HerbItemViewModel（单个药材：Herb + Dosage）
   - 实现ISaveable和IValidatable接口

2. **PrescriptionEditorView.xaml**（260行）
   - TabControl布局（3个Tab）
   - DataGrid 8列布局
   - 剂数/用法/备注输入
   - 统计信息显示（药材总数、单剂价格、总价格）

3. **PrescriptionEditorView.xaml.cs**
   - Loaded事件触发LoadHerbsAsync()

#### 修改文件（2个）
1. **MedicalCaseFlowViewModel.cs**
   - 添加IServiceProvider依赖注入（Task #1499）
   - FlowStep.FillPrescription集成PrescriptionEditorViewModel

2. **MedicalCaseModule.cs**
   - 注册PrescriptionEditorViewModel
   - 注册PrescriptionEditorView

---

## ⚠️ 架构调整：避免循环依赖

### 问题背景
- LYBT.Desktop.Prescriptions已引用LYBT.Desktop.MedicalCase（line 79）
- 如果MedicalCase反向引用Prescriptions → 形成循环依赖（编译错误MSB4006）

### 解决方案
**移除对IPrescriptionRepository和IHerbRepository的直接依赖**：
- ❌ 不注入IPrescriptionRepository和IHerbRepository
- ✅ LoadHerbsAsync()使用临时Mock数据
- ✅ SaveAsync()使用临时Mock实现（记录日志）
- ✅ 待后续通过**事件总线**或**服务抽象层**解耦

### 后续改进方向
1. 将IPrescriptionRepository接口抽象到LYBT.Desktop.Contracts
2. 使用EventAggregator发布PrescriptionSaveEvent
3. 或创建中间服务层（LYBT.Desktop.Services）

---

## 🧪 验收标准

- [x] DataGrid 8列布局（每行4个药材）
- [x] 药材列：ComboBox，绑定HerbDto列表
- [x] 用量列：TextBox，支持数字输入
- [x] 添加行/删除行按钮
- [x] Tab 1：手工录入（完整实现）
- [x] Tab 2：验方导入（占位UI）
- [x] Tab 3：历史复制（占位UI）
- [x] 剂数输入框（默认7帖）
- [x] 用法输入框（默认"水煎服，一日一剂"）
- [x] 自动计算：药材总数、单剂价格、总价格
- [x] ISaveable接口实现（SaveAsync）
- [x] IValidatable接口实现（Validate + ValidationMessage）
- [x] 编译通过（0 errors, 0 warnings）
- [ ] 单元测试（待Task #1502后补充）

---

## 📝 待完成功能（后续Issue）

**Tab 2 - 验方导入**（需要单独Issue）：
- [ ] 验方搜索对话框
- [ ] 验方列表显示
- [ ] 导入验方药材到DataGrid

**Tab 3 - 历史复制**（需要单独Issue）：
- [ ] 患者历史处方列表对话框
- [ ] 选择历史处方后复制药材到DataGrid

**真实数据接口**（待循环依赖解决）：
- [ ] 集成真实IPrescriptionRepository.CreateAsync()
- [ ] 集成真实IHerbRepository.GetAllAsync()

---

## 🔗 关联Issue

- **Epic**: #1494（医案流程UI实现）
- **Task**: #1499（Step 3 - PrescriptionEditor实现）

---

## 📊 编译状态

```
dotnet build LYBT.Desktop.MedicalCase.csproj -c Release --no-restore
✅ 0 errors
✅ 0 warnings
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>