### PR TITLE
fix(patients): 修复PatientSelectionDialog资源引用错误（Issue #1534）

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Patients/Views/PatientSelectionDialog.xaml
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Patients/Views/PatientSelectionDialog.xaml
@@ -92,7 +92,7 @@
                           GridLinesVisibility="Horizontal"
                           HeadersVisibility="Column"
                           Background="White"
-                          AlternatingRowBackground="{StaticResource AlternateSurfaceBrush}"
+                          AlternatingRowBackground="{StaticResource AlternateRowBrush}"
                           RowHeight="40"
                           FontSize="14"
                           VirtualizingPanel.IsVirtualizing="True"


### PR DESCRIPTION
## 📋 问题描述

修复患者选择对话框XAML解析错误，导致无法打开对话框的P0级阻塞问题。

**错误信息**：
```
System.Windows.Markup.XamlParseException
Exception: 无法找到名为"AlternateSurfaceBrush"的资源。资源名称区分大小写。
```

**复现路径**：
1. 启动桌面应用
2. 点击主页"开始看诊"按钮
3. 应用崩溃，XAML解析失败

---

## 🔧 修复内容

### 变更文件
- `src/Client/Desktop/Modules/LYBT.Desktop.Patients/Views/PatientSelectionDialog.xaml`

### 修复详情
**行95 - DataGrid AlternatingRowBackground属性**：
```xml
<!-- 修复前（错误）-->
AlternatingRowBackground="{StaticResource AlternateSurfaceBrush}"

<!-- 修复后（正确）-->
AlternatingRowBackground="{StaticResource AlternateRowBrush}"
```

**原因分析**：
- `AlternateSurfaceBrush` 资源不存在（全局搜索只有1处引用）
- `AlternateRowBrush` 已在 `src/Client/Desktop/Shell/Styles/CommonStyles.xaml:43` 定义
- 资源名称拼写错误导致XAML解析失败

---

## ✅ 验证结果

### 编译验证
```bash
dotnet build LYBT.All.sln -c Release --no-restore
```
- ✅ 0 errors
- ✅ 0 warnings
- ⏱️ Build time: 00:00:24.92

### 功能验证（待人工测试）
- [ ] 启动桌面应用成功
- [ ] 点击"开始看诊"按钮
- [ ] 患者选择对话框正常打开
- [ ] DataGrid交替行背景正常显示

---

## 📊 影响范围

- **优先级**：P0（阻塞核心功能）
- **影响模块**：Patients模块
- **影响功能**：患者选择对话框无法打开，导致整个看诊流程无法启动
- **修复难度**：简单（1行代码修改）
- **风险评估**：低（仅修正资源引用，不改变逻辑）

---

## 🔗 关联Issue

Closes #1534

---

## 📝 Checklist

- [x] 代码已修改
- [x] 编译通过（0 errors, 0 warnings）
- [ ] 功能测试通过（需人工测试）
- [ ] 无副作用

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>