### PR TITLE
fix: 继续看诊时加载Consultation数据 (Issue #1570部分修复)

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationFormViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.Consultation/ViewModels/ConsultationFormViewModel.cs
@@ -25,8 +25,11 @@ namespace LYBT.Desktop.Consultation.ViewModels
     {
         #region 服务依赖
 
-        // Issue #1563: 删除IConsultationRepository依赖，使用聚合根Repository
+        // Issue #1563: 保存时使用聚合根Repository
         private readonly IMedicalCaseRepository _medicalCaseRepository;
+
+        // Issue #1570: 加载时使用ConsultationRepository
+        private readonly IConsultationRepository _consultationRepository;
 
         #endregion
 
@@ -311,6 +314,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
 
         public ConsultationFormViewModel(
             IMedicalCaseRepository medicalCaseRepository,
+            IConsultationRepository consultationRepository,
             IEventAggregator eventAggregator,
             ILoggerFactory loggerFactory,
             IRegionManager regionManager,
@@ -320,6 +324,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
         {
             // Issue #1563: 只注入聚合根Repository
             _medicalCaseRepository = medicalCaseRepository ?? throw new ArgumentNullException(nameof(medicalCaseRepository));
+            _consultationRepository = consultationRepository ?? throw new ArgumentNullException(nameof(consultationRepository));
 
             // 初始化命令
             ClearFormCommand = new DelegateCommand(ExecuteClearForm);
@@ -370,6 +375,7 @@ namespace LYBT.Desktop.Consultation.ViewModels
         /// <summary>
         /// 导航到当前视图时调用
         /// Issue #1557 Phase 3: 接收MedicalCaseFlowViewModel传来的MedicalCaseId和CurrentPatient
+        /// Issue #1570: 继续看诊时加载现有Consultation数据
         /// </summary>
         public override void OnNavigatedTo(NavigationContext navigationContext)
         {
@@ -392,10 +398,64 @@ namespace LYBT.Desktop.Consultation.ViewModels
                     Logger.LogInformation("接收到CurrentPatient: {PatientName}", currentPatient.Name);
                     CurrentPatient = currentPatient;
                 }
+
+                // Issue #1570: 加载现有Consultation数据（如果存在）
+                if (medicalCaseId != Guid.Empty)
+                {
+                    _ = LoadExistingConsultationAsync(medicalCaseId);
+                }
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "导航到ConsultationFormView时发生异常");
+            }
+        }
+
+        /// <summary>
+        /// 加载现有Consultation数据
+        /// Issue #1570: 继续看诊时从后端加载旧数据
+        /// </summary>
+        private async Task LoadExistingConsultationAsync(Guid medicalCaseId)
+        {
+            try
+            {
+                Logger.LogInformation("尝试加载现有Consultation，MedicalCaseId: {MedicalCaseId}", medicalCaseId);
+
+                SetIsBusy(true, "正在加载诊断数据...");
+
+                // Issue #1570: 使用ConsultationRepository.GetByMedicalCaseIdAsync获取Consultation
+                // Consultation与MedicalCase共享主键，所以可以通过MedicalCaseId查询
+                var consultations = await _consultationRepository.GetByMedicalCaseIdAsync(medicalCaseId);
+                var consultation = consultations.FirstOrDefault();
+
+                if (consultation != null)
+                {
+                    // 填充表单数据
+                    ChiefComplaint = consultation.ChiefComplaint ?? string.Empty;
+                    PresentIllness = consultation.PresentIllness ?? string.Empty;
+                    Inspection = consultation.Inspection ?? string.Empty;
+                    AuscultationOlfaction = consultation.AuscultationOlfaction ?? string.Empty;
+                    Inquiry = consultation.Inquiry ?? string.Empty;
+                    Palpation = consultation.Palpation ?? string.Empty;
+                    TCMDiagnosis = consultation.TCMDiagnosis ?? string.Empty;
+                    TreatmentPrinciple = consultation.TreatmentPrinciple ?? string.Empty;
+                    Remark = consultation.Remark ?? string.Empty;
+
+                    Logger.LogInformation("Consultation数据加载成功，主诉: {ChiefComplaint}", ChiefComplaint);
+                }
+                else
+                {
+                    Logger.LogInformation("MedicalCase无关联Consultation，保持表单空白");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "加载Consultation数据失败，MedicalCaseId: {MedicalCaseId}", medicalCaseId);
+                // 不显示错误提示，允许用户继续填写新数据
+            }
+            finally
+            {
+                SetIsBusy(false);
             }
         }
 


### PR DESCRIPTION
## 📝 问题描述

修复 Issue #1570（部分）：选择有激活病案的患者时，选择"继续看诊"后，旧的诊断（Consultation）和处方（Prescription）数据没有加载到表单中。

## 🔧 修复内容

### ✅ 已修复：Consultation数据加载

**文件**：`ConsultationFormViewModel.cs`

**关键变更**：
1. **添加IConsultationRepository依赖注入**（行314, 324, 32）
   ```csharp
   public ConsultationFormViewModel(
       IMedicalCaseRepository medicalCaseRepository,
       IConsultationRepository consultationRepository,  // ← 新增
       ...
   )
   ```

2. **在OnNavigatedTo中调用数据加载**（行398-400）
   ```csharp
   if (medicalCaseId != Guid.Empty)
   {
       _ = LoadExistingConsultationAsync(medicalCaseId);
   }
   ```

3. **实现LoadExistingConsultationAsync方法**（行418-460）
   - 使用`_consultationRepository.GetByMedicalCaseIdAsync()`获取数据
   - 填充9个诊断字段：ChiefComplaint, PresentIllness, Inspection, AuscultationOlfaction, Inquiry, Palpation, TCMDiagnosis, TreatmentPrinciple, Remark

### ⏸️ 待处理：Prescription数据加载

**原因**：
- Prescription使用复杂的8列DataGrid结构（SimpleItemRow，每行4个药材）
- 数据填充需要处理行/列映射逻辑
- 需要确认业务需求：继续看诊时是否应该加载旧处方？

**建议**：
1. **方案A（推荐）**：保持当前逻辑，医生基于诊断重新开处方
2. **方案B**：实现Prescription数据加载（需要额外开发工作）

## ✅ 验收标准

- [x] 编译通过（0 errors, 0 warnings）
- [ ] 继续看诊时，Consultation数据正确加载到表单（需运行时验证）
- [ ] Prescription部分行为待确认

## 📊 影响范围

- **影响模块**：Consultation
- **影响文件**：1个 (ConsultationFormViewModel.cs)
- **风险评估**：低风险（仅添加数据加载逻辑）

## 🤔 需要确认

**问题**：继续看诊时，是否需要同时加载旧的Prescription数据到处方编辑器？

**选项**：
- ✅ **不需要**：医生根据当前诊断重新开处方（简化实现）
- ⏸️ **需要**：完整恢复旧处方供修改（需要额外实现）

请确认后我可以继续完善Prescription部分的实现。

## 🔗 相关Issue

Partially addresses #1570

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)