### PR TITLE
修复Issue #1569 - 暂存时MedicalCase状态更新失败

### DIFF
--- a/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
+++ b/src/Client/Desktop/Modules/LYBT.Desktop.MedicalCase/ViewModels/MedicalCaseFlowViewModel.cs
@@ -619,10 +619,26 @@ namespace LYBT.Desktop.MedicalCase.ViewModels
                 Logger.LogInformation("更新MedicalCase状态，MedicalCaseId: {MedicalCaseId}, 新状态: {NewStatus}",
                     MedicalCaseId, newStatus);
 
-                // 构建更新DTO
+                // Issue #1569: 修复MedicalCaseUpdateDto缺少必填字段导致更新失败
+                // MedicalCaseUpdateDto继承自MedicalCaseInputBaseDto，需要PatientId和DoctorId
+                if (CurrentPatient == null)
+                {
+                    Logger.LogError("CurrentPatient为空，无法更新MedicalCase状态");
+                    throw new InvalidOperationException("患者信息丢失，无法更新医案状态");
+                }
+
+                if (SessionManager?.CurrentUser == null)
+                {
+                    Logger.LogError("SessionManager.CurrentUser为空，无法更新MedicalCase状态");
+                    throw new InvalidOperationException("用户信息丢失，无法更新医案状态");
+                }
+
+                // 构建更新DTO（包含所有必填字段）
                 var updateDto = new MedicalCaseUpdateDto
                 {
                     Id = MedicalCaseId,
+                    PatientId = CurrentPatient.Id,        // 必填字段
+                    DoctorId = SessionManager.CurrentUser.Id,  // 必填字段
                     Status = newStatus.ToString()
                 };
 


### PR DESCRIPTION
## 🐛 问题描述

**Issue #1569** - 用户点击"暂存诊疗"时报错，暂存功能失败。

### 错误堆栈
```
LYBT.Desktop.MedicalCase.ViewModels.MedicalCaseFlowViewModel: Error: 更新MedicalCase状态失败
System.InvalidOperationException: 更新失败：更新医疗案例失败
   at LYBT.Desktop.Infrastructure.Repositories.RepositoryBase.UpdateAsync(TUpdateDto dto)
   at LYBT.Desktop.MedicalCase.ViewModels.MedicalCaseFlowViewModel.UpdateMedicalCaseStatusAsync(MedicalCaseStatus newStatus)
   at LYBT.Desktop.MedicalCase.ViewModels.MedicalCaseFlowViewModel.ExecuteSaveDraft()
```

### 用户影响
- 无法暂存诊疗数据
- 必须一次性完成整个看诊流程
- 无法中途离开

## 🔍 根本原因

**MedicalCaseFlowViewModel.UpdateMedicalCaseStatusAsync** 方法在构建 `MedicalCaseUpdateDto` 时，只设置了2个字段：
- ✅ Id
- ✅ Status

但缺少了2个**必填字段**：
- ❌ PatientId (Required)
- ❌ DoctorId (Required)

### DTO继承链分析
```
MedicalCaseUpdateDto 
  → MedicalCaseEditDto 
    → MedicalCaseInputBaseDto  ← 这里定义了PatientId和DoctorId为Required
```

**MedicalCaseInputBaseDto.cs:**
```csharp
public abstract class MedicalCaseInputBaseDto : IRemarkable
{
    [Required(ErrorMessage = "患者ID不能为空")]
    public Guid PatientId { get; set; }

    [Required(ErrorMessage = "医生ID不能为空")]
    public Guid DoctorId { get; set; }
    
    // ...
}
```

服务器端验证检测到缺少必填字段 → 返回400错误 → 客户端抛出InvalidOperationException

## ✅ 修复方案

### 修复前（lines 622-627）
```csharp
var updateDto = new MedicalCaseUpdateDto
{
    Id = MedicalCaseId,
    Status = newStatus.ToString()  // ❌ 缺少PatientId和DoctorId
};
```

### 修复后（lines 622-643）
```csharp
// 添加空值检查
if (CurrentPatient == null)
{
    Logger.LogError("CurrentPatient为空，无法更新MedicalCase状态");
    throw new InvalidOperationException("患者信息丢失，无法更新医案状态");
}

if (SessionManager?.CurrentUser == null)
{
    Logger.LogError("SessionManager.CurrentUser为空，无法更新MedicalCase状态");
    throw new InvalidOperationException("用户信息丢失，无法更新医案状态");
}

// 构建完整的更新DTO
var updateDto = new MedicalCaseUpdateDto
{
    Id = MedicalCaseId,
    PatientId = CurrentPatient.Id,        // ✅ 必填字段
    DoctorId = SessionManager.CurrentUser.Id,  // ✅ 必填字段
    Status = newStatus.ToString()
};
```

## 📋 验证步骤

1. **合并PR后**重启Desktop
2. **选择患者** → 开始诊断
3. **填写部分诊断信息**
4. **点击"暂存诊疗"**
5. **预期结果**：
   - ✅ 不报错
   - ✅ 显示"医案已暂存"提示
   - ✅ 停留在当前界面（Issue #1575已修复导航问题）

## 🔗 相关PR

- **PR #1575** - 修复暂存后导航问题（已完成）
- **本PR** - 修复暂存时MedicalCase更新失败（新发现）

## 📊 影响范围

- **影响模块**：MedicalCase模块（医案流程）
- **影响功能**：暂存诊疗、取消诊疗、完成诊疗（所有调用UpdateMedicalCaseStatusAsync的功能）
- **破坏性变更**：无
- **向后兼容**：✅ 完全兼容

## ✅ 编译结果

```
已成功生成。
0 errors, 2 warnings（无关警告）
已用时间 00:00:17.83
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)