### PR TITLE
[Test] 补充RULE-3业务规则单元测试

### DIFF
--- a/LYBT.All.sln
+++ b/LYBT.All.sln
@@ -153,7 +153,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LYBT.Desktop.Presentation",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LYBT.Shared.Components", "src\Shared\LYBT.Shared.Components\LYBT.Shared.Components.csproj", "{AC561A4F-4F50-4737-838B-D9F2288A809A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LYBT.Desktop.MedicalCase.Tests", "tests\UnitTests\Client\Desktop\LYBT.Desktop.MedicalCase.Tests\LYBT.Desktop.MedicalCase.Tests.csproj", "{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -753,18 +752,6 @@ Global
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19}.Release|x64.Build.0 = Release|Any CPU
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19}.Release|x86.ActiveCfg = Release|Any CPU
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19}.Release|x86.Build.0 = Release|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x64.Build.0 = Debug|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Debug|x86.Build.0 = Debug|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|Any CPU.Build.0 = Release|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x64.ActiveCfg = Release|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x64.Build.0 = Release|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x86.ActiveCfg = Release|Any CPU
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -841,7 +828,6 @@ Global
 		{E9FAEFA8-21CF-41A0-8A53-075BB100C47E} = {394A81D9-3C45-9818-BB26-23F2B85056FF}
 		{8E16421C-52D1-4522-8987-D2A839E32B02} = {E9FAEFA8-21CF-41A0-8A53-075BB100C47E}
 		{15C25E1A-6E41-4936-B5C5-968DFC3F1D19} = {B2C3D4E5-F6A7-5B6C-9D0E-1F2A3B4C5D6E}
-		{33DC545F-3EE3-475C-9C6A-4EFE4BA8C063} = {B5FC5F97-B31F-4FDC-859A-02FEE737F1A7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D0E1F2A3-B4C5-4D6E-7F8A-9B0C1D2E3F4A}

--- a/tests/UnitTests/Server/Modules/LYBT.Module.Prescriptions.Tests/Services/PrescriptionServiceTests.cs
+++ b/tests/UnitTests/Server/Modules/LYBT.Module.Prescriptions.Tests/Services/PrescriptionServiceTests.cs
@@ -879,6 +879,97 @@ namespace LYBT.Module.Prescriptions.Tests.Services
 
         #endregion
 
+        #region Business Rules Tests (Issue #1423 - RULE-3)
+
+        /// <summary>
+        /// RULE-3: 当天可改隔日锁定 - 创建当天可以修改
+        /// </summary>
+        [Fact]
+        public async Task UpdateAsync_WhenCreatedToday_ShouldReturnSuccess()
+        {
+            // Arrange
+            var prescriptionId = Guid.NewGuid();
+            var existingPrescription = new Prescription
+            {
+                Id = prescriptionId,
+                MedicalCaseId = Guid.NewGuid(),
+                PatientId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                DosageCount = 7,
+                Discount = 1.0m,
+                Advice = "原始医嘱",
+                CreatedAt = DateTime.Today.AddHours(10) // 今天创建
+            };
+
+            var updateDto = new PrescriptionUpdateDto
+            {
+                Advice = "更新后的医嘱",
+                Discount = 0.9m,
+                Remark = "更新备注",
+                DosageCount = 10
+            };
+
+            _repositoryMock.Setup(x => x.GetByIdAsync(prescriptionId))
+                .ReturnsAsync(existingPrescription);
+
+            _repositoryMock.Setup(x => x.UpdateAsync(It.IsAny<Prescription>()))
+                .ReturnsAsync(existingPrescription);
+
+            // Act
+            var result = await _prescriptionService.UpdateAsync(prescriptionId, updateDto);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            result.Data.Should().NotBeNull();
+
+            _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<Prescription>()), Times.Once);
+        }
+
+        /// <summary>
+        /// RULE-3: 当天可改隔日锁定 - 隔日后不可修改
+        /// </summary>
+        [Fact]
+        public async Task UpdateAsync_WhenCreatedYesterday_ShouldReturnFailure()
+        {
+            // Arrange
+            var prescriptionId = Guid.NewGuid();
+            var existingPrescription = new Prescription
+            {
+                Id = prescriptionId,
+                MedicalCaseId = Guid.NewGuid(),
+                PatientId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                DosageCount = 7,
+                Discount = 1.0m,
+                Advice = "原始医嘱",
+                CreatedAt = DateTime.Today.AddDays(-1).AddHours(10) // 昨天创建
+            };
+
+            var updateDto = new PrescriptionUpdateDto
+            {
+                Advice = "尝试更新的医嘱",
+                Discount = 0.9m
+            };
+
+            _repositoryMock.Setup(x => x.GetByIdAsync(prescriptionId))
+                .ReturnsAsync(existingPrescription);
+
+            // Act
+            var result = await _prescriptionService.UpdateAsync(prescriptionId, updateDto);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.Message.Should().Contain("已超过可修改期限");
+            result.Message.Should().Contain("仅限创建当天可修改");
+
+            // 验证UpdateAsync不应被调用
+            _repositoryMock.Verify(x => x.UpdateAsync(It.IsAny<Prescription>()), Times.Never);
+        }
+
+        #endregion
+
         public override void Dispose()
         {
             base.Dispose();


### PR DESCRIPTION
## 📋 关联 Issue
- Closes #1526

## 📝 变更说明

### 新增测试
为 `PrescriptionService` 补充 **RULE-3（当天可改隔日锁定）** 单元测试：

#### PrescriptionServiceTests.cs
- ✅ `UpdateAsync_WhenCreatedToday_ShouldReturnSuccess()` - 验证创建当天可以修改
- ✅ `UpdateAsync_WhenCreatedYesterday_ShouldReturnFailure()` - 验证隔日后不可修改

#### ConsultationServiceTests.cs
- ✅ RULE-1 和 RULE-3 测试已存在（来自 PR #1429）

### 其他变更
- 清理 `LYBT.All.sln` 中不存在的测试项目引用（LYBT.Desktop.MedicalCase.Tests）

## ✅ 测试结果
```
PrescriptionServiceTests: 2/2 通过 ✅
  - UpdateAsync_WhenCreatedToday_ShouldReturnSuccess
  - UpdateAsync_WhenCreatedYesterday_ShouldReturnFailure

ConsultationServiceTests: RULE-1/RULE-3 已存在 ✅
```

## 📚 验收标准
- [x] PrescriptionService 的 RULE-3 单元测试补充完成
- [x] ConsultationService 的 RULE-1 和 RULE-3 测试已验证存在
- [x] 所有测试通过

## 🔗 相关文档
- `.claude/core/WORKFLOW.md` - Issue驱动工作流
- `docs/architecture/shared/business-rules.md` - 业务规则定义

🤖 Generated with [Claude Code](https://claude.com/claude-code)