### PR TITLE
fix: 修复暂存后错误导航问题 (Issue #1569)

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
@@ -426,8 +426,7 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
                 Logger.LogInformation("医案暂存成功");
                 await ShowSuccessMessageAsync("医案已暂存");
 
-                // 3. 返回患者选择界面
-                _regionManager.RequestNavigate("ContentRegion", "PatientSelectionView");
+                // Issue #1569: 暂存后停留在当前界面，不返回患者选择
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## 📝 问题描述

修复 Issue #1569：暂存诊疗时，数据可以正常保存，但界面错误地返回到患者选择界面，而不是停留在当前步骤。

## 🔧 修复内容

### 代码变更
- **文件**：`MedicalCaseFlowViewModel.cs` (行429-430)
- **方法**：`ExecuteSaveDraft()`
- **修改**：删除暂存成功后的导航语句

### 关键变更
```csharp
// 修改前
Logger.LogInformation("医案暂存成功");
await ShowSuccessMessageAsync("医案已暂存");

// 3. 返回患者选择界面
_regionManager.RequestNavigate("ContentRegion", "PatientSelectionView");

// 修改后
Logger.LogInformation("医案暂存成功");
await ShowSuccessMessageAsync("医案已暂存");

// Issue #1569: 暂存后停留在当前界面，不返回患者选择
```

## ✅ 验收标准

- [x] 编译通过（0 errors, 1 warning in unrelated file）
- [ ] 点击"暂存"按钮后停留在当前步骤（需运行时验证）
- [ ] 数据正常保存到后端
- [ ] MedicalCase状态正确更新为Active

## 📊 影响范围

- **影响模块**：MedicalCase
- **影响文件**：1个 (MedicalCaseFlowViewModel.cs)
- **风险评估**：低风险（仅删除导航逻辑）

## 🔗 相关Issue

Closes #1569

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)