### PR TITLE
test(medicalcase): 添加MedicalCaseFlowViewModel单元测试 (#1496)

### DIFF
--- a/LYBT.All.sln
+++ b/LYBT.All.sln
@@ -153,6 +153,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LYBT.Desktop.Presentation",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LYBT.Shared.Components", "src\Shared\LYBT.Shared.Components\LYBT.Shared.Components.csproj", "{AC561A4F-4F50-4737-838B-D9F2288A809A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LYBT.Desktop.MedicalCase.Tests", "tests\UnitTests\Client\Desktop\LYBT.Desktop.MedicalCase.Tests\LYBT.Desktop.MedicalCase.Tests.csproj", "{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -752,6 +753,18 @@ Global
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19}.Release|x64.Build.0 = Release|Any CPU
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19}.Release|x86.ActiveCfg = Release|Any CPU
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19}.Release|x86.Build.0 = Release|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x64.Build.0 = Debug|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x86.Build.0 = Debug|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x64.ActiveCfg = Release|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x64.Build.0 = Release|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x86.ActiveCfg = Release|Any CPU
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -828,6 +841,7 @@ Global
 		{E9FAEFA8-21CF-41A0-8A53-075BB100C47E} = {394A81D9-3C45-9818-BB26-23F2B85056FF}
 		{8E16421C-52D1-4522-8987-D2A839E32B02} = {E9FAEFA8-21CF-41A0-8A53-075BB100C47E}
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19} = {B2C3D4E5-F6A7-5B6C-9D0E-1F2A3B4C5D6E}
+		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063} = {B5FC5F97-B31F-4FDC-859A-02FEE737F1A7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D0E1F2A3-B4C5-4D6E-7F8A-9B0C1D2E3F4A}

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.MedicalCase.Tests/LYBT.Desktop.MedicalCase.Tests.csproj
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.MedicalCase.Tests/LYBT.Desktop.MedicalCase.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Modules\LYBT.Desktop.MedicalCase\LYBT.Desktop.MedicalCase.csproj" />
+    <ProjectReference Include="..\..\..\..\..\src\Client\Desktop\Core\LYBT.Desktop.Infrastructure\LYBT.Desktop.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\..\..\TestConfiguration\LYBT.Tests.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UnitTests/Client/Desktop/LYBT.Desktop.MedicalCase.Tests/ViewModels/MedicalCaseFlowViewModelTests.cs
+++ b/tests/UnitTests/Client/Desktop/LYBT.Desktop.MedicalCase.Tests/ViewModels/MedicalCaseFlowViewModelTests.cs
@@ -1,0 +1,301 @@
+using FluentAssertions;
+using LYBT.Desktop.MedicalCase.Models;
+using LYBT.Desktop.MedicalCase.ViewModels;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Prism.Events;
+using Prism.Ioc;
+using Prism.Regions;
+
+namespace LYBT.Desktop.MedicalCase.Tests.ViewModels
+{
+    /// <summary>
+    /// MedicalCaseFlowViewModel单元测试（Task #1496验收标准）
+    /// 测试重点：进度条状态切换逻辑、患者信息条显示、按钮状态
+    /// </summary>
+    public class MedicalCaseFlowViewModelTests
+    {
+        private readonly Mock<IRegionManager> _regionManagerMock;
+        private readonly Mock<IContainerProvider> _containerProviderMock;
+        private readonly Mock<IEventAggregator> _eventAggregatorMock;
+        private readonly Mock<ILoggerFactory> _loggerFactoryMock;
+        private readonly Mock<ILogger<MedicalCaseFlowViewModel>> _loggerMock;
+
+        public MedicalCaseFlowViewModelTests()
+        {
+            _regionManagerMock = new Mock<IRegionManager>();
+            _containerProviderMock = new Mock<IContainerProvider>();
+            _eventAggregatorMock = new Mock<IEventAggregator>();
+            _loggerFactoryMock = new Mock<ILoggerFactory>();
+            _loggerMock = new Mock<ILogger<MedicalCaseFlowViewModel>>();
+
+            _loggerFactoryMock
+                .Setup(x => x.CreateLogger(It.IsAny<string>()))
+                .Returns(_loggerMock.Object);
+        }
+
+        private MedicalCaseFlowViewModel CreateViewModel()
+        {
+            return new MedicalCaseFlowViewModel(
+                _regionManagerMock.Object,
+                _containerProviderMock.Object,
+                _eventAggregatorMock.Object,
+                _loggerFactoryMock.Object
+            );
+        }
+
+        #region 进度条状态切换逻辑测试
+
+        [Fact]
+        public void CurrentStep_WhenSetToStep1_IsStep1ShouldBeTrue()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.SelectPatient;
+
+            // Assert
+            viewModel.IsStep1.Should().BeTrue();
+            viewModel.IsStep2.Should().BeFalse();
+            viewModel.IsStep3.Should().BeFalse();
+            viewModel.IsStep4.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CurrentStep_WhenSetToStep2_IsStep2ShouldBeTrue()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.FillConsultation;
+
+            // Assert
+            viewModel.IsStep1.Should().BeFalse();
+            viewModel.IsStep2.Should().BeTrue();
+            viewModel.IsStep3.Should().BeFalse();
+            viewModel.IsStep4.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CurrentStep_WhenSetToStep3_IsStep3ShouldBeTrue()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.FillPrescription;
+
+            // Assert
+            viewModel.IsStep1.Should().BeFalse();
+            viewModel.IsStep2.Should().BeFalse();
+            viewModel.IsStep3.Should().BeTrue();
+            viewModel.IsStep4.Should().BeFalse();
+        }
+
+        [Fact]
+        public void CurrentStep_WhenSetToStep4_IsStep4ShouldBeTrue()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.CompleteMedicalCase;
+
+            // Assert
+            viewModel.IsStep1.Should().BeFalse();
+            viewModel.IsStep2.Should().BeFalse();
+            viewModel.IsStep3.Should().BeFalse();
+            viewModel.IsStep4.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(FlowStep.SelectPatient, true, false, false, false)]
+        [InlineData(FlowStep.FillConsultation, false, true, false, false)]
+        [InlineData(FlowStep.FillPrescription, false, false, true, false)]
+        [InlineData(FlowStep.CompleteMedicalCase, false, false, false, true)]
+        public void CurrentStep_ShouldSetCorrectStepHighlight(
+            FlowStep step,
+            bool expectedIsStep1,
+            bool expectedIsStep2,
+            bool expectedIsStep3,
+            bool expectedIsStep4)
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = step;
+
+            // Assert
+            viewModel.IsStep1.Should().Be(expectedIsStep1);
+            viewModel.IsStep2.Should().Be(expectedIsStep2);
+            viewModel.IsStep3.Should().Be(expectedIsStep3);
+            viewModel.IsStep4.Should().Be(expectedIsStep4);
+        }
+
+        #endregion
+
+        #region 患者信息条显示逻辑测试
+
+        [Fact]
+        public void PatientInfoBarVisible_WhenStep1_ShouldBeFalse()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.SelectPatient;
+
+            // Assert
+            viewModel.PatientInfoBarVisible.Should().BeFalse("Step 1不显示患者信息条");
+        }
+
+        [Theory]
+        [InlineData(FlowStep.FillConsultation)]
+        [InlineData(FlowStep.FillPrescription)]
+        [InlineData(FlowStep.CompleteMedicalCase)]
+        public void PatientInfoBarVisible_WhenStep2To4_ShouldBeTrue(FlowStep step)
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = step;
+
+            // Assert
+            viewModel.PatientInfoBarVisible.Should().BeTrue($"Step {(int)step}应显示患者信息条");
+        }
+
+        #endregion
+
+        #region 按钮状态测试
+
+        [Fact]
+        public void CanGoBack_WhenStep1_ShouldBeFalse()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.SelectPatient;
+
+            // Assert
+            viewModel.CanGoBack.Should().BeFalse("Step 1不能返回上一步");
+        }
+
+        [Theory]
+        [InlineData(FlowStep.FillConsultation)]
+        [InlineData(FlowStep.FillPrescription)]
+        [InlineData(FlowStep.CompleteMedicalCase)]
+        public void CanGoBack_WhenStep2To4_ShouldBeTrue(FlowStep step)
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = step;
+
+            // Assert
+            viewModel.CanGoBack.Should().BeTrue($"Step {(int)step}可以返回上一步");
+        }
+
+        [Theory]
+        [InlineData(FlowStep.SelectPatient)]
+        [InlineData(FlowStep.FillConsultation)]
+        [InlineData(FlowStep.FillPrescription)]
+        public void CanGoNext_WhenStep1To3_ShouldBeTrue(FlowStep step)
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = step;
+
+            // Assert
+            viewModel.CanGoNext.Should().BeTrue($"Step {(int)step}可以前进下一步");
+        }
+
+        [Fact]
+        public void CanGoNext_WhenStep4_ShouldBeFalse()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.CompleteMedicalCase;
+
+            // Assert
+            viewModel.CanGoNext.Should().BeFalse("Step 4不能前进下一步");
+        }
+
+        #endregion
+
+        #region 下一步按钮文字测试
+
+        [Theory]
+        [InlineData(FlowStep.SelectPatient, "下一步")]
+        [InlineData(FlowStep.FillConsultation, "下一步")]
+        [InlineData(FlowStep.FillPrescription, "下一步")]
+        public void NextButtonText_WhenStep1To3_ShouldBeNextStep(FlowStep step, string expectedText)
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = step;
+
+            // Assert
+            viewModel.NextButtonText.Should().Be(expectedText);
+        }
+
+        [Fact]
+        public void NextButtonText_WhenStep4_ShouldBeComplete()
+        {
+            // Arrange
+            var viewModel = CreateViewModel();
+
+            // Act
+            viewModel.CurrentStep = FlowStep.CompleteMedicalCase;
+
+            // Assert
+            viewModel.NextButtonText.Should().Be("完成看诊");
+        }
+
+        #endregion
+
+        #region 初始状态测试
+
+        [Fact]
+        public void Constructor_ShouldInitializeWithStep1()
+        {
+            // Act
+            var viewModel = CreateViewModel();
+
+            // Assert
+            viewModel.CurrentStep.Should().Be(FlowStep.SelectPatient);
+            viewModel.IsStep1.Should().BeTrue();
+            viewModel.PatientInfoBarVisible.Should().BeFalse();
+            viewModel.CanGoBack.Should().BeFalse();
+            viewModel.CanGoNext.Should().BeTrue();
+            viewModel.NextButtonText.Should().Be("下一步");
+        }
+
+        [Fact]
+        public void Constructor_ShouldInitializeCommands()
+        {
+            // Act
+            var viewModel = CreateViewModel();
+
+            // Assert
+            viewModel.BackToHomeCommand.Should().NotBeNull();
+            viewModel.PreviousStepCommand.Should().NotBeNull();
+            viewModel.NextStepCommand.Should().NotBeNull();
+            viewModel.SaveDraftCommand.Should().NotBeNull();
+            viewModel.CancelCommand.Should().NotBeNull();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## 📋 关联Issue
Closes #1496

## 📝 任务描述
补充Task #1496缺失的验收标准：**单元测试覆盖进度条状态切换逻辑**

MedicalCaseFlowView核心框架的代码实现已在commit `455a4f23`合并到master，本PR补充单元测试以完全满足验收标准。

## ✅ 实现内容

### 1. 创建测试项目
- 项目：`LYBT.Desktop.MedicalCase.Tests`
- 位置：`tests/UnitTests/Client/Desktop/LYBT.Desktop.MedicalCase.Tests/`
- 框架：xUnit + FluentAssertions + Moq
- 已添加到`LYBT.All.sln`解决方案

### 2. 测试覆盖范围（26个测试用例）

#### 进度条状态切换逻辑（Task #1496核心验收标准）
- ✅ `CurrentStep_WhenSetToStep1_IsStep1ShouldBeTrue`
- ✅ `CurrentStep_WhenSetToStep2_IsStep2ShouldBeTrue`
- ✅ `CurrentStep_WhenSetToStep3_IsStep3ShouldBeTrue`
- ✅ `CurrentStep_WhenSetToStep4_IsStep4ShouldBeTrue`
- ✅ `CurrentStep_ShouldSetCorrectStepHighlight` (4个Theory测试，覆盖所有步骤组合)

#### 患者信息条显示逻辑
- ✅ `PatientInfoBarVisible_WhenStep1_ShouldBeFalse`
- ✅ `PatientInfoBarVisible_WhenStep2To4_ShouldBeTrue` (3个Theory测试)

#### 按钮状态逻辑
- ✅ `CanGoBack_WhenStep1_ShouldBeFalse`
- ✅ `CanGoBack_WhenStep2To4_ShouldBeTrue` (3个Theory测试)
- ✅ `CanGoNext_WhenStep1To3_ShouldBeTrue` (3个Theory测试)
- ✅ `CanGoNext_WhenStep4_ShouldBeFalse`

#### 下一步按钮文字
- ✅ `NextButtonText_WhenStep1To3_ShouldBeNextStep` (3个Theory测试)
- ✅ `NextButtonText_WhenStep4_ShouldBeComplete`

#### 初始化测试
- ✅ `Constructor_ShouldInitializeWithStep1`
- ✅ `Constructor_ShouldInitializeCommands`

## 📊 测试结果

```
测试运行成功。
测试总数: 26
     通过数: 26
总时间: 2.3193 秒
```

**所有测试全部通过！✅**

## ✅ 编译验证

```
dotnet build LYBT.All.sln -c Release --no-restore
已成功生成。
    0 个警告
    0 个错误
```

## 🎯 验收标准检查

Task #1496的所有验收标准：

- [x] 顶部导航栏：60px高度，包含【返回主页】按钮 ✅（commit 455a4f23）
- [x] 流程进度条：80px高度，4个Step，当前Step高亮显示 ✅（commit 455a4f23）
- [x] 患者信息条：50px高度，浅蓝背景，显示患者姓名/性别/年龄/电话 ✅（commit 455a4f23）
- [x] 主内容区：动态高度（1920x1080下约810px），支持ContentControl切换 ✅（commit 455a4f23）
- [x] 底部操作栏：80px高度，【上一步】【下一步】【保存草稿】【取消】按钮 ✅（commit 455a4f23）
- [x] 【上一步】按钮：Step 1时禁用 ✅（commit 455a4f23）
- [x] 【下一步】按钮：Step 4时隐藏（显示【完成看诊】） ✅（commit 455a4f23）
- [x] 编译通过（0 errors, 0 warnings） ✅（本PR）
- [x] **单元测试：进度条状态切换逻辑** ✅（本PR） ⭐

## 📚 相关信息

- Epic: #1494 - 医案流程UI重构
- 核心实现: commit `455a4f23` (已在master)
- 本PR: 补充单元测试

## 🔗 后续任务

Task #1496完成后，Epic #1494剩余任务：
- Task #1500: Step 4 - CompletionView实现
- Task #1502: 自动保存草稿功能
- Task #1503: 小屏幕兼容性测试